### PR TITLE
Security hardening: fail-closed auth, dashboard password, input sanitizing (v0.3.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,19 +2,40 @@
 # independent 40 RPM lane; five keys = 200 RPM aggregate.
 NIM_API_KEYS=nvapi-xxxx,nvapi-yyyy
 
-# Everything below is optional.
-
-# Client access keys. Unset = local mode (no auth required, client label
-# "local" in metrics). Set to comma-separated "name:secret" entries to
-# require Bearer auth; the name becomes the per-client metrics label.
-# Bare secrets (no name) get labeled client0, client1, ...
+# ─── Authentication (required unless INSECURE_NO_AUTH=true) ──────────────────
+# The proxy refuses to start exposed without auth. Pick ONE:
+#
+#  A) Secure mode — set BOTH of the next two (recommended for any network-
+#     reachable deploy: VPS, ECS, Railway, Fly, …):
+#
+# Client access key(s) that gate the API (/v1/*). Any secret works; the
+# optional "name:secret" form labels that client in metrics/leaderboard, a
+# bare secret is auto-labeled client0, client1, …
 #PROXY_API_KEYS=alice:some-long-random-string,bob:another-long-random-string
+#
+# Shared password that gates the dashboard, /metrics, and /api/history.
+# Browsers log in at /login (signed HttpOnly session cookie); scrapers send
+# `Authorization: Bearer <ADMIN_PASSWORD>`.
+#ADMIN_PASSWORD=change-me-to-a-long-random-string
+#
+#  B) Open mode — everything unauthenticated. ONLY on localhost or fully
+#     firewalled/VPN'd networks.
+#INSECURE_NO_AUTH=false
+#
+# Set true when a reverse proxy / platform terminates TLS in front of you: the
+# session cookie is then marked Secure (requires X-Forwarded-Proto: https).
+#TRUST_PROXY=false
+# ────────────────────────────────────────────────────────────────────────────
 
 # Upstream base URL.
 #NIM_BASE_URL=https://integrate.api.nvidia.com
 
-# Port the proxy listens on.
+# Bind address / port the proxy listens on.
+#HOST=0.0.0.0
 #PORT=8000
+
+# Max concurrent in-flight requests before shedding with 503 (flood guard).
+#MAX_INFLIGHT=512
 
 # Per-key rate limit (requests per rolling 60s). NIM's free tier is ~40.
 #RPM_PER_KEY=40

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,16 @@ jobs:
       - name: Tests (unit + integration)
         run: cargo test
 
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   docker:
     name: docker build
     runs-on: ubuntu-latest
@@ -34,7 +44,7 @@ jobs:
         run: docker build -t nim-proxy:ci .
       - name: Smoke test image
         run: |
-          docker run -d --name smoke -e NIM_API_KEYS=test-key -p 8000:8000 nim-proxy:ci
+          docker run -d --name smoke -e NIM_API_KEYS=test-key -e INSECURE_NO_AUTH=true -p 8000:8000 nim-proxy:ci
           for i in $(seq 1 30); do
             if curl -fsS http://127.0.0.1:8000/health > /dev/null 2>&1; then ok=1; break; fi
             sleep 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,14 @@
 nim-proxy is a Rust proxy that makes NVIDIA NIM's free tier usable for agent
 harnesses: it paces requests to the per-key rate limit, load-balances across
 keys, and keeps client connections alive while it waits. Source lives in
-`src/` (~5 files), tests in `tests/`, load harness in `scripts/`.
+`src/` (`main.rs`, `proxy.rs`, `pool.rs`, `dispatch.rs`, `history.rs`,
+`auth.rs`, `dashboard.html`), tests in `tests/`, load harness in `scripts/`.
+
+Auth lives in `src/auth.rs` (fail-closed posture, admin-password session
+cookie, constant-time compares); the API-key gate and label sanitizing are in
+`src/proxy.rs`. Any change touching auth, request labels, or the dashboard's
+`innerHTML` must keep the security invariants — see the `decisions/` pages on
+auth posture and input sanitizing before editing.
 
 ## Working on the code
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +191,27 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "displaydoc"
@@ -299,6 +338,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +388,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -711,16 +769,20 @@ dependencies = [
 
 [[package]]
 name = "nim-proxy"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "axum",
  "bytes",
  "dotenvy",
  "futures-util",
+ "getrandom 0.2.17",
+ "hmac",
  "metrics",
  "metrics-exporter-prometheus",
  "reqwest",
  "serde_json",
+ "sha2",
+ "subtle",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1157,6 +1219,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,6 +1567,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,6 +1607,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nim-proxy"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Rate-limit-aware OpenAI-compatible proxy for NVIDIA NIM with multi-key load balancing"
 license = "MIT"
@@ -18,6 +18,11 @@ tokio-stream = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 dotenvy = "0.15"
+# Auth: HMAC-signed session cookies + constant-time secret comparison.
+hmac = "0.12"
+sha2 = "0.10"
+subtle = "2"
+getrandom = "0.2"
 
 [dev-dependencies]
 axum = "0.8"

--- a/README.md
+++ b/README.md
@@ -26,17 +26,19 @@ This tool is **not** designed to circumvent NVIDIA's terms of service. It maximi
 2. Configure and run:
 
 ```sh
-cp .env.example .env        # paste your keys into NIM_API_KEYS
+cp .env.example .env        # paste keys into NIM_API_KEYS, then pick an auth mode (below)
 docker compose up -d --build
 ```
 
-Or without Docker: `NIM_API_KEYS=nvapi-xxx,nvapi-yyy cargo run --release`
+Or without Docker: `NIM_API_KEYS=nvapi-xxx,nvapi-yyy INSECURE_NO_AUTH=true cargo run --release`
 
 3. Open the dashboard at `http://localhost:8000/` and point your client at `http://localhost:8000/v1`.
 
+> **The proxy refuses to start exposed without auth.** Either set `ADMIN_PASSWORD` + `PROXY_API_KEYS` (secure mode) or `INSECURE_NO_AUTH=true` (open — localhost/firewalled only). See [Security & deployment](#security--deployment).
+
 ## Client recipes
 
-Model IDs are passed through verbatim — use any ID from the [NIM catalog](https://build.nvidia.com/models) (or `curl localhost:8000/v1/models`). No API key is needed client-side in local mode; if the proxy has `PROXY_API_KEYS` set, use your assigned secret as the API key.
+Model IDs are passed through verbatim — use any ID from the [NIM catalog](https://build.nvidia.com/models) (or `curl localhost:8000/v1/models`). In open mode no client-side key is needed; in secure mode, use your assigned `PROXY_API_KEYS` secret as the API key.
 
 **OpenCode** — `opencode.json`:
 
@@ -99,15 +101,47 @@ Served at `GET /` — a single embedded HTML file, no Grafana, no config. Three 
 
 **Time ranges & history.** The filter row offers Live (pausable, 3 s refresh) plus 1h/6h/24h/7d/30d presets and a custom calendar date-time range. Range views are served from the proxy's own history: a ~4 KB metrics snapshot every 5 minutes, kept `HISTORY_DAYS` days (default 30, `0` = forever) in `DATA_DIR` (a Docker volume in the compose file; ~35 MB per 30 days). In a range view every tile, card, and table reports totals *for that window* — instant usage reports.
 
-## Client access keys
+## Security & deployment
 
-By default the proxy runs in **local mode**: no authentication, every request attributed to the client `local`. Set `PROXY_API_KEYS` to require a Bearer token and the proxy becomes safe to share:
+The proxy **fails closed**: it will not start on a network-reachable port without authentication. There are exactly two ways to run it.
+
+### Secure mode (any exposed deployment)
+
+Set both credentials:
 
 ```sh
-PROXY_API_KEYS=alice:8f3k...,bob:2mq9...
+PROXY_API_KEYS=alice:8f3k...,bob:2mq9...   # gates the API (/v1/*); any key works
+ADMIN_PASSWORD=a-long-random-string        # gates the dashboard, /metrics, /api/history
 ```
 
-The name is the metrics/dashboard label, so per-friend usage is visible per model. Unknown tokens get an OpenAI-style 401. Keep `/metrics`, `/health`, and the dashboard behind your firewall or reverse proxy — they are intentionally unauthenticated.
+- **API** (`/v1/*`): clients send `Authorization: Bearer <key>`. The optional `name:secret` form labels that client in metrics (per-friend leaderboard); a bare secret is auto-labeled. Unknown keys get an OpenAI-style 401. Key comparison is constant-time.
+- **Dashboard**: browsers hit `/login`, enter the password, and get a signed, HttpOnly, SameSite=Strict session cookie (12 h). `/`, `/metrics`, and `/api/history` require it.
+- **Scrapers**: Prometheus scrapes `/metrics` with `Authorization: Bearer <ADMIN_PASSWORD>` (or HTTP Basic). Example scrape config:
+  ```yaml
+  scrape_configs:
+    - job_name: nim-proxy
+      authorization: { credentials: "<ADMIN_PASSWORD>" }
+      static_configs: [{ targets: ["nim-proxy:8000"] }]
+  ```
+- `/health` stays public (load-balancer / Docker probe; exposes nothing).
+
+### Open mode (localhost / firewalled only)
+
+```sh
+INSECURE_NO_AUTH=true
+```
+
+Everything is unauthenticated. Only use this bound to loopback or on a fully private network. The compose file publishes `127.0.0.1:8000:8000` by default for exactly this case.
+
+### Deployment patterns
+
+| Pattern | How |
+|---|---|
+| **Local self-host** | `INSECURE_NO_AUTH=true`, keep the default loopback port publish. Or set `HOST=127.0.0.1` when running the binary directly. |
+| **VPS / bare metal** | Secure mode + a TLS-terminating reverse proxy (nginx/Caddy) in front. Set `TRUST_PROXY=true` so the session cookie is marked `Secure` (needs `X-Forwarded-Proto: https`). |
+| **PaaS (ECS / Railway / Fly)** | Secure mode; the platform edge terminates TLS. Set `TRUST_PROXY=true`. Inject `ADMIN_PASSWORD` / `PROXY_API_KEYS` as platform secrets, not in the image. |
+
+**TLS is not built in** — passwords and keys must travel over HTTPS, so terminate TLS at a reverse proxy or platform edge for any exposed deployment. Additional hardening in place: a strict `Content-Security-Policy` and anti-framing/sniffing headers on all responses, a failed-login throttle, and an in-flight cap (`MAX_INFLIGHT`) that sheds floods with a 503.
 
 ## Configuration
 
@@ -117,14 +151,18 @@ All via environment variables (or `.env`). Only `NIM_API_KEYS` is required.
 |---|---|---|
 | `NIM_API_KEYS` | — (required) | Comma-separated `nvapi-...` keys; each is an independent 40 RPM lane |
 | `NIM_BASE_URL` | `https://integrate.api.nvidia.com` | Upstream base URL |
-| `PORT` | `8000` | Listen port |
+| `HOST` / `PORT` | `0.0.0.0` / `8000` | Bind address and port |
+| `PROXY_API_KEYS` | unset | API keys (`secret` or `name:secret`, comma-separated). Required in secure mode |
+| `ADMIN_PASSWORD` | unset | Dashboard/observability password. Required in secure mode |
+| `INSECURE_NO_AUTH` | `false` | `true` runs fully open (localhost/firewalled only) |
+| `TRUST_PROXY` | `false` | Trust `X-Forwarded-Proto` and mark the session cookie `Secure` |
+| `MAX_INFLIGHT` | `512` | Concurrent-request cap before shedding with 503 |
 | `RPM_PER_KEY` | `40` | Per-key requests per rolling minute |
 | `MAX_WAIT_SECS` | `900` | Max time a request waits for a slot / retries before giving up |
 | `HEARTBEAT_SECS` | `10` | SSE keepalive interval while waiting |
 | `MODELS_TTL_SECS` | `600` | `/v1/models` cache lifetime |
 | `STREAM_IDLE_SECS` | `300` | Abort a stream after this much upstream silence (0 = off) |
 | `STRICT_PASSTHROUGH` | `false` | Never modify request bodies (disables usage injection) |
-| `PROXY_API_KEYS` | unset | Client access keys, `name:secret` comma-separated; unset = local mode |
 | `REF_PRICE_IN` / `REF_PRICE_OUT` | `0.5` / `2.0` | $/1M-token reference prices for "dollars saved" |
 | `HISTORY_DAYS` | `30` | Metrics-history retention in days (0 = forever) |
 | `DATA_DIR` | `data` (`/data` in Docker) | Where `history.jsonl` lives; empty = in-memory only |
@@ -151,17 +189,21 @@ All via environment variables (or `.env`). Only `NIM_API_KEYS` is required.
 | `nimproxy_lane_requests_total` | lane | Requests per key lane |
 | `nimproxy_lane_benched_total` | lane, status | Upstream 429/5xx/connect per lane |
 | `nimproxy_affinity_total` | result | Conversation routing: `sticky` / `spill` / `none` |
-| `nimproxy_unauthorized_total` | — | Rejected client requests |
+| `nimproxy_unauthorized_total` | — | Rejected API requests |
+| `nimproxy_login_failures_total` | — | Failed dashboard logins |
+| `nimproxy_shed_total` | — | Requests shed at the in-flight cap |
+
+The `model` and `path` labels are sanitized (safe charset, length-capped) and `model` cardinality is bounded, so untrusted clients can't inject into the exposition format or explode the registry.
 
 ## Testing
 
 Three layers, all runnable locally:
 
 ```sh
-cargo test          # 13 unit + 15 end-to-end tests (real binary vs scripted mock NIM)
+cargo test          # 26 unit + 19 end-to-end tests (real binary vs scripted mock NIM)
 ```
 
-The e2e suite covers auth, 429 ride-out with key failover, Retry-After timing, pacing enforcement, fail-fast 504s, conversation affinity, models caching, usage injection (incl. rejection fallback), stalled-stream recovery, metrics accuracy, history persistence across restart, and SIGTERM.
+The e2e suite covers auth (API keys, admin password / session cookie / Bearer, fail-closed boot posture), 429 ride-out with key failover, Retry-After timing, pacing enforcement, fail-fast 504s, conversation affinity, models caching, usage injection (incl. rejection fallback), stalled-stream recovery, label-injection sanitizing, security headers, metrics accuracy, history persistence across restart, and SIGTERM.
 
 Load test (100 concurrent clients against a mock that *strictly enforces* NIM's per-key window and counts violations):
 
@@ -180,7 +222,9 @@ Exits non-zero on any client-visible failure or a single upstream rate violation
 - **One instance per key set.** Rate state is in-memory; two replicas sharing keys would each assume the full 40 RPM. Run one instance (it comfortably saturates far more keys than you can register).
 - **Rate windows reset on restart.** A restart right after heavy traffic can draw a burst of 429s — the retry machinery absorbs them invisibly.
 - **Chart history in a Live view lives in the browser** (~20 min); range views and totals come from server-side history and survive refresh.
-- **"OTel metrics?"** Prometheus exposition format, which every OpenTelemetry collector ingests natively (`prometheus` receiver).
+- **"OTel metrics?"** Prometheus exposition format, which every OpenTelemetry collector ingests natively (`prometheus` receiver). In secure mode the scraper authenticates with `Authorization: Bearer <ADMIN_PASSWORD>`.
+- **No built-in TLS.** Terminate TLS at a reverse proxy or platform edge for any exposed deployment; set `TRUST_PROXY=true` so session cookies are marked `Secure`.
+- **Sessions reset on restart.** The cookie signing key is random per boot, so a restart logs everyone out of the dashboard (API keys are unaffected).
 
 ## Project knowledge base
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,10 @@ services:
     image: nim-proxy:latest
     restart: unless-stopped
     ports:
-      - "8000:8000"
+      # Bound to loopback by default — reachable only from this host. To expose
+      # it, set auth in .env (ADMIN_PASSWORD + PROXY_API_KEYS), put TLS in front
+      # (nginx/Caddy or your platform's edge), then change this to "8000:8000".
+      - "127.0.0.1:8000:8000"
     env_file: .env
     read_only: true
     cap_drop: [ALL]

--- a/knowledge/architecture/client-auth.md
+++ b/knowledge/architecture/client-auth.md
@@ -1,27 +1,47 @@
 ---
 type: Component
-title: Client auth (PROXY_API_KEYS)
-description: Local mode (no auth) vs named Bearer tokens; per-client attribution everywhere.
-tags: [auth, multi-user]
+title: Auth (API keys + admin password)
+description: Fail-closed posture; API Bearer keys gate /v1/*, a shared-password session gates the dashboard and observability.
+tags: [auth, multi-user, security]
 timestamp: 2026-07-02T00:00:00Z
 ---
 
-# Client auth
+# Auth
 
-- **Local mode** (default, `PROXY_API_KEYS` unset): no authentication; all
-  traffic is attributed to the client label `local`.
-- **Shared mode**: `PROXY_API_KEYS=alice:secret1,bob:secret2` — inbound
-  `Authorization: Bearer <secret>` must match; the *name* becomes the client
-  label on every metric, dashboard tile, and leaderboard row. Bare secrets
-  (no name) get `client0, client1, …`. Unknown/missing tokens get an
-  OpenAI-style 401 plus a `nimproxy_unauthorized_total` tick.
-- Inbound Authorization is **never forwarded** — the proxy substitutes its
-  own NIM key per lane. Clients that insist on an API key can use any
-  placeholder in local mode.
-- `/` (dashboard), `/metrics`, `/health`, and `/api/history` are deliberately
-  unauthenticated (scrape/probe surfaces) — firewall them when exposing the
-  proxy beyond localhost ([runbook](../ops/sharing-with-friends.md)).
+Two independent gates, both required to run exposed (see the
+[posture decision](../decisions/auth-posture-and-dashboard-password.md)). The
+process refuses to start unless either both credentials are set (secure mode)
+or `INSECURE_NO_AUTH=true` (open mode).
 
-There is no rate limit on failed auth attempts; a fat brute-force is visible
-in `nimproxy_unauthorized_total`. Accepted for the friends-scale threat
-model.
+## API gate — `/v1/*` (`src/proxy.rs`)
+
+- `PROXY_API_KEYS` = comma-separated secrets; `name:secret` labels that client
+  in metrics/leaderboard, a bare secret auto-labels `client0, …`. **Any** key
+  works — the requirement is "≥1 key exists," not a specific one.
+- Inbound `Authorization: Bearer <secret>` is matched **constant-time**
+  (`auth::ct_eq`) against every configured key; no early-exit timing leak.
+  Miss → OpenAI-style 401, a `nimproxy_unauthorized_total` tick, and a 250 ms
+  delay to slow brute force.
+- The inbound token is **never forwarded** — the proxy substitutes its own NIM
+  key per lane.
+
+## Admin gate — dashboard + observability (`src/auth.rs`)
+
+- `ADMIN_PASSWORD` protects `/`, `/dash`, `/dash/config.json`, `/api/history`,
+  `/metrics` via `require_admin` middleware. `/health` stays public (probes).
+- Browsers `POST /login` → an HMAC-signed, HttpOnly, SameSite=Strict session
+  cookie (12 h). Signing key = 32 random bytes per boot (no persisted secret;
+  restart invalidates sessions). Scrapers use `Authorization: Bearer
+  <password>` or HTTP Basic. All secret compares are constant-time.
+- Failed logins: `nimproxy_login_failures_total`, a 500 ms delay, and a
+  per-process fixed-window throttle (>10/min → 429). A reverse proxy should
+  add IP-level limiting.
+
+## Open mode
+
+`INSECURE_NO_AUTH=true` disables both gates (login endpoints inert, dashboard
+served directly). Intended for loopback / firewalled hosts only; the compose
+file publishes `127.0.0.1:8000:8000` for this case.
+
+TLS is not built in — terminate it at a reverse proxy / platform edge and set
+`TRUST_PROXY=true` so the session cookie is marked `Secure`.

--- a/knowledge/decisions/auth-posture-and-dashboard-password.md
+++ b/knowledge/decisions/auth-posture-and-dashboard-password.md
@@ -1,0 +1,67 @@
+---
+type: Decision
+title: Fail-closed auth posture with a dashboard password
+description: Refuse to start exposed without auth; gate the API with any key and the dashboard/observability with a shared-password session.
+tags: [security, auth, deployment]
+timestamp: 2026-07-02T00:00:00Z
+---
+
+# Fail-closed auth posture with a dashboard password
+
+## Context
+
+A security review found the proxy shipped **open by default**: the dashboard,
+`/metrics`, and `/api/history` were unauthenticated, and `/v1/*` auth was
+optional (unset `PROXY_API_KEYS` = anyone can spend the rate budget). The
+listener binds `0.0.0.0` and the project is meant for VPS / ECS / Railway, so
+an accidental exposure leaked usage data and the operator's browser was a
+[stored-XSS](input-sanitizing-and-xss.md) target. Deployment patterns to
+support: local self-host (loopback/firewalled), VPS behind a TLS reverse
+proxy, and PaaS behind a platform edge.
+
+## Options
+
+1. Keep optional auth, add a warning log. (Rejected — the dangerous default
+   that caused the review persists.)
+2. Infer safety from the bind address (loopback = open, else require auth).
+   (Rejected — Docker always binds `0.0.0.0`; host port-publish, invisible to
+   the process, controls real exposure. The heuristic would be wrong in a
+   container every time.)
+3. **Fail closed on explicit flags**: refuse to start without auth unless the
+   operator opts into open mode.
+
+## Choice
+
+Option 3, with two clean states and no silent open default:
+
+- **Secure mode** — `PROXY_API_KEYS` (≥1 key) *and* `ADMIN_PASSWORD` both set.
+  API requires a Bearer key (constant-time compare, any key works — names are
+  optional metrics labels); dashboard/`/metrics`/`/api/history` require the
+  password.
+- **Open mode** — `INSECURE_NO_AUTH=true`, everything unauthenticated, loud
+  startup warning. Loopback / firewalled only.
+- Anything else → `eprintln!` guidance + `exit(1)`.
+
+Two *separate* credentials (not one master key): the API key is a per-client
+secret (bonus attribution), the admin password is the operator's — so they
+rotate independently and a friend's leaked API key never touches the
+dashboard.
+
+**Dashboard auth mechanism**: a shared password → `POST /login` sets an
+HMAC-signed, HttpOnly, SameSite=Strict session cookie (signing key = 32 random
+bytes per boot, so no secret to persist and restarts invalidate sessions).
+Scrapers use `Authorization: Bearer <password>` (or Basic) on `/metrics`.
+`/health` stays public for probes. A per-process failed-login throttle + a
+250 ms delay on rejected API keys slow brute force; a reverse proxy should add
+IP-level limiting.
+
+## Consequences
+
+- Safe to expose by default; the three deployment patterns are documented in
+  [deploy-docker](../ops/deploy-docker.md) and [sharing-with-friends](../ops/sharing-with-friends.md).
+- **No built-in TLS** — credentials must ride HTTPS, so TLS terminates at a
+  reverse proxy / platform edge; `TRUST_PROXY=true` marks the cookie `Secure`.
+- Compose now publishes `127.0.0.1:8000:8000` by default (loopback), so a bare
+  `docker compose up` can't accidentally expose an open instance.
+- Session-cookie state is per-boot; a restart logs dashboard users out (API
+  keys unaffected).

--- a/knowledge/decisions/index.md
+++ b/knowledge/decisions/index.md
@@ -14,3 +14,5 @@ description: Lightweight ADRs — context, options, choice, consequences.
 - [history-retention-days-not-size](history-retention-days-not-size.md)
 - [distroless-scratch-image](distroless-scratch-image.md)
 - [usage-injection-auto-fallback](usage-injection-auto-fallback.md)
+- [auth-posture-and-dashboard-password](auth-posture-and-dashboard-password.md)
+- [input-sanitizing-and-xss](input-sanitizing-and-xss.md)

--- a/knowledge/decisions/input-sanitizing-and-xss.md
+++ b/knowledge/decisions/input-sanitizing-and-xss.md
@@ -1,0 +1,52 @@
+---
+type: Decision
+title: Sanitize client-controlled labels; escape + CSP the dashboard
+description: The request `model` field flowed unsanitized into metric labels, logs, and the dashboard — a stored-XSS + cardinality + log-injection vector. Fixed at ingest and in the view.
+tags: [security, xss, metrics, dashboard]
+timestamp: 2026-07-02T00:00:00Z
+---
+
+# Sanitize client-controlled labels; escape + CSP the dashboard
+
+## Context
+
+The security review found one root cause with three sinks: the client-supplied
+`model` field (and `path`) flowed **unsanitized** into (1) Prometheus metric
+labels, (2) the access-log line, and (3) the dashboard via `innerHTML`. A
+semi-trusted client (an authenticated "friend" in a shared pool) could:
+
+- **Stored XSS** — `model` = `<img src=x onerror=…>` is stored as a label,
+  persisted in `history.jsonl`, and executes in the operator's browser when
+  they open the dashboard.
+- **Cardinality blowup** — unbounded distinct `model` values grow the metrics
+  registry (RAM) and every 5-min history snapshot (disk).
+- **Exposition / log injection** — quotes, braces, and newlines break the
+  Prometheus text format (spoof series) or forge log lines / inject ANSI.
+
+## Choice
+
+Defense in depth, fixing it at both ends:
+
+- **At ingest** (`src/proxy.rs`): `sanitize_label` keeps a conservative
+  charset `[A-Za-z0-9._/:-]` (what model ids actually use), drops everything
+  else, and caps length at 64 — killing exposition + log injection. A bounded
+  seen-set (cap 256) collapses further distinct models to `"other"`, bounding
+  cardinality. `path` is reduced to an allowlist of known endpoints.
+- **In the view** (`src/dashboard.html`): an `esc()` HTML-escaper wraps every
+  dynamic value interpolated into `innerHTML` (model, client, tooltip/legend
+  series names). Pure defense-in-depth now that labels are sanitized server
+  side — the payload can no longer even reach the label.
+- **Response CSP** (`src/main.rs`): `connect-src 'self'` blocks the classic
+  exfil vector even if an escape were missed; `frame-ancestors 'none'` +
+  `nosniff` + `X-Frame-Options` round it out.
+
+## Consequences
+
+- Verified end-to-end in a real browser: a malicious `model` sent through the
+  proxy renders as inert text, fires no script, and injects no element; the
+  `/metrics` label is stripped to a safe token on one line.
+- Covered by unit tests (`sanitize_label`, `bounded_label`, `label_path`) and
+  an e2e test asserting `/metrics` carries no injection chars and no spurious
+  series.
+- Constant-time comparison is used for API keys and the admin password (see
+  [auth-posture](auth-posture-and-dashboard-password.md)).

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -24,6 +24,8 @@ the chronology in [log.md](log.md).
 | [history-retention-days-not-size](decisions/history-retention-days-not-size.md) | 5-min ~4KB snapshots make days the right knob; a size cap would never trigger |
 | [distroless-scratch-image](decisions/distroless-scratch-image.md) | Static musl binary with baked-in TLS roots; FROM scratch, non-root, --health probe |
 | [usage-injection-auto-fallback](decisions/usage-injection-auto-fallback.md) | Inject stream_options for exact tokens; 400 → retry untouched and remember |
+| [auth-posture-and-dashboard-password](decisions/auth-posture-and-dashboard-password.md) | Fail closed without auth; API keys + a shared-password dashboard session |
+| [input-sanitizing-and-xss](decisions/input-sanitizing-and-xss.md) | Sanitize client `model`/`path` labels; escape + CSP the dashboard (XSS/cardinality/log-injection) |
 
 ## Research — validated external facts
 
@@ -42,7 +44,7 @@ the chronology in [log.md](log.md).
 | [streaming-pipeline](architecture/streaming-pipeline.md) | Heartbeats, retry/failover, idle timeout, SSE usage scanning |
 | [metrics-history](architecture/metrics-history.md) | Prometheus registry + 5-min snapshot history replayed by the dashboard |
 | [dashboard](architecture/dashboard.md) | Single embedded HTML; live/range modes; chart & palette rules |
-| [client-auth](architecture/client-auth.md) | Local mode vs PROXY_API_KEYS; per-client attribution |
+| [client-auth](architecture/client-auth.md) | API Bearer keys + admin-password dashboard session; fail-closed posture |
 
 ## Operations — runbooks
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,27 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-02] ingest — Security hardening (v0.3.0)
+
+A security review of the merged proxy found a stored-XSS chain (client-supplied
+`model` → unescaped dashboard `innerHTML`), unbounded metric-label cardinality,
+log injection, and an open-by-default posture (unauthenticated dashboard +
+optional API auth). Hardening phase (branch `claude/security-hardening-auth`):
+
+- **Fail-closed auth** → [auth-posture-and-dashboard-password](decisions/auth-posture-and-dashboard-password.md):
+  refuse to start exposed without auth; `PROXY_API_KEYS` gates the API,
+  `ADMIN_PASSWORD` gates the dashboard/`/metrics`/`/api/history` via an
+  HMAC-signed session cookie (Bearer/Basic for scrapers).
+- **Input hardening** → [input-sanitizing-and-xss](decisions/input-sanitizing-and-xss.md):
+  sanitize + cardinality-cap the `model`/`path` labels at ingest, `esc()` every
+  dashboard `innerHTML` sink, add a strict CSP + anti-framing/sniffing headers.
+- Constant-time secret compares, failed-login throttle, `MAX_INFLIGHT` flood
+  cap, `cargo audit` in CI, compose loopback-publish by default.
+- Verified: 45 tests (26 unit + 19 e2e incl. boot posture, session flow, label
+  sanitizing, security headers), a real-browser XSS check (payload rendered
+  inert), secure-mode load test (300/300, 0 rate violations), `cargo audit`
+  clean.
+
 ## [2026-07-02] ingest — CI caught the musl proc-macro trap
 
 First real Docker build (in CI — this environment has no daemon) failed:

--- a/knowledge/ops/configure-env.md
+++ b/knowledge/ops/configure-env.md
@@ -15,6 +15,12 @@ config files, no reload.
 | Variable | Default | Change it when… |
 |---|---|---|
 | `NIM_API_KEYS` | required | Always — comma-separated `nvapi-…` keys, one lane each |
+| `PROXY_API_KEYS` | — | Secure mode (required with `ADMIN_PASSWORD`). `secret` or `name:secret` |
+| `ADMIN_PASSWORD` | — | Secure mode — gates dashboard/`/metrics`/`/api/history` |
+| `INSECURE_NO_AUTH` | `false` | `true` runs fully open (localhost/firewalled only) |
+| `TRUST_PROXY` | `false` | Behind a TLS reverse proxy — marks the session cookie `Secure` |
+| `HOST` | `0.0.0.0` | Bind loopback-only (`127.0.0.1`) for bare-metal local |
+| `MAX_INFLIGHT` | `512` | Concurrent-request flood cap (503 beyond it) |
 | `NIM_BASE_URL` | `https://integrate.api.nvidia.com` | Pointing at self-hosted NIM or a mock |
 | `PORT` | `8000` | Port conflicts |
 | `RPM_PER_KEY` | `40` | NVIDIA grants you a higher limit |
@@ -23,7 +29,6 @@ config files, no reload.
 | `MODELS_TTL_SECS` | `600` | Rarely |
 | `STREAM_IDLE_SECS` | `300` | Models that legitimately pause >5 min mid-stream (0 disables) |
 | `STRICT_PASSTHROUGH` | `false` | You want zero body modification (loses exact token counts) |
-| `PROXY_API_KEYS` | unset | Exposing beyond localhost — see [sharing](sharing-with-friends.md) |
 | `REF_PRICE_IN` / `REF_PRICE_OUT` | `0.5` / `2.0` | Different reference $/1M-token prices for "saved" |
 | `HISTORY_DAYS` | `30` | Longer/shorter report horizon (0 = forever; ~35 MB / 30 days) |
 | `DATA_DIR` | `data` (image sets `/data`) | Non-Docker layouts; empty disables persistence |
@@ -31,6 +36,9 @@ config files, no reload.
 
 Gotchas:
 
+- **Fail closed**: the proxy refuses to start unless secure mode
+  (`PROXY_API_KEYS` + `ADMIN_PASSWORD`) or `INSECURE_NO_AUTH=true` is set
+  ([posture](../decisions/auth-posture-and-dashboard-password.md)).
 - Rate state is in-memory: **one instance per key set**, never two replicas
   sharing keys.
 - `RPM_PER_KEY` is per *rolling* minute with a built-in safety margin

--- a/knowledge/ops/deploy-docker.md
+++ b/knowledge/ops/deploy-docker.md
@@ -9,21 +9,36 @@ timestamp: 2026-07-02T00:00:00Z
 # Deploy with Docker
 
 ```sh
-cp .env.example .env     # NIM_API_KEYS is the only required value
+cp .env.example .env     # set NIM_API_KEYS + an auth mode (below)
 docker compose up -d --build
 docker ps                # STATUS shows (healthy) via the built-in probe
 docker logs nim-proxy-nim-proxy-1
 ```
 
+**Auth is mandatory** ([posture](../decisions/auth-posture-and-dashboard-password.md)):
+set `ADMIN_PASSWORD` + `PROXY_API_KEYS` (secure), or `INSECURE_NO_AUTH=true`
+(open). The proxy exits with guidance if neither is configured.
+
+Deployment patterns:
+
+- **Local**: `INSECURE_NO_AUTH=true`; compose publishes `127.0.0.1:8000:8000`
+  (loopback) so it can't leak. Reach it at `http://localhost:8000`.
+- **VPS / bare metal**: secure mode behind nginx/Caddy doing TLS; change the
+  publish to `8000:8000` (or bind the reverse proxy to the loopback port) and
+  set `TRUST_PROXY=true`.
+- **PaaS (ECS/Railway/Fly)**: secure mode; platform edge terminates TLS; inject
+  `ADMIN_PASSWORD`/`PROXY_API_KEYS` as platform secrets; `TRUST_PROXY=true`.
+
 What the compose file gives you (see
 [distroless-scratch-image](../decisions/distroless-scratch-image.md) for why):
 
-- `FROM scratch` image (~3.5 MB), non-root UID 10001.
+- `FROM scratch` image (~3.5 MB), non-root UID 10001, loopback publish default.
 - `read_only: true`, `cap_drop: [ALL]`, `no-new-privileges` — writes go only
   to the named `history` volume mounted at `/data`.
 - `HEALTHCHECK` via `nim-proxy --health` (the binary probes itself; there is
   no shell in the image).
 - SIGTERM drains gracefully on `docker stop`.
+- Strict CSP + anti-framing/sniffing headers on every response.
 
 Logs are one access line per request plus startup detail; ANSI is disabled
 automatically when stdout isn't a TTY. There is no shell to exec into — use

--- a/knowledge/ops/sharing-with-friends.md
+++ b/knowledge/ops/sharing-with-friends.md
@@ -15,15 +15,17 @@ pool, and share the aggregate throughput. Five keys = 200 RPM for everyone.
 ## Setup
 
 1. Collect keys into `NIM_API_KEYS`.
-2. Issue one `name:secret` per person in `PROXY_API_KEYS` — the name is what
-   shows on the dashboard leaderboard and in per-client metrics, so
-   contribution and consumption stay visible.
-3. Expose **only the proxy port**, ideally via Tailscale/VPN or an
-   authenticating reverse proxy. `/`, `/metrics`, `/health`, and
-   `/api/history` are unauthenticated by design
-   ([client-auth](../architecture/client-auth.md)) — keep them private.
-4. Everyone points their OpenAI-compatible client at the URL with their
-   secret as the API key (recipes in the README).
+2. Issue one `name:secret` per person in `PROXY_API_KEYS` — the name shows on
+   the dashboard leaderboard and in per-client metrics, so contribution and
+   consumption stay visible. (Any key works; naming is just for attribution.)
+3. Set `ADMIN_PASSWORD` — the shared dashboard/metrics password. With both set,
+   the proxy runs in secure mode and every surface requires auth
+   ([client-auth](../architecture/client-auth.md)); it refuses to start
+   otherwise. `/health` stays public.
+4. Terminate TLS in front (reverse proxy / VPN / platform edge) and set
+   `TRUST_PROXY=true` — passwords and keys must not travel in cleartext.
+5. Everyone points their OpenAI-compatible client at the URL with their secret
+   as the API key (recipes in the README); the dashboard is at `/login`.
 
 ## Fairness & capacity
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,500 @@
+//! Authentication: a shared-password admin gate for the dashboard and
+//! observability endpoints, plus the primitives (constant-time compare,
+//! HMAC-signed session cookies, a failed-attempt throttle) the rest of the
+//! app uses. The `/v1/*` API keeps its own Bearer-key check in `proxy.rs`;
+//! this module is about protecting the operator surface.
+
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::sync::Arc;
+use subtle::ConstantTimeEq;
+
+use crate::AppState;
+
+const COOKIE: &str = "nimproxy_session";
+const SESSION_TTL_SECS: u64 = 12 * 3600;
+
+/// Constant-time string equality (avoids leaking length-prefix matches via
+/// timing). Distinct lengths compare unequal without early return.
+pub fn ct_eq(a: &str, b: &str) -> bool {
+    a.as_bytes().ct_eq(b.as_bytes()).into()
+}
+
+fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Admin auth state: the shared password and a random per-boot signing key.
+/// `None` password means insecure mode (no admin gate).
+pub struct Admin {
+    password: Option<String>,
+    signing_key: [u8; 32],
+    trust_proxy: bool,
+    throttle: Mutex<Throttle>,
+}
+
+/// Fixed-window failed-login limiter (per process, not per IP — a reverse
+/// proxy should do IP-level limiting; this is a cheap backstop).
+struct Throttle {
+    window_start: u64,
+    failures: u32,
+}
+
+const THROTTLE_WINDOW_SECS: u64 = 60;
+const THROTTLE_MAX_FAILURES: u32 = 10;
+
+impl Admin {
+    pub fn new(password: Option<String>, trust_proxy: bool) -> Self {
+        let mut signing_key = [0u8; 32];
+        getrandom::getrandom(&mut signing_key).expect("OS RNG for session key");
+        Self {
+            password,
+            signing_key,
+            trust_proxy,
+            throttle: Mutex::new(Throttle {
+                window_start: now(),
+                failures: 0,
+            }),
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.password.is_some()
+    }
+
+    /// Sign an expiry into a session token: `hex(expiry).hex(hmac)`.
+    fn sign(&self, expiry: u64) -> String {
+        let mut mac =
+            Hmac::<Sha256>::new_from_slice(&self.signing_key).expect("HMAC accepts any key length");
+        mac.update(&expiry.to_be_bytes());
+        let tag = mac.finalize().into_bytes();
+        format!("{expiry:x}.{}", hex(&tag))
+    }
+
+    /// Verify a session token: HMAC matches (constant-time) and not expired.
+    fn verify(&self, token: &str) -> bool {
+        let Some((exp_hex, tag_hex)) = token.split_once('.') else {
+            return false;
+        };
+        let Ok(expiry) = u64::from_str_radix(exp_hex, 16) else {
+            return false;
+        };
+        if expiry < now() {
+            return false;
+        }
+        // Recompute and compare in constant time.
+        let expected = self.sign(expiry);
+        let Some((_, expected_tag)) = expected.split_once('.') else {
+            return false;
+        };
+        ct_eq(tag_hex, expected_tag)
+    }
+
+    fn password_matches(&self, candidate: &str) -> bool {
+        self.password
+            .as_deref()
+            .is_some_and(|p| ct_eq(candidate, p))
+    }
+
+    /// Record a failed attempt; returns true if the caller is now throttled.
+    fn note_failure(&self) -> bool {
+        let mut t = self.throttle.lock().unwrap();
+        let n = now();
+        if n - t.window_start >= THROTTLE_WINDOW_SECS {
+            t.window_start = n;
+            t.failures = 0;
+        }
+        t.failures += 1;
+        t.failures > THROTTLE_MAX_FAILURES
+    }
+
+    fn is_throttled(&self) -> bool {
+        let t = self.throttle.lock().unwrap();
+        now() - t.window_start < THROTTLE_WINDOW_SECS && t.failures > THROTTLE_MAX_FAILURES
+    }
+
+    fn cookie(&self, headers: &HeaderMap, token: &str, max_age: i64) -> String {
+        let secure = self.trust_proxy
+            && headers
+                .get("x-forwarded-proto")
+                .and_then(|v| v.to_str().ok())
+                .is_some_and(|p| p.eq_ignore_ascii_case("https"));
+        let secure_attr = if secure { "; Secure" } else { "" };
+        format!(
+            "{COOKIE}={token}; HttpOnly; SameSite=Strict; Path=/; Max-Age={max_age}{secure_attr}"
+        )
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+fn cookie_token(headers: &HeaderMap) -> Option<String> {
+    let raw = headers.get(header::COOKIE)?.to_str().ok()?;
+    for part in raw.split(';') {
+        let part = part.trim();
+        if let Some(v) = part.strip_prefix(&format!("{COOKIE}=")) {
+            return Some(v.to_owned());
+        }
+    }
+    None
+}
+
+/// True if the request carries valid admin credentials: a valid session
+/// cookie, `Authorization: Bearer <password>`, or HTTP Basic with the
+/// password. All secret comparisons are constant-time.
+pub fn authorized(admin: &Admin, headers: &HeaderMap) -> bool {
+    if !admin.enabled() {
+        return true; // insecure mode: no admin gate
+    }
+    if let Some(tok) = cookie_token(headers) {
+        if admin.verify(&tok) {
+            return true;
+        }
+    }
+    if let Some(auth) = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+    {
+        if let Some(bearer) = auth.strip_prefix("Bearer ") {
+            if admin.password_matches(bearer.trim()) {
+                return true;
+            }
+        }
+        if let Some(basic) = auth.strip_prefix("Basic ") {
+            // "user:pass" base64; accept any user, match the password half.
+            if let Some(pass) = decode_basic_password(basic.trim()) {
+                if admin.password_matches(&pass) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+fn decode_basic_password(b64: &str) -> Option<String> {
+    let decoded = base64_decode(b64)?;
+    let s = String::from_utf8(decoded).ok()?;
+    Some(s.split_once(':').map(|(_, p)| p).unwrap_or(&s).to_owned())
+}
+
+/// Minimal base64 decoder (standard alphabet, optional padding) — avoids a
+/// dependency for the one place we need it (HTTP Basic).
+fn base64_decode(s: &str) -> Option<Vec<u8>> {
+    fn val(c: u8) -> Option<u32> {
+        match c {
+            b'A'..=b'Z' => Some((c - b'A') as u32),
+            b'a'..=b'z' => Some((c - b'a' + 26) as u32),
+            b'0'..=b'9' => Some((c - b'0' + 52) as u32),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+    let clean: Vec<u8> = s
+        .bytes()
+        .filter(|&c| c != b'=' && !c.is_ascii_whitespace())
+        .collect();
+    let mut out = Vec::with_capacity(clean.len() * 3 / 4);
+    for chunk in clean.chunks(4) {
+        let mut acc = 0u32;
+        for &c in chunk {
+            acc = (acc << 6) | val(c)?;
+        }
+        acc <<= 6 * (4 - chunk.len());
+        let bytes = match chunk.len() {
+            4 => 3,
+            3 => 2,
+            2 => 1,
+            _ => return None,
+        };
+        for i in 0..bytes {
+            out.push((acc >> (16 - i * 8)) as u8);
+        }
+    }
+    Some(out)
+}
+
+/// axum middleware: gate the admin surface. HTML clients get a redirect to
+/// the login page; API clients (and scrapers) get a 401.
+pub async fn require_admin(
+    State(state): State<Arc<AppState>>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Response {
+    if authorized(&state.admin, req.headers()) {
+        return next.run(req).await;
+    }
+    let wants_html = req
+        .headers()
+        .get(header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|a| a.contains("text/html"));
+    if wants_html {
+        Response::builder()
+            .status(StatusCode::FOUND)
+            .header(header::LOCATION, "/login")
+            .body(Body::empty())
+            .unwrap()
+    } else {
+        unauthorized_json()
+    }
+}
+
+fn unauthorized_json() -> Response {
+    let body = serde_json::json!({
+        "error": {
+            "message": "admin authentication required (session cookie or Authorization: Bearer <password>)",
+            "type": "proxy_error",
+            "code": "unauthorized"
+        }
+    });
+    (
+        StatusCode::UNAUTHORIZED,
+        [(header::WWW_AUTHENTICATE, "Bearer")],
+        axum::Json(body),
+    )
+        .into_response()
+}
+
+/// `GET /login` — serve the form, or bounce to `/` if already authed.
+pub async fn login_page(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    if authorized(&state.admin, &headers) {
+        return redirect("/");
+    }
+    login_html(false)
+}
+
+/// `POST /login` — verify the password, set the session cookie.
+pub async fn login_submit(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    body: String,
+) -> Response {
+    let admin = &state.admin;
+    if admin.is_throttled() {
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        return too_many();
+    }
+    let password = form_field(&body, "password").unwrap_or_default();
+    if admin.password_matches(&password) {
+        let expiry = now() + SESSION_TTL_SECS;
+        let token = admin.sign(expiry);
+        let cookie = admin.cookie(&headers, &token, SESSION_TTL_SECS as i64);
+        return Response::builder()
+            .status(StatusCode::SEE_OTHER)
+            .header(header::LOCATION, "/")
+            .header(header::SET_COOKIE, cookie)
+            .body(Body::empty())
+            .unwrap();
+    }
+    metrics::counter!("nimproxy_login_failures_total").increment(1);
+    admin.note_failure();
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    login_html(true)
+}
+
+/// `POST /logout` — clear the cookie.
+pub async fn logout(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    let cookie = state.admin.cookie(&headers, "", 0);
+    Response::builder()
+        .status(StatusCode::SEE_OTHER)
+        .header(header::LOCATION, "/login")
+        .header(header::SET_COOKIE, cookie)
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn redirect(to: &str) -> Response {
+    Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, to)
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn too_many() -> Response {
+    (
+        StatusCode::TOO_MANY_REQUESTS,
+        [(header::RETRY_AFTER, "60")],
+        "too many failed attempts, try again shortly\n",
+    )
+        .into_response()
+}
+
+/// Parse a single field from an application/x-www-form-urlencoded body.
+fn form_field(body: &str, field: &str) -> Option<String> {
+    for pair in body.split('&') {
+        if let Some((k, v)) = pair.split_once('=') {
+            if k == field {
+                return Some(url_decode(v));
+            }
+        }
+    }
+    None
+}
+
+fn url_decode(s: &str) -> String {
+    let bytes = s.replace('+', " ");
+    let bytes = bytes.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(b) = u8::from_str_radix(&s[i + 1..i + 3], 16) {
+                out.push(b);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn login_html(error: bool) -> Response {
+    let err = if error {
+        r#"<p class="err">Incorrect password.</p>"#
+    } else {
+        ""
+    };
+    let html = format!(
+        r##"<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1"><title>NIM Proxy — Sign in</title>
+<style>
+:root {{ color-scheme: light dark; }}
+body {{ margin:0; min-height:100vh; display:grid; place-items:center;
+  font:15px/1.5 system-ui,-apple-system,"Segoe UI",sans-serif; background:#f9f9f7; color:#0b0b0b; }}
+@media (prefers-color-scheme:dark) {{ body {{ background:#0d0d0d; color:#fff; }} }}
+.card {{ background:Canvas; border:1px solid rgba(128,128,128,.25); border-radius:14px;
+  padding:28px 26px; width:300px; box-shadow:0 6px 24px rgba(0,0,0,.12); }}
+h1 {{ font-size:17px; margin:0 0 4px; }}
+p.sub {{ color:#898781; font-size:13px; margin:0 0 18px; }}
+input {{ width:100%; box-sizing:border-box; font:inherit; padding:9px 11px; border-radius:9px;
+  border:1px solid rgba(128,128,128,.4); background:Field; color:inherit; margin-bottom:12px; }}
+button {{ width:100%; font:inherit; font-weight:600; padding:9px; border:0; border-radius:9px;
+  background:#2a78d6; color:#fff; cursor:pointer; }}
+.err {{ color:#d03b3b; font-size:13px; margin:0 0 12px; }}
+</style></head><body>
+<form class="card" method="post" action="/login">
+  <h1>NIM&nbsp;Proxy</h1><p class="sub">Enter the dashboard password.</p>
+  {err}
+  <input type="password" name="password" placeholder="Password" autofocus autocomplete="current-password">
+  <button type="submit">Sign in</button>
+</form></body></html>"##
+    );
+    let status = if error {
+        StatusCode::UNAUTHORIZED
+    } else {
+        StatusCode::OK
+    };
+    (
+        status,
+        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        html,
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn admin() -> Admin {
+        Admin::new(Some("hunter2".into()), false)
+    }
+
+    #[test]
+    fn ct_eq_matches_std_eq() {
+        assert!(ct_eq("abc", "abc"));
+        assert!(!ct_eq("abc", "abd"));
+        assert!(!ct_eq("abc", "abcd"));
+        assert!(!ct_eq("", "x"));
+    }
+
+    #[test]
+    fn valid_session_round_trips() {
+        let a = admin();
+        let tok = a.sign(now() + 100);
+        assert!(a.verify(&tok));
+    }
+
+    #[test]
+    fn expired_session_rejected() {
+        let a = admin();
+        let tok = a.sign(now() - 1);
+        assert!(!a.verify(&tok));
+    }
+
+    #[test]
+    fn tampered_session_rejected() {
+        let a = admin();
+        let tok = a.sign(now() + 100);
+        // Flip the last hex nibble of the tag.
+        let mut chars: Vec<char> = tok.chars().collect();
+        let last = chars.len() - 1;
+        chars[last] = if chars[last] == 'a' { 'b' } else { 'a' };
+        let tampered: String = chars.into_iter().collect();
+        assert!(!a.verify(&tampered));
+    }
+
+    #[test]
+    fn foreign_key_session_rejected() {
+        let a = admin();
+        let b = admin(); // different random signing key
+        let tok = a.sign(now() + 100);
+        assert!(!b.verify(&tok), "token signed by a must not verify under b");
+    }
+
+    #[test]
+    fn basic_auth_password_extracted() {
+        // base64("alice:hunter2")
+        let b64 = "YWxpY2U6aHVudGVyMg==";
+        assert_eq!(decode_basic_password(b64).as_deref(), Some("hunter2"));
+    }
+
+    #[test]
+    fn bearer_and_basic_authorize() {
+        let a = admin();
+        let mut h = HeaderMap::new();
+        h.insert(header::AUTHORIZATION, "Bearer hunter2".parse().unwrap());
+        assert!(authorized(&a, &h));
+        h.insert(header::AUTHORIZATION, "Bearer wrong".parse().unwrap());
+        assert!(!authorized(&a, &h));
+    }
+
+    #[test]
+    fn insecure_mode_allows_all() {
+        let a = Admin::new(None, false);
+        assert!(authorized(&a, &HeaderMap::new()));
+    }
+
+    #[test]
+    fn form_field_parses() {
+        assert_eq!(
+            form_field("password=hunter2", "password").as_deref(),
+            Some("hunter2")
+        );
+        assert_eq!(
+            form_field("a=1&password=p%40ss", "password").as_deref(),
+            Some("p@ss")
+        );
+    }
+}

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -270,6 +270,11 @@ const $ = id => document.getElementById(id);
 const SLOTS = ['--s1','--s2','--s3','--s4','--s5','--s6'];
 const css = v => getComputedStyle(document.documentElement).getPropertyValue(v).trim();
 const dark = matchMedia('(prefers-color-scheme: dark)').matches;
+// HTML-escape any value that reaches innerHTML. Model ids and client names
+// originate from request data; the server sanitizes them, but escape here too
+// so a stray character can never become markup (defense in depth vs XSS).
+const esc = s => String(s).replace(/[&<>"']/g, c =>
+  ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 // Sequential blue ramp for the heatmap (light: light→dark = more).
 const RAMP = dark
   ? ['#0d366b','#104281','#184f95','#1c5cab','#256abf','#2a78d6','#3987e5']
@@ -423,7 +428,7 @@ function lineChart(el, series, unitFmt) {
     for (const s of live) {
       let best = s.pts[0];
       for (const p of s.pts) if (Math.abs(p.t - t) < Math.abs(best.t - t)) best = p;
-      html += `<div class="row"><span><i class="swatch" style="background:${s.color}"></i>${s.name}</span><b>${unitFmt(best.v)}</b></div>`;
+      html += `<div class="row"><span><i class="swatch" style="background:${s.color}"></i>${esc(s.name)}</span><b>${unitFmt(best.v)}</b></div>`;
     }
     showTip(ev.clientX, ev.clientY, html);
   });
@@ -432,7 +437,7 @@ function lineChart(el, series, unitFmt) {
 
 function legend(el, series) {
   el.innerHTML = series.length > 1
-    ? series.map(s => `<span><i style="background:${s.color}"></i>${s.name}</span>`).join('')
+    ? series.map(s => `<span><i style="background:${s.color}"></i>${esc(s.name)}</span>`).join('')
     : '';
 }
 
@@ -614,7 +619,7 @@ function render() {
     const statCell = (l, v) => `<span class="stat"><span class="l">${l}</span><br><span class="v">${v}</span></span>`;
     return `<div class="mcard"><span class="rank">#${i + 1}</span>
       <div class="brand">${logoHtml(pub)}
-        <div><div class="name">${prettyName(m)}</div><div class="pub">${pub.name}</div></div>
+        <div><div class="name">${esc(prettyName(m))}</div><div class="pub">${esc(pub.name)}</div></div>
       </div>
       <div class="stats">
         ${statCell('requests', fmt(reqModels.get(m) || 0))}
@@ -630,7 +635,7 @@ function render() {
     `<table><tr><th>Model</th><th class="num">Requests</th><th class="num">Tokens out</th><th class="num">Avg TTFT</th><th class="num">Avg tok/s</th><th class="num">Avg reply</th><th class="num">Errors</th><th class="num">Saved</th></tr>` +
     models.map(m => {
       const c = ctok.get(m)||0, ok = okByModel.get(m)||0;
-      return `<tr><td>${modelSlots.has(m) ? `<i class="swatch" style="background:${css(slotFor(m))}"></i>` : ''}${m}</td>` +
+      return `<tr><td>${modelSlots.has(m) ? `<i class="swatch" style="background:${css(slotFor(m))}"></i>` : ''}${esc(m)}</td>` +
         `<td class="num">${fmt(reqModels.get(m)||0)}</td><td class="num">${fmt(c)}</td>` +
         `<td class="num">${ttftMC.get(m) ? secs(ttftMS.get(m)/ttftMC.get(m)) : '–'}</td>` +
         `<td class="num">${tpsMC.get(m) ? fmt(tpsMS.get(m)/tpsMC.get(m)) : '–'}</td>` +
@@ -710,7 +715,7 @@ function render() {
   $('table-clients').innerHTML = !clients.length ? '<div class="empty">No traffic yet</div>' :
     `<table><tr><th>Client</th><th class="num">Requests</th><th class="num">Tokens in</th><th class="num">Tokens out</th><th class="num">Saved</th></tr>` +
     clients.map((c, i) =>
-      `<tr><td>${MEDALS[i] ? `<span class="medal">${MEDALS[i]}</span>` : ''}${c}</td><td class="num">${fmt(cReq.get(c)||0)}</td><td class="num">${fmt(cP.get(c)||0)}</td>` +
+      `<tr><td>${MEDALS[i] ? `<span class="medal">${MEDALS[i]}</span>` : ''}${esc(c)}</td><td class="num">${fmt(cReq.get(c)||0)}</td><td class="num">${fmt(cP.get(c)||0)}</td>` +
       `<td class="num">${fmt(cC.get(c)||0)}</td>` +
       `<td class="num">${money((cP.get(c)||0)/1e6*cfg.price_in + (cC.get(c)||0)/1e6*cfg.price_out)}</td></tr>`
     ).join('') + '</table>';

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,22 @@
+mod auth;
 mod dispatch;
 mod history;
 mod pool;
 mod proxy;
 
 use std::collections::HashMap;
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use axum::extract::DefaultBodyLimit;
-use axum::routing::{any, get};
+use axum::routing::{any, get, post};
 use axum::Router;
 use bytes::Bytes;
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
 use tokio::sync::Mutex;
 
+use auth::Admin;
 use dispatch::Dispatcher;
 use pool::Pool;
 
@@ -41,10 +44,45 @@ pub struct AppState {
     pub clients: Option<HashMap<String, String>>,
     /// Models that rejected stream_options injection; never inject for them again.
     pub no_inject: std::sync::Mutex<std::collections::HashSet<String>>,
+    /// Distinct sanitized model labels seen (bounds metric cardinality).
+    pub model_labels: std::sync::Mutex<std::collections::HashSet<String>>,
+    /// Admin gate for the dashboard + observability endpoints.
+    pub admin: Admin,
+    /// Requests currently in flight; capped to bound memory under floods.
+    pub inflight: AtomicUsize,
+    pub max_inflight: usize,
 }
 
 fn env_or(name: &str, default: &str) -> String {
     std::env::var(name).unwrap_or_else(|_| default.to_owned())
+}
+
+/// Add hardening headers to every response. The CSP allows the dashboard's
+/// own inline script/style and unpkg logos, but pins `connect-src` to 'self'
+/// so an injected element can't exfiltrate to another origin — a second line
+/// of defense behind server-side sanitizing and the dashboard's `esc()`.
+async fn security_headers(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::http::HeaderValue;
+    let mut resp = next.run(req).await;
+    let h = resp.headers_mut();
+    h.insert(
+        "content-security-policy",
+        HeaderValue::from_static(
+            "default-src 'none'; img-src 'self' https://unpkg.com data:; \
+             style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; \
+             connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'",
+        ),
+    );
+    h.insert(
+        "x-content-type-options",
+        HeaderValue::from_static("nosniff"),
+    );
+    h.insert("x-frame-options", HeaderValue::from_static("DENY"));
+    h.insert("referrer-policy", HeaderValue::from_static("no-referrer"));
+    resp
 }
 
 const BANNER: &str = r#"
@@ -98,8 +136,9 @@ async fn main() {
         std::process::exit(1);
     }
 
-    // PROXY_API_KEYS entries are "name:secret" (name becomes the metrics
-    // label) or a bare secret. Unset = local mode: no auth required.
+    // PROXY_API_KEYS entries gate /v1/*. Any key works; an optional
+    // "name:secret" form labels that client in metrics, a bare secret is
+    // auto-labeled. Empty = no API keys configured.
     let clients: Option<HashMap<String, String>> = {
         let entries: Vec<(String, String)> = env_or("PROXY_API_KEYS", "")
             .split(',')
@@ -113,6 +152,39 @@ async fn main() {
             .collect();
         (!entries.is_empty()).then(|| entries.into_iter().collect())
     };
+
+    // Admin password gates the dashboard + observability endpoints.
+    let admin_password = {
+        let p = env_or("ADMIN_PASSWORD", "");
+        (!p.is_empty()).then_some(p)
+    };
+    let insecure = env_or("INSECURE_NO_AUTH", "false") == "true";
+    let trust_proxy = env_or("TRUST_PROXY", "false") == "true";
+
+    // Fail closed: refuse to start exposed without auth. Secure mode requires
+    // both an API key and an admin password; the only way to run fully open is
+    // to opt in explicitly (loopback / firewalled deployments).
+    let secure_mode = clients.is_some() && admin_password.is_some();
+    if !(insecure || secure_mode) {
+        eprintln!(
+            "\nnim-proxy refuses to start without authentication.\n\n\
+             Choose one:\n  \
+             1. Secure mode  — set BOTH:\n       \
+             PROXY_API_KEYS=<one-or-more-secrets>   (gates the API)\n       \
+             ADMIN_PASSWORD=<password>              (gates the dashboard/metrics)\n  \
+             2. Open mode    — set INSECURE_NO_AUTH=true\n       \
+             (ONLY on localhost or behind a firewall/VPN; everything is unauthenticated)\n\n\
+             Currently set: PROXY_API_KEYS={}, ADMIN_PASSWORD={}\n",
+            if clients.is_some() { "yes" } else { "no" },
+            if admin_password.is_some() {
+                "yes"
+            } else {
+                "no"
+            },
+        );
+        std::process::exit(1);
+    }
+
     let rpm: usize = env_or("RPM_PER_KEY", "40").parse().expect("RPM_PER_KEY");
     let cfg = Config {
         base_url: env_or("NIM_BASE_URL", "https://integrate.api.nvidia.com")
@@ -155,11 +227,22 @@ async fn main() {
         rpm,
         keys.len() * rpm
     );
+    if insecure {
+        tracing::warn!("INSECURE_NO_AUTH=true — API and dashboard are UNAUTHENTICATED. Use only on localhost or behind a firewall.");
+    }
     tracing::info!(
-        "client auth       {}",
+        "API auth          {}",
         match &clients {
-            Some(c) => format!("required ({} clients)", c.len()),
-            None => "off (local mode)".to_owned(),
+            Some(c) => format!("required ({} key(s))", c.len()),
+            None => "OFF (no PROXY_API_KEYS)".to_owned(),
+        }
+    );
+    tracing::info!(
+        "dashboard auth    {}",
+        if admin_password.is_some() {
+            "required (ADMIN_PASSWORD)"
+        } else {
+            "OFF"
         }
     );
     tracing::info!(
@@ -192,6 +275,7 @@ async fn main() {
         .install_recorder()
         .expect("prometheus recorder");
 
+    let max_inflight: usize = env_or("MAX_INFLIGHT", "512").parse().expect("MAX_INFLIGHT");
     let pool = Arc::new(Pool::new(keys, rpm));
     let state = Arc::new(AppState {
         dispatch: Dispatcher::new(pool.clone()),
@@ -204,6 +288,10 @@ async fn main() {
             .expect("http client"),
         models_cache: Mutex::new(None),
         no_inject: std::sync::Mutex::new(std::collections::HashSet::new()),
+        model_labels: std::sync::Mutex::new(std::collections::HashSet::new()),
+        admin: Admin::new(admin_password, trust_proxy),
+        inflight: AtomicUsize::new(0),
+        max_inflight,
         cfg,
     });
 
@@ -254,7 +342,10 @@ async fn main() {
             include_str!("dashboard.html"),
         )
     };
-    let app = Router::new()
+    // Admin-gated surface: dashboard, config, history, metrics. The guard
+    // middleware passes a valid session cookie / Bearer / Basic, else it
+    // redirects browsers to /login and 401s API clients.
+    let protected = Router::new()
         .route("/", get(dash))
         .route("/dash", get(dash))
         .route(
@@ -286,13 +377,25 @@ async fn main() {
                 },
             ),
         )
-        .route("/health", get(|| async { "ok" }))
         .route("/metrics", get(move || async move { prometheus.render() }))
+        .route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            auth::require_admin,
+        ));
+
+    // Public surface: health probe, login flow, and the API (its own key gate).
+    let app = Router::new()
+        .merge(protected)
+        .route("/health", get(|| async { "ok" }))
+        .route("/login", get(auth::login_page).post(auth::login_submit))
+        .route("/logout", post(auth::logout))
         .route("/v1/{*path}", any(proxy::handle))
+        .layer(axum::middleware::from_fn(security_headers))
         .layer(DefaultBodyLimit::max(64 * 1024 * 1024))
         .with_state(state);
 
-    let addr = format!("0.0.0.0:{port}");
+    let host = env_or("HOST", "0.0.0.0");
+    let addr = format!("{host}:{port}");
     tracing::info!("dashboard         http://localhost:{port}/  (metrics at /metrics)");
     tracing::info!("listening on      {addr}");
     let listener = tokio::net::TcpListener::bind(&addr).await.expect("bind");

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -29,6 +29,62 @@ struct Ctx {
     started: Instant,
 }
 
+/// Cap on distinct `model` label values tracked, past which new models are
+/// bucketed to "other" so an attacker can't explode metric cardinality.
+const MODEL_LABEL_CAP: usize = 256;
+
+/// Reduce an arbitrary client-supplied string to a safe metric-label / log
+/// value: keep a conservative charset (which model ids use), drop everything
+/// else (quotes, braces, newlines, control/ANSI — the injection vectors for
+/// Prometheus exposition, structured logs, and terminals), and cap length.
+fn sanitize_label(raw: &str) -> String {
+    let cleaned: String = raw
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '/' | ':'))
+        .take(64)
+        .collect();
+    if cleaned.is_empty() {
+        "none".to_owned()
+    } else {
+        cleaned
+    }
+}
+
+/// Sanitize a model id and bound its cardinality: known models pass through,
+/// but once `MODEL_LABEL_CAP` distinct values have been seen, further new
+/// ones collapse to "other".
+fn label_model(state: &AppState, raw: &str) -> String {
+    let s = sanitize_label(raw);
+    let mut seen = state.model_labels.lock().unwrap();
+    bounded_label(&mut seen, s, MODEL_LABEL_CAP)
+}
+
+/// Cardinality guard: return `s` if already seen or under the cap (recording
+/// it), else "other". Pure so it can be tested without an AppState.
+fn bounded_label(seen: &mut std::collections::HashSet<String>, s: String, cap: usize) -> String {
+    if seen.contains(&s) {
+        s
+    } else if seen.len() < cap {
+        seen.insert(s.clone());
+        s
+    } else {
+        "other".to_owned()
+    }
+}
+
+/// Bound the `path` label to the known OpenAI endpoints; anything else
+/// (arbitrary sub-paths a client can hit under /v1/) becomes "other".
+fn label_path(path: &str) -> String {
+    match path {
+        "/v1/chat/completions"
+        | "/v1/completions"
+        | "/v1/embeddings"
+        | "/v1/models"
+        | "/v1/rankings" => path.to_owned(),
+        _ => "other".to_owned(),
+    }
+}
+
 /// Statuses worth waiting out: rate limit and transient server-side trouble.
 fn retryable(status: reqwest::StatusCode) -> bool {
     matches!(status.as_u16(), 429 | 500 | 502 | 503 | 504)
@@ -194,8 +250,28 @@ pub async fn handle(
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {
+    // Shed load past the in-flight cap so a connection flood can't grow the
+    // queue unbounded. A guard decrements on every exit path.
+    let inflight = state
+        .inflight
+        .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+        + 1;
+    let _guard = crate::dispatch::scopeguard({
+        let state = state.clone();
+        move || {
+            state
+                .inflight
+                .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    });
+    if inflight > state.max_inflight {
+        counter!("nimproxy_shed_total").increment(1);
+        return overloaded(&state);
+    }
+
     // Client auth: local mode (no configured keys) admits everyone as
     // "local"; otherwise the Bearer token must match a configured key.
+    // The match is constant-time to avoid leaking a valid key byte-by-byte.
     let client = match &state.clients {
         None => "local".to_owned(),
         Some(clients) => {
@@ -204,10 +280,17 @@ pub async fn handle(
                 .and_then(|v| v.to_str().ok())
                 .and_then(|s| s.strip_prefix("Bearer "))
                 .unwrap_or("");
-            match clients.get(token) {
-                Some(name) => name.clone(),
+            let mut matched = None;
+            for (secret, name) in clients {
+                if crate::auth::ct_eq(token, secret) {
+                    matched = Some(name.clone());
+                }
+            }
+            match matched {
+                Some(name) => name,
                 None => {
                     counter!("nimproxy_unauthorized_total").increment(1);
+                    tokio::time::sleep(Duration::from_millis(250)).await;
                     return unauthorized();
                 }
             }
@@ -220,14 +303,14 @@ pub async fn handle(
         .unwrap_or_else(|| uri.path().to_owned());
 
     let parsed = serde_json::from_slice::<serde_json::Value>(&body).ok();
+    let raw_model = parsed
+        .as_ref()
+        .and_then(|v| v.get("model").and_then(|m| m.as_str()))
+        .unwrap_or("none");
     let ctx = Ctx {
         client,
-        model: parsed
-            .as_ref()
-            .and_then(|v| v.get("model").and_then(|m| m.as_str()))
-            .unwrap_or("none")
-            .to_owned(),
-        path: uri.path().to_owned(),
+        model: label_model(&state, raw_model),
+        path: label_path(uri.path()),
         started: Instant::now(),
     };
 
@@ -603,6 +686,25 @@ fn unauthorized() -> Response {
         .into_response()
 }
 
+fn overloaded(state: &AppState) -> Response {
+    let body = serde_json::json!({
+        "error": {
+            "message": format!(
+                "proxy at capacity ({} concurrent requests); retry shortly",
+                state.max_inflight
+            ),
+            "type": "proxy_error",
+            "code": "overloaded"
+        }
+    });
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        [(header::RETRY_AFTER, "5")],
+        axum::Json(body),
+    )
+        .into_response()
+}
+
 fn gateway_timeout(state: &AppState) -> Response {
     let body = serde_json::json!({
         "error": {
@@ -620,7 +722,48 @@ fn gateway_timeout(state: &AppState) -> Response {
 
 #[cfg(test)]
 mod tests {
-    use super::SseScan;
+    use super::{bounded_label, label_path, sanitize_label, SseScan};
+    use std::collections::HashSet;
+
+    #[test]
+    fn sanitize_strips_injection_chars() {
+        // Quotes, braces, angle brackets, newlines, ANSI escapes all removed.
+        assert_eq!(sanitize_label("meta/llama-3.3-70b"), "meta/llama-3.3-70b");
+        assert_eq!(sanitize_label("a\"} fake_metric 1"), "afake_metric1");
+        assert_eq!(
+            sanitize_label("<img src=x onerror=alert(1)>"),
+            "imgsrcxonerroralert1"
+        );
+        assert_eq!(sanitize_label("line1\nline2"), "line1line2");
+        assert_eq!(sanitize_label("\x1b[31mred"), "31mred");
+        assert_eq!(sanitize_label(""), "none");
+        assert_eq!(sanitize_label("!!!"), "none");
+    }
+
+    #[test]
+    fn sanitize_caps_length() {
+        let long = "a".repeat(200);
+        assert_eq!(sanitize_label(&long).len(), 64);
+    }
+
+    #[test]
+    fn bounded_label_caps_cardinality() {
+        let mut seen = HashSet::new();
+        assert_eq!(bounded_label(&mut seen, "m1".into(), 2), "m1");
+        assert_eq!(bounded_label(&mut seen, "m2".into(), 2), "m2");
+        // Third distinct value exceeds the cap -> "other".
+        assert_eq!(bounded_label(&mut seen, "m3".into(), 2), "other");
+        // Already-seen values still pass through after the cap.
+        assert_eq!(bounded_label(&mut seen, "m1".into(), 2), "m1");
+    }
+
+    #[test]
+    fn path_label_is_allowlisted() {
+        assert_eq!(label_path("/v1/chat/completions"), "/v1/chat/completions");
+        assert_eq!(label_path("/v1/embeddings"), "/v1/embeddings");
+        assert_eq!(label_path("/v1/anything-else"), "other");
+        assert_eq!(label_path("/v1/../etc"), "other");
+    }
 
     #[test]
     fn scan_counts_events_and_finds_usage() {

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -4,10 +4,18 @@ mod support;
 
 use std::time::{Duration, Instant};
 
-use support::{chat_body, read_sse, start_mock, start_proxy, Behavior};
+use support::{chat_body, expect_refuses_to_start, read_sse, start_mock, start_proxy, Behavior};
 
 fn client() -> reqwest::Client {
     reqwest::Client::new()
+}
+
+/// A client that does NOT follow redirects, so we can assert on 302/303.
+fn no_redirect_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap()
 }
 
 #[tokio::test]
@@ -455,4 +463,223 @@ async fn dashboard_and_config_are_served() {
         .unwrap();
     assert_eq!(cfg["lanes"], 3);
     assert_eq!(cfg["auth"], false);
+}
+
+// ---------- security hardening ----------
+
+#[tokio::test]
+async fn refuses_to_start_without_auth() {
+    let mock = start_mock().await;
+    // Nothing set: no INSECURE flag, no admin password, no API keys.
+    expect_refuses_to_start(&mock.url, &[]).await;
+    // Partial config is still refused (only a password, no API key).
+    expect_refuses_to_start(&mock.url, &[("ADMIN_PASSWORD", "pw")]).await;
+    // Only API keys, no admin password: still refused.
+    expect_refuses_to_start(&mock.url, &[("PROXY_API_KEYS", "k")]).await;
+}
+
+#[tokio::test]
+async fn secure_mode_gates_dashboard_metrics_and_history() {
+    let mock = start_mock().await;
+    let proxy = start_proxy(
+        &mock.url,
+        &[
+            ("INSECURE_NO_AUTH", "false"),
+            ("ADMIN_PASSWORD", "s3cret"),
+            ("PROXY_API_KEYS", "api-key-1"),
+        ],
+    )
+    .await;
+
+    // Health stays public (load balancers / Docker probe).
+    assert_eq!(
+        client()
+            .get(proxy.url("/health"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        200
+    );
+
+    // Metrics require creds; Bearer <password> works (Prometheus scrape path).
+    assert_eq!(
+        client()
+            .get(proxy.url("/metrics"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        401
+    );
+    let ok = client()
+        .get(proxy.url("/metrics"))
+        .bearer_auth("s3cret")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(ok.status(), 200);
+    assert_eq!(
+        client()
+            .get(proxy.url("/api/history"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        401
+    );
+    assert_eq!(
+        client()
+            .get(proxy.url("/api/history"))
+            .bearer_auth("s3cret")
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        200
+    );
+
+    // Browser hitting the dashboard without a session is redirected to /login.
+    let nr = no_redirect_client();
+    let redir = nr
+        .get(proxy.url("/"))
+        .header("accept", "text/html")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(redir.status(), 302);
+    assert_eq!(redir.headers()["location"], "/login");
+    assert_eq!(
+        nr.get(proxy.url("/login")).send().await.unwrap().status(),
+        200
+    );
+
+    // Wrong password is rejected; correct password sets a session cookie.
+    let bad = nr
+        .post(proxy.url("/login"))
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body("password=wrong")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(bad.status(), 401);
+
+    let good = nr
+        .post(proxy.url("/login"))
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body("password=s3cret")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(good.status(), 303);
+    let cookie = good.headers()["set-cookie"].to_str().unwrap().to_owned();
+    assert!(cookie.contains("nimproxy_session="));
+    assert!(cookie.contains("HttpOnly"));
+    assert!(cookie.contains("SameSite=Strict"));
+
+    // The session cookie then opens the dashboard.
+    let session = cookie.split(';').next().unwrap();
+    let dash = nr
+        .get(proxy.url("/"))
+        .header("accept", "text/html")
+        .header("cookie", session)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(dash.status(), 200);
+    assert!(dash.text().await.unwrap().contains("NIM"));
+
+    // API still requires a valid key.
+    assert_eq!(
+        client()
+            .post(proxy.url("/v1/chat/completions"))
+            .json(&chat_body("hi", false))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        401
+    );
+    assert_eq!(
+        client()
+            .post(proxy.url("/v1/chat/completions"))
+            .bearer_auth("api-key-1")
+            .json(&chat_body("hi", false))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        200
+    );
+}
+
+#[tokio::test]
+async fn model_label_is_sanitized_in_metrics() {
+    let mock = start_mock().await;
+    let proxy = start_proxy(&mock.url, &[]).await;
+
+    // A malicious model id carrying Prometheus/HTML/log injection payloads.
+    let evil = "<img src=x onerror=alert(1)>\"} pwn 1\nmeta";
+    let body = serde_json::json!({
+        "model": evil,
+        "messages": [{"role": "user", "content": "hi"}]
+    });
+    let r = client()
+        .post(proxy.url("/v1/chat/completions"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200);
+
+    let metrics = client()
+        .get(proxy.url("/metrics"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    // The sanitized label keeps only safe chars; none of the injection
+    // characters survive, and no spurious `pwn` series was created.
+    // The model label value (after `model="`) must contain only safe chars —
+    // no `<`, `>`, quote, brace, or newline that could break the exposition
+    // format, inject a series, or become HTML. The payload collapses to one
+    // harmless alphanumeric token on a single line.
+    let req_line = metrics
+        .lines()
+        .find(|l| l.starts_with("nimproxy_requests_total"))
+        .expect("requests_total present");
+    let value = req_line
+        .split("model=\"")
+        .nth(1)
+        .and_then(|s| s.split('"').next())
+        .expect("model label present");
+    assert!(
+        value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '/' | ':')),
+        "unsafe chars in model label: {value:?}"
+    );
+    // No injected standalone series (the `\n... pwn 1` part of the payload).
+    assert!(
+        !metrics.lines().any(|l| l.trim_start().starts_with("pwn")),
+        "injected metric series present"
+    );
+}
+
+#[tokio::test]
+async fn dashboard_sends_security_headers() {
+    let mock = start_mock().await;
+    let proxy = start_proxy(&mock.url, &[]).await;
+    let resp = client().get(proxy.url("/")).send().await.unwrap();
+    let h = resp.headers();
+    let csp = h["content-security-policy"].to_str().unwrap();
+    assert!(csp.contains("frame-ancestors 'none'"));
+    assert!(
+        csp.contains("connect-src 'self'"),
+        "blocks cross-origin exfil"
+    );
+    assert_eq!(h["x-content-type-options"], "nosniff");
+    assert_eq!(h["x-frame-options"], "DENY");
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -225,18 +225,10 @@ pub async fn start_proxy(upstream: &str, envs: &[(&str, &str)]) -> Proxy {
         let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         l.local_addr().unwrap().port()
     };
-    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_nim-proxy"));
-    cmd.env_clear()
-        .current_dir(std::env::temp_dir()) // dodge any local .env
-        .env("PORT", port.to_string())
-        .env("NIM_BASE_URL", upstream)
-        .env("NIM_API_KEYS", "test-key-0,test-key-1,test-key-2")
-        .env("DATA_DIR", "")
-        .env("MAX_WAIT_SECS", "30")
-        .env("HEARTBEAT_SECS", "1")
-        .env("RUST_LOG", "nim_proxy=warn")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null());
+    // Default to open mode so behavior tests need no auth boilerplate; auth
+    // tests override INSECURE_NO_AUTH/ADMIN_PASSWORD/PROXY_API_KEYS.
+    let mut cmd = base_cmd(port, upstream);
+    cmd.env("INSECURE_NO_AUTH", "true");
     for (k, v) in envs {
         cmd.env(k, v);
     }
@@ -252,6 +244,62 @@ pub async fn start_proxy(upstream: &str, envs: &[(&str, &str)]) -> Proxy {
             }
         }
         assert!(Instant::now() < deadline, "proxy did not become healthy");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+fn base_cmd(port: u16, upstream: &str) -> std::process::Command {
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_nim-proxy"));
+    cmd.env_clear()
+        .current_dir(std::env::temp_dir()) // dodge any local .env
+        .env("PORT", port.to_string())
+        .env("NIM_BASE_URL", upstream)
+        .env("NIM_API_KEYS", "test-key-0,test-key-1,test-key-2")
+        .env("DATA_DIR", "")
+        .env("MAX_WAIT_SECS", "30")
+        .env("HEARTBEAT_SECS", "1")
+        .env("RUST_LOG", "nim_proxy=warn")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    cmd
+}
+
+/// Spawn the proxy with only the given env (no INSECURE default) and assert it
+/// exits non-zero without ever becoming healthy — used for boot-posture tests.
+pub async fn expect_refuses_to_start(upstream: &str, envs: &[(&str, &str)]) {
+    let port = {
+        let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        l.local_addr().unwrap().port()
+    };
+    let mut cmd = base_cmd(port, upstream);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    let mut child = cmd.spawn().expect("spawn proxy");
+    let client = reqwest::Client::new();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            assert!(
+                !status.success(),
+                "proxy should exit non-zero, got {status:?}"
+            );
+            return;
+        }
+        if let Ok(r) = client
+            .get(format!("http://127.0.0.1:{port}/health"))
+            .send()
+            .await
+        {
+            if r.status().is_success() {
+                let _ = child.kill();
+                panic!("proxy became healthy but should have refused to start");
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "proxy neither exited nor became healthy"
+        );
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
 }


### PR DESCRIPTION
## What

Addresses a security review of the merged proxy. Three real findings (a stored XSS chain, unbounded metric-label cardinality, and log/exposition injection — all rooted in the client-controlled `model` field) plus a structural gap: the dashboard and observability endpoints were unauthenticated and API auth was optional (open by default on a `0.0.0.0` bind).

## Auth — fail closed

The proxy now **refuses to start** on a reachable port without authentication. Two clean states:

- **Secure mode** — `PROXY_API_KEYS` (gates `/v1/*`; any key works, constant-time compared) **and** `ADMIN_PASSWORD` (gates `/`, `/metrics`, `/api/history`). Browsers log in at `/login` for an HMAC-signed, HttpOnly, SameSite=Strict session cookie (signing key random per boot); Prometheus/curl use `Authorization: Bearer <password>` or Basic. `/health` stays public for probes.
- **Open mode** — `INSECURE_NO_AUTH=true`, fully unauthenticated, loud warning (localhost/firewalled only).
- Anything else → exit with guidance.

New `src/auth.rs`. Plus a failed-login throttle + delay, and a `MAX_INFLIGHT` in-flight cap that sheds floods with 503.

## Input hardening

- **Server-side** (`src/proxy.rs`): `model`/`path` metric labels are sanitized (safe charset, length-capped) with bounded `model` cardinality (→ `other` past 256), killing exposition/log injection and registry blowup.
- **Dashboard** (`src/dashboard.html`): `esc()` wraps every dynamic `innerHTML` sink (defense-in-depth).
- **Headers** (`src/main.rs`): strict `Content-Security-Policy` (`connect-src 'self'` blocks exfil), `X-Frame-Options`, `nosniff`, `Referrer-Policy` on all responses.

## Ops

Compose publishes `127.0.0.1:8000:8000` by default (can't leak an open instance); `cargo audit` job added to CI; Docker smoke test runs in open mode.

## Verification

- **45 tests** (26 unit + 19 e2e) — new coverage: fail-closed boot posture, session-cookie login flow, Bearer/Basic admin auth, label-injection sanitizing, security headers. All green; `clippy -D warnings` and `fmt` clean.
- **Real-browser XSS check**: a malicious `model` sent through the proxy renders as inert text, fires no script, injects no element; the `/metrics` label is stripped to a safe token.
- **Secure-mode load test**: 100 concurrent clients with auth on → 300/300 successes, **0 upstream rate violations** (no throughput regression).
- **`cargo audit`**: clean across 212 dependencies.
- Static musl release build: 3.6 MB.

## Docs

README **Security & deployment** section (local / VPS+TLS-reverse-proxy / PaaS patterns, TLS-at-the-edge, Prometheus bearer scrape), `.env.example`, and the knowledge base (2 new decision ADRs, updated auth/ops runbooks, dated log ingest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC)_