### PR TITLE
Add GLM-5.2 OpenCode example config tuned for nim-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Model IDs are passed through verbatim — use any ID from the [NIM catalog](http
     "nim": {
       "npm": "@ai-sdk/openai-compatible",
       "name": "NVIDIA NIM (proxied)",
-      "options": { "baseURL": "http://localhost:8000/v1" },
+      "options": { "baseURL": "http://localhost:8000/v1", "timeout": false },
       "models": {
         "moonshotai/kimi-k2-instruct": { "name": "Kimi K2 Instruct" },
         "deepseek-ai/deepseek-r1": { "name": "DeepSeek R1" }
@@ -58,6 +58,8 @@ Model IDs are passed through verbatim — use any ID from the [NIM catalog](http
   }
 }
 ```
+
+Set `options.timeout: false` so OpenCode waits through the proxy's rate-limit heartbeats instead of aborting. For a complete config tuned for **GLM-5.2** (context, compaction, sampling), copy [`examples/opencode.json`](examples/opencode.json) — see [`examples/README.md`](examples/README.md) for the rationale behind each setting.
 
 **Codex CLI** — `~/.codex/config.toml`:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,52 @@
+# Example configs
+
+## `opencode.json` — GLM-5.2 via nim-proxy
+
+A ready-to-use [OpenCode](https://opencode.ai) config pointed at a local
+nim-proxy (`http://localhost:8000/v1`) and tuned for **GLM-5.2**, Z.ai's
+long-context agentic-coding model on the [NVIDIA NIM catalog](https://build.nvidia.com/z-ai).
+
+### Install
+
+Copy it to your project root (or `~/.config/opencode/opencode.json` for
+global use) and set the API key OpenCode sends to the proxy:
+
+```sh
+cp examples/opencode.json ./opencode.json
+export NIM_PROXY_KEY=your-proxy-secret   # a PROXY_API_KEYS secret (secure mode),
+                                         # or any non-empty string (INSECURE_NO_AUTH=true)
+opencode
+```
+
+Confirm the model id your NIM account actually serves — the proxy is a strict
+pass-through, so the key under `models` must match NIM exactly:
+
+```sh
+curl -s localhost:8000/v1/models | grep -i glm
+```
+
+If it returns a different id (e.g. `z-ai/glm-5.1`, or GLM-5.2 isn't on the
+hosted free API yet), change the `models` key and the `model` reference to match.
+
+### Why these settings
+
+| Setting | Value | Rationale |
+|---|---|---|
+| `options.timeout` | `false` | **The important one.** nim-proxy holds the connection open with SSE heartbeats while it waits out NIM's 40 RPM limit. With a client-side timeout, OpenCode would abort mid-wait and defeat the proxy's whole purpose. Disable it and let the proxy pace. |
+| `options.baseURL` | `http://localhost:8000/v1` | Points at the proxy, not NIM directly. Change the port if you set a non-default `PORT`. |
+| `options.apiKey` | `{env:NIM_PROXY_KEY}` | The SDK requires a key. In secure mode this is your `PROXY_API_KEYS` secret; in open mode any non-empty value works. |
+| `limit.context` | `131072` (128k) | GLM-5.2's card advertises a 1M-token window, but NIM's **hosted** endpoint has historically served GLM at 128k. 128k is the safe floor and is plenty for agentic coding. Because OpenCode auto-compacts *below* this number, setting it conservatively means compaction fires before NIM can reject an over-length request. Raise it toward 1M only if testing confirms the hosted window is larger. |
+| `limit.output` | `32768` | OpenCode silently caps `limit.output` at 32k ([issue #29363](https://github.com/anomalyco/opencode/issues/29363)), so this is the effective ceiling. Generous headroom for GLM-5.2's reasoning/"thinking" tokens, which count toward output. |
+| `options.temperature` | `0.6` | Balanced for agentic coding — deterministic enough to follow tool schemas, loose enough to reason. Bump toward `1.0` (Z.ai's general-purpose default) for more exploratory work. |
+| `options.top_p` | `0.95` | Z.ai's recommended nucleus-sampling value for GLM. |
+| `compaction` | `auto`/`prune`/`reserved: 24000` | Auto-compact keeps long sessions under the window; `prune` drops stale tool outputs; `reserved` leaves ~24k tokens free so a compaction summary plus the next response never overflow. **Option names have changed across OpenCode releases** — if your version ignores this block, check `opencode.ai/docs/config`; the real lever is `limit.context` above, which every version honors. |
+| `small_model` | GLM-5.2 | Title/summary generation stays on the same provider so you don't need a second key. It's cheap; the proxy answers `/v1/models` from cache so it costs no rate budget. |
+
+### Notes
+
+- **Rate budget**: one NIM key = 40 RPM. Long agentic runs on GLM-5.2 (which
+  emits many reasoning tokens) go faster with more keys in `NIM_API_KEYS` —
+  the proxy load-balances across them. Watch utilization on the dashboard.
+- **Thinking effort**: GLM-5.2 supports variable thinking effort. This example
+  omits a `reasoning_effort` parameter because NIM may reject unknown fields
+  with a 400; add it only after confirming your NIM endpoint accepts it.

--- a/examples/opencode.json
+++ b/examples/opencode.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "nim": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "NVIDIA NIM (via nim-proxy)",
+      "options": {
+        "baseURL": "http://localhost:8000/v1",
+        "apiKey": "{env:NIM_PROXY_KEY}",
+        "timeout": false
+      },
+      "models": {
+        "z-ai/glm-5.2": {
+          "name": "GLM-5.2 (NIM)",
+          "limit": {
+            "context": 131072,
+            "output": 32768
+          },
+          "options": {
+            "temperature": 0.6,
+            "top_p": 0.95
+          }
+        }
+      }
+    }
+  },
+  "model": "nim/z-ai/glm-5.2",
+  "small_model": "nim/z-ai/glm-5.2",
+  "compaction": {
+    "auto": true,
+    "prune": true,
+    "reserved": 24000
+  }
+}

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -509,6 +509,7 @@ const PUBLISHERS = {
   'ibm-granite': { name: 'IBM Granite', slug: 'ibm-color', color: '#0F62FE' },
   'upstage': { name: 'Upstage', slug: 'upstage-color', color: '#805CFB' },
   'zhipuai': { name: 'Zhipu AI', slug: 'zhipu-color', color: '#3859FF' },
+  'z-ai': { name: 'Z.ai', slug: 'zhipu-color', color: '#3859FF' },
   'minimaxai': { name: 'MiniMax', slug: 'minimax-color', color: '#F23F5D' },
   'baichuan-inc': { name: 'Baichuan', slug: 'baichuan-color', color: '#FF6933' },
   '01-ai': { name: '01.AI', slug: 'yi-color', color: '#003425' },


### PR DESCRIPTION
## What

A ready-to-use [`examples/opencode.json`](examples/opencode.json) pointed at a local nim-proxy (`http://localhost:8000/v1`) and tuned for **GLM-5.2** (Z.ai's long-context agentic-coding model on the [NVIDIA NIM catalog](https://build.nvidia.com/z-ai)), plus [`examples/README.md`](examples/README.md) documenting the rationale for every setting.

## Tuning highlights (researched from OpenCode docs + community)

- **`options.timeout: false`** — the load-bearing setting. nim-proxy holds the connection open with SSE heartbeats while waiting out NIM's 40 RPM limit; a client-side timeout would abort mid-wait and defeat the proxy's entire purpose.
- **`limit.context: 131072` (128k)** — GLM-5.2's card advertises 1M tokens, but NIM's *hosted* endpoint has historically served GLM at 128k. Conservative is correct: OpenCode auto-compacts *below* this number, so it fires before NIM can reject an over-length request. Documented how to raise it if testing confirms a larger served window.
- **`limit.output: 32768`** — OpenCode silently caps output at 32k ([issue #29363](https://github.com/anomalyco/opencode/issues/29363)); this is the effective ceiling, with headroom for GLM-5.2's reasoning tokens.
- **`compaction` (auto/prune/reserved: 24000)** — keeps long sessions under the window, with a version caveat since OpenCode's compaction keys have drifted (the real lever, `limit.context`, is honored by every version).
- **`temperature: 0.6`, `top_p: 0.95`** — coding-tuned; Z.ai's recommended nucleus value.

## Also

- Wired the `timeout: false` tip and a pointer to the example into the main README's OpenCode recipe.
- Added Z.ai (`z-ai` namespace) to the dashboard publisher map so GLM model cards render with proper branding instead of a fallback monogram.

## Verification

- Config validated as well-formed JSON.
- Routed the exact `z-ai/glm-5.2` model id end-to-end through the proxy against a mock NIM: `/v1/models` lists it, a streaming chat returns 200, and it lands with the correct `model="z-ai/glm-5.2"` metric label.
- Build + 26 unit tests green.

> Note: confirm the served model id with `curl localhost:8000/v1/models | grep -i glm` — GLM-5.2 may surface under a different id (or not yet be on the hosted free API), and the strict pass-through means the config key must match NIM exactly. The example README covers this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC)_