### PR TITLE
Benchmarking observability: request-shape/quality metrics + six-view dashboard (v0.4.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,16 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
       - name: Tests (unit + integration)
         run: cargo test
+      - name: Dashboard JS syntax
+        run: |
+          python3 - <<'PY' > "$RUNNER_TEMP/dash.js"
+          import re, pathlib
+          html = pathlib.Path("src/dashboard.html").read_text()
+          m = re.search(r"<script>\n(.*)</script>", html, re.S)
+          assert m, "no <script> block found in src/dashboard.html"
+          print(m.group(1))
+          PY
+          node --check "$RUNNER_TEMP/dash.js"
 
   audit:
     name: cargo audit

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .env
+/data

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .env
 /data
+__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@ auth posture and input sanitizing before editing.
 
 ## Working on the code
 
-- `cargo test` runs 13 unit + 15 end-to-end tests (the e2e suite launches the
-  real binary against a scriptable mock; see `tests/support/mod.rs`).
+- `cargo test` runs the unit suite plus an end-to-end suite that launches the
+  real binary against a scriptable mock (see `tests/support/mod.rs`).
 - `cargo fmt` and `cargo clippy --all-targets -- -D warnings` must stay clean
   (CI enforces both).
 - Rate-limit changes must pass the load harness:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "nim-proxy"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nim-proxy"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Rate-limit-aware OpenAI-compatible proxy for NVIDIA NIM with multi-key load balancing"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ curl http://localhost:8000/v1/chat/completions \
 
 Served at `GET /` — a single embedded HTML file, no Grafana, no config. Three views, light and dark mode:
 
-- **Models** — ranked model cards (publisher logos with offline fallback, requests, tokens, TTFT, tok/s, error rate, dollars saved), TTFT median/p95 over time, tokens-per-minute by model, cumulative savings, full table.
-- **Proxy** — capacity-used and success-rate gauges, request/outcome/load charts, queue-wait median/p95, hour-of-day activity heatmap, per-client leaderboard.
+- **Models** — ranked model cards (publisher logos with offline fallback, requests, tokens, TTFT, tok/s, error rate, dollars saved), TTFT and generation-speed (tok/s) median/p95 over time, tokens-per-minute by model, cumulative savings, full table.
+- **Proxy** — capacity-used and success-rate gauges (colored by threshold — amber as lanes saturate, red when overloaded or failing), request/outcome/load charts, a ranked non-success-outcome breakdown, queue-wait median/p95, hour-of-day activity heatmap, per-client leaderboard.
 - **Keys** — per-lane utilization meters, 429s-per-minute by lane, conversation stickiness, per-lane table.
 
 **Time ranges & history.** The filter row offers Live (pausable, 3 s refresh) plus 1h/6h/24h/7d/30d presets and a custom calendar date-time range. Range views are served from the proxy's own history: a ~4 KB metrics snapshot every 5 minutes, kept `HISTORY_DAYS` days (default 30, `0` = forever) in `DATA_DIR` (a Docker volume in the compose file; ~35 MB per 30 days). In a range view every tile, card, and table reports totals *for that window* — instant usage reports.

--- a/README.md
+++ b/README.md
@@ -220,12 +220,12 @@ inject into the exposition format or explode the registry.
 Three layers, all runnable locally:
 
 ```sh
-cargo test          # 26 unit + 19 end-to-end tests (real binary vs scripted mock NIM)
+cargo test          # 29 unit + 21 end-to-end tests (real binary vs scripted mock NIM)
 ```
 
-The e2e suite covers auth (API keys, admin password / session cookie / Bearer, fail-closed boot posture), 429 ride-out with key failover, Retry-After timing, pacing enforcement, fail-fast 504s, conversation affinity, models caching, usage injection (incl. rejection fallback), stalled-stream recovery, label-injection sanitizing, security headers, metrics accuracy, history persistence across restart, and SIGTERM.
+The e2e suite covers auth (API keys, admin password / session cookie / Bearer, fail-closed boot posture), 429 ride-out with key failover, Retry-After timing, pacing enforcement, fail-fast 504s, conversation affinity, models caching, usage injection (incl. rejection fallback), stalled-stream recovery, label-injection sanitizing, security headers, metrics accuracy (incl. request-shape & response-quality signal on both the streaming and buffered paths, and the finish-reason cardinality clamp), history persistence across restart, and SIGTERM.
 
-Load test (100 concurrent clients against a mock that *strictly enforces* NIM's per-key window and counts violations):
+Load test (100 concurrent clients — a mix of plain, tool-offering, and JSON-mode calls — against a mock that *strictly enforces* NIM's per-key window and counts violations):
 
 ```sh
 python3 scripts/mock_nim.py --enforce --rpm 40 --port 9999 &

--- a/README.md
+++ b/README.md
@@ -95,11 +95,14 @@ curl http://localhost:8000/v1/chat/completions \
 
 ## Dashboard
 
-Served at `GET /` — a single embedded HTML file, no Grafana, no config. Three views, light and dark mode:
+Served at `GET /` — a single embedded HTML file, no Grafana, no config. Because the proxy sits in the request path for every harness and model, it doubles as a **benchmarking and agent-observability tool**: it can see how tool-heavy each harness is, how deep its conversations run, how it tunes sampling, where models truncate, and how much "thinking" a reasoning model burns — all from counts and sizes, never message content. Six persona-aligned views, light and dark mode, each ordered at-a-glance → trends → detail:
 
-- **Models** — ranked model cards (publisher logos with offline fallback, requests, tokens, TTFT, tok/s, error rate, dollars saved), TTFT and generation-speed (tok/s) median/p95 over time, tokens-per-minute by model, cumulative savings, full table.
-- **Proxy** — capacity-used and success-rate gauges (colored by threshold — amber as lanes saturate, red when overloaded or failing), request/outcome/load charts, a ranked non-success-outcome breakdown, queue-wait median/p95, hour-of-day activity heatmap, per-client leaderboard.
-- **Keys** — per-lane utilization meters, 429s-per-minute by lane, conversation stickiness, per-lane table.
+- **Overview** — the one-screen landing: dollars saved, capacity and success-rate gauges (threshold-colored), request/token/savings sparklines, a health strip (active/queued/shed/401/failed-logins), and top models & harnesses.
+- **Models** — ranked model cards, TTFT / generation-speed (tok/s) / inter-token-latency (TPOT) / upstream-latency median-p95 charts, tokens-per-minute by model, cumulative savings, a "how responses end" (truncation) breakdown, reasoning-vs-output share, and a full per-model table (adds TPOT, truncation %, reasoning %).
+- **Compare** — a head-to-head model scorecard (requests, TTFT, tok/s, TPOT, avg reply, truncation, reasoning, errors) with the best value in each column highlighted, plus a generation-speed bar race.
+- **Harnesses** — what each agent is *doing*: tool intensity (avg tools/request), conversation depth (avg messages/request), sampling fingerprint (avg temperature), streaming-vs-buffered mix, and a per-harness leaderboard.
+- **Proxy** — capacity-used and success-rate gauges (colored by threshold), request/outcome/load charts, a ranked non-success-outcome breakdown, queue-wait median/p95, hour-of-day heatmap, a reliability & security panel (shed/benches/401s/failed logins), a request-types panel (stream vs buffered, JSON mode, tool-choice mix), and a per-client leaderboard.
+- **Keys** — per-lane utilization meters, 429s-per-minute by lane, conversation stickiness, live headroom, a keys-for-peak sizing estimate, and a per-lane table.
 
 **Time ranges & history.** The filter row offers Live (pausable, 3 s refresh) plus 1h/6h/24h/7d/30d presets and a custom calendar date-time range. Range views are served from the proxy's own history: a ~4 KB metrics snapshot every 5 minutes, kept `HISTORY_DAYS` days (default 30, `0` = forever) in `DATA_DIR` (a Docker volume in the compose file; ~35 MB per 30 days). In a range view every tile, card, and table reports totals *for that window* — instant usage reports.
 
@@ -185,7 +188,18 @@ All via environment variables (or `.env`). Only `NIM_API_KEYS` is required.
 | `nimproxy_completion_tokens_total` | client, model, source | Completion tokens; `usage` = exact, `estimate` = per-SSE-event fallback |
 | `nimproxy_ttft_seconds` | model | Upstream send → first streamed byte |
 | `nimproxy_tokens_per_second` | model, source | Generation speed |
-| `nimproxy_upstream_seconds` | model | Non-streaming upstream latency |
+| `nimproxy_tpot_seconds` | model | Mean inter-token latency (time per output token) |
+| `nimproxy_upstream_seconds` | model | Upstream latency (streaming + non-streaming) |
+| `nimproxy_finish_reason_total` | model, reason | How generations end; `length` = truncation |
+| `nimproxy_tool_calls_total` | model | Tool calls emitted |
+| `nimproxy_reasoning_tokens_total` | model | Reasoning ("thinking") tokens, from `usage` details |
+| `nimproxy_stream_requests_total` | client, stream | Requests per harness, streaming vs buffered |
+| `nimproxy_request_messages` | client | Conversation depth per request (histogram) |
+| `nimproxy_request_tools` | client | Tools offered per request (histogram) |
+| `nimproxy_request_max_tokens` | client | Requested output cap (histogram) |
+| `nimproxy_request_temperature` | client | Sampling temperature (histogram) |
+| `nimproxy_tool_choice_total` | mode | Tool-selection mode: `auto`/`none`/`required`/`named` |
+| `nimproxy_json_mode_total` | client | Structured-output (JSON-mode) requests |
 | `nimproxy_queue_wait_seconds` | — | Time waiting for a rate-limit slot |
 | `nimproxy_queue_depth` / `nimproxy_active_requests` | — | Live load gauges |
 | `nimproxy_lane_requests_total` | lane | Requests per key lane |
@@ -195,7 +209,11 @@ All via environment variables (or `.env`). Only `NIM_API_KEYS` is required.
 | `nimproxy_login_failures_total` | — | Failed dashboard logins |
 | `nimproxy_shed_total` | — | Requests shed at the in-flight cap |
 
-The `model` and `path` labels are sanitized (safe charset, length-capped) and `model` cardinality is bounded, so untrusted clients can't inject into the exposition format or explode the registry.
+Request shape (messages, tools, sampling params) is captured as **counts and
+sizes only — never message content**. The `model` and `path` labels are
+sanitized (safe charset, length-capped) and `model` cardinality is bounded;
+`reason`, `mode`, and `stream` are fixed enums — so untrusted clients can't
+inject into the exposition format or explode the registry.
 
 ## Testing
 

--- a/knowledge/architecture/dashboard.md
+++ b/knowledge/architecture/dashboard.md
@@ -10,7 +10,27 @@ timestamp: 2026-07-02T00:00:00Z
 
 One self-contained HTML file compiled into the binary (`include_str!`), no
 build step, no config, no external assets except optional CDN logos with an
-offline monogram fallback. Three tabs (Models / Proxy / Keys), light + dark.
+offline monogram fallback. Six persona-aligned tabs, light + dark, each ordered
+**at-a-glance → trends → detail**:
+
+- **Overview** (landing, balanced) — hero KPIs + threshold gauges, request/
+  token/savings sparklines, a health strip, top models & harnesses.
+- **Models** (benchmarker) — cards + TTFT/tok/s/TPOT/upstream quantile charts,
+  truncation breakdown, reasoning-vs-output share, per-model table.
+- **Compare** (benchmarker) — head-to-head scorecard, best-in-column
+  highlighted, via the `scorecard()` helper; a tok/s bar race via `barRows()`.
+- **Harnesses** (agent analyst) — per-client tool intensity, conversation
+  depth, sampling fingerprint, streaming mix, leaderboard. Driven by the
+  per-client request-shape metrics
+  ([request-shape-metrics](../decisions/request-shape-metrics.md)).
+- **Proxy** (operator) — gauges, outcome/load charts, non-success breakdown,
+  reliability & security panel, request-types panel, heatmap, per-client table.
+- **Keys** (capacity) — lane meters, 429/min, stickiness, live headroom,
+  keys-for-peak sizing.
+
+Colors follow the entity: the first six take the validated categorical slots,
+beyond that a stable hash-to-hue (`colorFor`) keeps every model/harness a
+consistent color instead of dropping to none.
 
 **Data flow**: Live mode polls `/metrics` every 3s into a browser-side ring
 (~20 min); range mode fetches `/api/history` once and rebuilds the same

--- a/knowledge/architecture/dashboard.md
+++ b/knowledge/architecture/dashboard.md
@@ -24,11 +24,22 @@ values; live views report lifetime totals. Pause suspends the live poll.
   tooltip hover layer, legend for ≥2 series, table twin for everything.
 - Categorical palette is the validated 6-slot set (CVD-checked in both
   modes); slots assign to models first-seen and never recycle.
-- Quantile lines (TTFT, queue wait) interpolate from histogram bucket deltas;
-  the two quantiles use an ordinal same-hue pair, not two categorical slots.
+- Quantile lines (TTFT, queue wait, generation speed) interpolate from
+  histogram bucket deltas; the two quantiles use an ordinal same-hue pair, not
+  two categorical slots. Generation speed filters to `source="usage"` buckets
+  so the trend reflects real reported throughput, not the ~1-token-per-event
+  estimate used when upstream omits usage.
 - The capacity gauge uses a **trailing-60s average**: the raw 3s pairwise
   rate honestly read 133% during a cold-start burst drain, which is
   math-correct but reads as broken.
+- Gauges are **colored by threshold**, not just numbered: capacity goes blue →
+  amber (≥70%) → red (≥90%) as lanes saturate; success rate goes green → amber
+  (<99%) → red (<90%). The dial itself signals health at a glance.
+- The Proxy tab pairs the outcomes-per-minute line chart with a ranked
+  **non-success-outcome table** (every recorded status that isn't 200 —
+  `429`/`400`/`504`/`disconnect`/`stall`/`stream_error`/… — mapped to a
+  plain-language reason with count and share), so *why* requests failed is
+  legible, not just how many.
 - Heatmap (weekday × hour) uses the sequential blue ramp with a table toggle.
 - Model cards derive identity from the id namespace
   ([schema research](../research/nim-models-endpoint-schema.md)): LobeHub CDN

--- a/knowledge/decisions/request-shape-metrics.md
+++ b/knowledge/decisions/request-shape-metrics.md
@@ -1,0 +1,72 @@
+---
+type: Decision
+title: Capture request-shape & response-quality metrics (counts, never content)
+description: The proxy already deserializes every request and streams every response, so agent-behavior and model-quality signal is in hand but unread. Record it as bounded-cardinality metrics to turn the proxy into a benchmarking / agent-observability tool.
+tags: [metrics, benchmarking, observability, cardinality, privacy]
+timestamp: 2026-07-02T00:00:00Z
+---
+
+# Capture request-shape & response-quality metrics (counts, never content)
+
+## Context
+
+nim-proxy sits in the request path for every harness (OpenCode, Codex, n8n)
+and every model, so it can *see* what agents actually do: how many tools they
+offer, how deep their conversations run, how they set sampling params, where
+models truncate, how much a reasoning model "thinks". The
+[streaming pipeline](../architecture/streaming-pipeline.md) already
+deserializes the request body once into a `serde_json::Value` (`proxy.rs`,
+`handle`) and scans every SSE event / buffered `usage` object. That signal was
+being discarded — the dashboard only ever showed tokens and latency.
+
+The tension: capturing more is nearly free, but the proxy is security-hardened
+(see [input-sanitizing-and-xss](input-sanitizing-and-xss.md)) and metric-label
+cardinality is a real exposure — an attacker who controls a label value can
+explode the registry.
+
+## Options
+
+1. **Do nothing extra** — keep tokens/latency only. Leaves the most interesting
+   data (agent behavior, truncation, reasoning cost) invisible.
+2. **Capture everything as labels** — e.g. `temperature="0.7"`, `messages="12"`.
+   Trivial to read, but every distinct value is a new time series: unbounded
+   cardinality, a registry-explosion vector.
+3. **Capture as bounded metrics** — counts/sizes/params go to **histograms**
+   (fixed buckets, no per-value series); categorical signal goes to **labels
+   only when the value set is a fixed enum** (`finish_reason`, `tool_choice`
+   mode, `stream` bool), clamped server-side so an odd upstream value collapses
+   to `other`. Record **counts and sizes only — never message content.**
+
+## Choice
+
+Option 3. New metrics, split by the label that makes them useful:
+
+- **Per client (harness behavior)** — `nimproxy_request_messages`,
+  `nimproxy_request_tools`, `nimproxy_request_max_tokens`,
+  `nimproxy_request_temperature` (histograms); `nimproxy_stream_requests_total`
+  `{stream}` and `nimproxy_json_mode_total`. Powers the Harnesses view.
+- **Per model (quality)** — `nimproxy_finish_reason_total` `{reason}` (→
+  truncation rate), `nimproxy_tool_calls_total`, `nimproxy_reasoning_tokens_total`,
+  `nimproxy_tpot_seconds` (mean inter-token latency). Powers Models & Compare.
+- **Global enum** — `nimproxy_tool_choice_total` `{mode}`.
+
+Request shape is read from the already-parsed body at `Ctx` construction, so no
+second deserialize. `SseScan` was broadened to parse only the events that carry
+`usage`, a concrete `finish_reason`, or `tool_calls` (plain content deltas are
+still skipped). `finish_reason` and `tool_choice` are clamped to known enums.
+
+## Consequences
+
+- The dashboard becomes a benchmarking / agent-observability tool: six
+  persona-aligned views (see [dashboard](../architecture/dashboard.md)),
+  including a head-to-head model Compare scorecard and a Harnesses view that
+  fingerprints each agent's tool intensity, conversation depth, and sampling.
+- Cardinality stays bounded by construction: no client-controlled free-text
+  reaches a label; params live in histogram buckets; enums are clamped. Verified
+  by unit tests (`finish_label`, `tool_choice_mode`, `SseScan`) and an e2e that
+  asserts the `stream` label is only ever `true`/`false`.
+- Privacy posture is explicit and documented: **counts and sizes, never
+  message content.** Nothing that could carry prompt text is recorded.
+- Shape is labeled by *client*, not *model* — the harness determines tool use
+  and sampling, so per-harness is the meaningful cut and avoids a
+  client×model×buckets cardinality blow-up.

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -26,6 +26,7 @@ the chronology in [log.md](log.md).
 | [usage-injection-auto-fallback](decisions/usage-injection-auto-fallback.md) | Inject stream_options for exact tokens; 400 → retry untouched and remember |
 | [auth-posture-and-dashboard-password](decisions/auth-posture-and-dashboard-password.md) | Fail closed without auth; API keys + a shared-password dashboard session |
 | [input-sanitizing-and-xss](decisions/input-sanitizing-and-xss.md) | Sanitize client `model`/`path` labels; escape + CSP the dashboard (XSS/cardinality/log-injection) |
+| [request-shape-metrics](decisions/request-shape-metrics.md) | Capture agent-behavior & quality signal as bounded metrics — counts, never content — for benchmarking |
 
 ## Research — validated external facts
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -27,6 +27,19 @@ agent-behavior + model-quality signal was in hand but unread.
   Harnesses view distinguishes both with distinct fingerprints, zero JS errors.
   Cardinality bounding is unit- and e2e-tested.
 
+### Pre-merge hardening pass (same PR)
+
+Before merge: security scan (dedicated dashboard-XSS audit + a full
+`/security-review` of the branch) found **zero** vulnerabilities — every new
+`innerHTML` value is escaped, every new label is a bounded enum / histogram, and
+no route left the admin gate. Documentation swept and confirmed current (six
+views, metric table, env vars). Test coverage extended to the buffered
+`relay()` quality path, an unknown-`finish_reason`→`other` clamp, JSON mode, and
+non-`auto` `tool_choice` (now **29 unit + 21 e2e**). The load harness gained
+tool/JSON/sampling variety and a corrected boot command (`INSECURE_NO_AUTH`);
+re-run at 80×3 = 240 requests → 0 failures, 0 upstream rate violations, balanced
+across all keys, with the new metric series confirmed populated.
+
 ## [2026-07-02] ingest — Dashboard reporting polish
 
 Client-side only (no server change, security invariants untouched); surfaces

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,27 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-02] decision + ingest — Benchmarking observability (v0.4.0)
+
+Turned the proxy into a benchmarking / agent-observability tool. The request
+body is already deserialized and every SSE event already scanned, so the
+agent-behavior + model-quality signal was in hand but unread.
+
+- **New decision** → [request-shape-metrics](decisions/request-shape-metrics.md):
+  capture request shape (messages, tools, sampling params, stream/JSON mode) and
+  response quality (finish_reason/truncation, tool calls, reasoning tokens, mean
+  TPOT) as bounded-cardinality metrics — **counts and sizes, never content**.
+  Shape is labeled by *client* (harness behavior), quality by *model*. Enums
+  (`finish_reason`, `tool_choice` mode, `stream`) are clamped server-side.
+- **Dashboard** rebuilt from three tabs to six persona-aligned views (Overview,
+  Models, Compare, Harnesses, Proxy, Keys); see
+  [dashboard](architecture/dashboard.md). Added `scorecard()`/`barRows()`
+  helpers and a hash-to-hue color fallback past the six categorical slots.
+- **Verified** in headless Chromium against a mock driving two named harnesses
+  (opencode: tool-heavy/deep; codex: plain): all six tabs populate, the
+  Harnesses view distinguishes both with distinct fingerprints, zero JS errors.
+  Cardinality bounding is unit- and e2e-tested.
+
 ## [2026-07-02] ingest — Dashboard reporting polish
 
 Client-side only (no server change, security invariants untouched); surfaces

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,26 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-02] ingest — Dashboard reporting polish
+
+Client-side only (no server change, security invariants untouched); surfaces
+data already collected but previously under-shown. See
+[dashboard](architecture/dashboard.md).
+
+- **Generation speed (tok/s) median/p95 trend** on the Models tab — the
+  `nimproxy_tokens_per_second` histogram was only ever shown as one average
+  tile. Same bucket-delta quantile machinery as TTFT, filtered to
+  `source="usage"` so estimates don't drag the trend down.
+- **Non-success outcomes table** on the Proxy tab — ranks every recorded
+  non-200 status by count with a plain-language reason and share, so the
+  status detail already in `nimproxy_requests_total` is legible instead of
+  lumped into one "errors/min" line.
+- **Threshold-colored gauges** — capacity (blue→amber≥70%→red≥90%) and success
+  rate (green→amber<99%→red<90%) so the dials signal, not just count.
+- Verified in headless Chromium against the mock: both new elements render with
+  live data, gauges take the amber band under induced load/errors, zero JS
+  page errors.
+
 ## [2026-07-02] ingest — Security hardening (v0.3.0)
 
 A security review of the merged proxy found a stored-XSS chain (client-supplied

--- a/scripts/loadtest.py
+++ b/scripts/loadtest.py
@@ -9,9 +9,13 @@ saw a failure or the upstream recorded a single rate-limit violation.
 Typical run (three terminals or backgrounded):
   python3 scripts/mock_nim.py --enforce --rpm 40 --port 9999
   NIM_API_KEYS=k1,k2,k3 NIM_BASE_URL=http://127.0.0.1:9999 PORT=8000 \
-      cargo run --release
+      INSECURE_NO_AUTH=true cargo run --release
   python3 scripts/loadtest.py --proxy http://127.0.0.1:8000 \
       --mock http://127.0.0.1:9999 --clients 100 --requests 3
+
+The request mix includes plain, tool-offering, and JSON-mode calls with
+sampling params, so the v0.4.0 request-shape / response-quality code paths are
+exercised under concurrency (not just the rate limiter).
 """
 import argparse
 import json
@@ -33,15 +37,27 @@ results_lock = threading.Lock()
 def one_request(args, client_id, seq):
     model = MODELS[(client_id + seq) % len(MODELS)]
     stream = (client_id + seq) % 2 == 0
-    body = json.dumps({
+    payload = {
         "model": model,
         "stream": stream,
+        "temperature": 0.2 + 0.1 * ((client_id + seq) % 8),
+        "max_tokens": 1024,
         "messages": [
             {"role": "system", "content": "you are a load test"},
-            # Stable per-client conversation identity exercises affinity.
+            # Stable per-client conversation identity exercises affinity
+            # (messages are unchanged by the shape variety below).
             {"role": "user", "content": f"conversation for client {client_id}"},
         ],
-    }).encode()
+    }
+    # Exercise the v0.4.0 shape/quality paths under concurrency: every 3rd
+    # request offers tools, every 5th asks for JSON output.
+    if (client_id + seq) % 3 == 0:
+        payload["tools"] = [{"type": "function",
+                             "function": {"name": "search", "parameters": {}}}]
+        payload["tool_choice"] = "auto"
+    if (client_id + seq) % 5 == 0:
+        payload["response_format"] = {"type": "json_object"}
+    body = json.dumps(payload).encode()
     req = urllib.request.Request(
         f"{args.proxy}/v1/chat/completions", data=body,
         headers={"Content-Type": "application/json",

--- a/scripts/mock_nim.py
+++ b/scripts/mock_nim.py
@@ -92,28 +92,55 @@ class Handler(BaseHTTPRequestHandler):
         if ARGS.delay_ms:
             time.sleep(ARGS.delay_ms / 1000)
 
+        # Echo request shape: a tool-offering request gets a tool_calls answer,
+        # otherwise a normal stop. Usage always carries reasoning-token details.
+        offers_tools = bool(req.get("tools"))
+        finish = "tool_calls" if offers_tools else "stop"
+        usage = {"prompt_tokens": 120, "completion_tokens": 4,
+                 "completion_tokens_details": {"reasoning_tokens": 12}}
+
         if req.get("stream"):
             self.send_response(200)
             self.send_header("Content-Type", "text/event-stream")
             self.send_header("Connection", "close")
             self.end_headers()
-            for tok in ["Hello", " from", " mock", " NIM"]:
-                chunk = {"id": "c1", "object": "chat.completion.chunk", "choices": [
-                    {"index": 0, "delta": {"content": tok}, "finish_reason": None}]}
-                self.wfile.write(f"data: {json.dumps(chunk)}\n\n".encode())
+            if offers_tools:
+                tc = {"id": "c1", "object": "chat.completion.chunk", "choices": [
+                    {"index": 0, "delta": {"tool_calls": [
+                        {"index": 0, "function": {"name": "get_weather"}}]},
+                     "finish_reason": None}]}
+                self.wfile.write(f"data: {json.dumps(tc)}\n\n".encode())
                 self.wfile.flush()
                 time.sleep(ARGS.token_ms / 1000)
+            else:
+                for tok in ["Hello", " from", " mock", " NIM"]:
+                    chunk = {"id": "c1", "object": "chat.completion.chunk", "choices": [
+                        {"index": 0, "delta": {"content": tok}, "finish_reason": None}]}
+                    self.wfile.write(f"data: {json.dumps(chunk)}\n\n".encode())
+                    self.wfile.flush()
+                    time.sleep(ARGS.token_ms / 1000)
+            stop = {"id": "c1", "object": "chat.completion.chunk", "choices": [
+                {"index": 0, "delta": {}, "finish_reason": finish}]}
+            self.wfile.write(f"data: {json.dumps(stop)}\n\n".encode())
             final = {"id": "c1", "object": "chat.completion.chunk", "choices": [],
-                     "usage": {"prompt_tokens": 120, "completion_tokens": 4}}
+                     "usage": usage}
             self.wfile.write(f"data: {json.dumps(final)}\n\n".encode())
             self.wfile.write(b"data: [DONE]\n\n")
+        elif offers_tools:
+            self._json(200, {
+                "id": "c1", "object": "chat.completion",
+                "choices": [{"index": 0, "message": {"role": "assistant", "tool_calls": [
+                    {"index": 0, "id": "c1", "type": "function",
+                     "function": {"name": "get_weather", "arguments": "{}"}}]},
+                    "finish_reason": "tool_calls"}],
+                "usage": usage})
         else:
             self._json(200, {
                 "id": "c1", "object": "chat.completion",
                 "choices": [{"index": 0, "message": {"role": "assistant",
                              "content": "Hello from mock NIM"},
                              "finish_reason": "stop"}],
-                "usage": {"prompt_tokens": 120, "completion_tokens": 4}})
+                "usage": usage})
 
 
 def main():

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -185,6 +185,11 @@ svg text { fill: var(--ink-3); font-size: 10.5px; font-variant-numeric: tabular-
         <div class="legend" id="legend-ttft"></div>
       </div>
       <div class="card">
+        <h2>Generation speed</h2>
+        <div id="chart-tps"></div>
+        <div class="legend" id="legend-tps"></div>
+      </div>
+      <div class="card">
         <h2>Dollars saved, cumulative</h2>
         <div id="chart-saved"></div>
       </div>
@@ -215,6 +220,10 @@ svg text { fill: var(--ink-3); font-size: 10.5px; font-variant-numeric: tabular-
         <h2>Outcomes per minute</h2>
         <div id="chart-outcomes"></div>
         <div class="legend" id="legend-outcomes"></div>
+      </div>
+      <div class="card">
+        <h2>Non-success outcomes</h2>
+        <div id="table-outcomes"></div>
       </div>
       <div class="card">
         <h2>In flight &amp; queued</h2>
@@ -441,18 +450,20 @@ function legend(el, series) {
     : '';
 }
 
-/* ---------- arc gauge: a meter bent into 270 degrees ---------- */
-function arcGauge(el, ratio, text) {
+/* ---------- arc gauge: a meter bent into 270 degrees ----------
+   `color` is a CSS var name (default --s1); pass a threshold color so the
+   dial itself signals saturation/health, not just the number. */
+function arcGauge(el, ratio, text, color) {
   const R = 40, C = 48, SW = 9, start = 135, sweep = 270;
   const clamped = Math.max(0, Math.min(1, ratio));
-  const arc = (from, deg, color) => {
+  const arc = (from, deg, stroke) => {
     const p = a => { const r = (a-90) * Math.PI/180; return `${C + R*Math.cos(r)},${C + R*Math.sin(r)}`; };
     const large = deg > 180 ? 1 : 0;
-    return `<path d="M${p(from)} A${R},${R} 0 ${large} 1 ${p(from+deg)}" fill="none" stroke="${color}" stroke-width="${SW}" stroke-linecap="round"/>`;
+    return `<path d="M${p(from)} A${R},${R} 0 ${large} 1 ${p(from+deg)}" fill="none" stroke="${stroke}" stroke-width="${SW}" stroke-linecap="round"/>`;
   };
   el.innerHTML = `<svg width="96" height="86" viewBox="0 0 96 90" role="img" aria-label="${text}">
     ${arc(start, sweep, css('--meter-track'))}
-    ${clamped > 0.005 ? arc(start, sweep * clamped, css('--s1')) : ''}
+    ${clamped > 0.005 ? arc(start, sweep * clamped, css(color || '--s1')) : ''}
     <text x="${C}" y="${C+5}" text-anchor="middle" style="font-size:17px;font-weight:650;fill:${css('--ink-1')}">${text}</text>
   </svg>`;
 }
@@ -594,6 +605,20 @@ function render() {
   lineChart($('chart-ttft'), qSeries, secs);
   legend($('legend-ttft'), qSeries);
 
+  /* generation speed p50/p95 from tokens_per_second bucket deltas. Filter to
+     source="usage" so the trend reflects real reported throughput, not the
+     ~1-token-per-event estimate used when upstream omits usage. */
+  const tpsBucketAt = s => buckets(s.rows, 'nimproxy_tokens_per_second', l => l.source === 'usage');
+  const tpsSeries = [[0.5, 'median', css('--q-lo')], [0.95, 'p95', css('--q-hi')]].map(([q, name, color]) => ({
+    name, color,
+    pts: samples.slice(1).map((s, i) => {
+      const d = deltaBuckets(tpsBucketAt(s), tpsBucketAt(samples[i]));
+      return { t: s.t, v: quantile(d, q) };
+    }).filter(p => isFinite(p.v)),
+  }));
+  lineChart($('chart-tps'), tpsSeries, n => fmt(n) + ' tok/s');
+  legend($('legend-tps'), tpsSeries);
+
   /* cumulative dollars within the view */
   const base = samples[0];
   const savedAt = s => {
@@ -653,10 +678,14 @@ function render() {
   const avgRpm = reqPts.length ? reqPts.reduce((a,p) => a+p.v, 0) / reqPts.length : 0;
   const capacity = Math.max(1, cfg.lanes * cfg.rpm);
   const capRatio = (mode.kind === 'live' ? curRpm : avgRpm) / capacity;
-  arcGauge($('g-cap'), capRatio, Math.round(capRatio * 100) + '%');
+  // Blue while there's headroom, amber approaching the cap, red once saturated.
+  const capColor = capRatio >= 0.9 ? '--critical' : capRatio >= 0.7 ? '--s3' : '--s1';
+  arcGauge($('g-cap'), capRatio, Math.round(capRatio * 100) + '%', capColor);
   const wreq = windowed(s => sum(s.rows, 'nimproxy_requests_total'));
   const wok = windowed(s => sum(s.rows, 'nimproxy_requests_total', l => l.status === '200'));
-  arcGauge($('g-ok'), wreq ? wok/wreq : 1, wreq ? Math.round(wok/wreq*100) + '%' : '–');
+  const okRatio = wreq ? wok/wreq : 1;
+  const okColor = okRatio < 0.9 ? '--critical' : okRatio < 0.99 ? '--s3' : '--good';
+  arcGauge($('g-ok'), okRatio, wreq ? Math.round(okRatio*100) + '%' : '–', okColor);
 
   $('p-reqs').textContent = fmt(wreq);
   $('p-rpm').textContent = fmt(curRpm);
@@ -676,6 +705,26 @@ function render() {
   ].map(({name, color, f}) => ({ name, color, pts: rateSeries(s => sum(s.rows, 'nimproxy_requests_total', f)) }));
   lineChart($('chart-outcomes'), outcomeSeries, fmt);
   legend($('legend-outcomes'), outcomeSeries);
+
+  /* non-success outcomes ranked by count — every status the proxy records
+     that isn't a clean 200, with a plain-language reason and its share. */
+  const REASONS = {
+    'disconnect': 'Client disconnected', 'stall': 'Stream stalled',
+    'stream_error': 'Stream error', '504': 'Upstream timeout (504)',
+    '429': 'Rate limited (429)', '400': 'Bad request (400)',
+    '401': 'Unauthorized (401)', '403': 'Forbidden (403)',
+    '404': 'Not found (404)', '502': 'Bad gateway (502)', '503': 'Unavailable (503)',
+  };
+  const reason = s => REASONS[s] || (/^\d+$/.test(s) ? `HTTP ${s}` : esc(s));
+  const statusG = wgroups('nimproxy_requests_total', 'status');
+  const totReq = [...statusG.values()].reduce((a, b) => a + b, 0) || 1;
+  const bad = [...statusG.entries()].filter(([s]) => s !== '200').sort((a, b) => b[1] - a[1]);
+  $('table-outcomes').innerHTML = !bad.length
+    ? '<div class="empty">All requests succeeded in this window</div>'
+    : '<table><tr><th>Reason</th><th class="num">Count</th><th class="num">Share</th></tr>' +
+      bad.map(([s, n]) =>
+        `<tr><td>${reason(s)}</td><td class="num">${fmt(n)}</td><td class="num">${(n / totReq * 100).toFixed(1)}%</td></tr>`
+      ).join('') + '</table>';
 
   const loadSeries = [
     { name: 'active', color: css('--s1'), pts: samples.map(s => ({ t: s.t, v: sum(s.rows, 'nimproxy_active_requests') })) },

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -96,6 +96,8 @@ td { padding: 7px 10px 7px 0; border-bottom: 1px solid var(--grid); font-size: 1
 td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
 tr:last-child td { border-bottom: 0; }
 .swatch { width: 9px; height: 9px; border-radius: 3px; display: inline-block; margin-right: 7px; }
+td.best { color: var(--good); font-weight: 650; }
+.meter .name.wide { width: 96px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .empty { color: var(--ink-3); padding: 26px 0; text-align: center; font-size: 13px; }
 .meter { display: flex; align-items: center; gap: 10px; margin: 7px 0; }
 .meter .name { width: 64px; color: var(--ink-2); font-size: 12.5px; flex: none; }
@@ -158,13 +160,54 @@ svg text { fill: var(--ink-3); font-size: 10.5px; font-variant-numeric: tabular-
 </div>
 
 <nav role="tablist">
-  <button role="tab" data-tab="models" aria-selected="true">Models</button>
+  <button role="tab" data-tab="overview" aria-selected="true">Overview</button>
+  <button role="tab" data-tab="models" aria-selected="false">Models</button>
+  <button role="tab" data-tab="compare" aria-selected="false">Compare</button>
+  <button role="tab" data-tab="harnesses" aria-selected="false">Harnesses</button>
   <button role="tab" data-tab="proxy" aria-selected="false">Proxy</button>
   <button role="tab" data-tab="keys" aria-selected="false">Keys</button>
 </nav>
 
 <main>
-  <section id="tab-models">
+  <section id="tab-overview">
+    <div class="tiles">
+      <div class="tile hero"><div class="label" id="o-savedLabel">Dollars saved (vs reference pricing)</div><div class="value" id="o-saved">$0.00</div></div>
+      <div class="tile gauge"><div id="o-cap"></div><div class="label">Capacity used</div></div>
+      <div class="tile gauge"><div id="o-ok"></div><div class="label">Success rate</div></div>
+      <div class="tile"><div class="label" id="o-reqsLabel">Requests</div><div class="value" id="o-reqs">0</div></div>
+      <div class="tile"><div class="label">Tokens out</div><div class="value" id="o-ctok">0</div></div>
+      <div class="tile"><div class="label">Avg TTFT</div><div class="value" id="o-ttft">–</div></div>
+      <div class="tile"><div class="label">Avg speed</div><div class="value" id="o-tps">–</div></div>
+    </div>
+    <div class="cards">
+      <div class="card">
+        <h2>Requests per minute</h2>
+        <div id="spark-reqs"></div>
+      </div>
+      <div class="card">
+        <h2>Completion tokens per minute</h2>
+        <div id="spark-tok"></div>
+      </div>
+      <div class="card">
+        <h2>Dollars saved, cumulative</h2>
+        <div id="spark-saved"></div>
+      </div>
+      <div class="card">
+        <h2>Health</h2>
+        <div id="o-health"></div>
+      </div>
+      <div class="card">
+        <h2>Top models</h2>
+        <div id="o-topmodels"></div>
+      </div>
+      <div class="card">
+        <h2>Top harnesses</h2>
+        <div id="o-topharness"></div>
+      </div>
+    </div>
+  </section>
+
+  <section id="tab-models" hidden>
     <div class="tiles">
       <div class="tile hero"><div class="label" id="savedLabel">Dollars saved (vs reference pricing)</div><div class="value" id="m-saved">$0.00</div></div>
       <div class="tile"><div class="label">Completion tokens</div><div class="value" id="m-ctok">0</div></div>
@@ -190,12 +233,75 @@ svg text { fill: var(--ink-3); font-size: 10.5px; font-variant-numeric: tabular-
         <div class="legend" id="legend-tps"></div>
       </div>
       <div class="card">
+        <h2>Inter-token latency (TPOT)</h2>
+        <div id="chart-tpot"></div>
+        <div class="legend" id="legend-tpot"></div>
+      </div>
+      <div class="card">
+        <h2>Upstream latency</h2>
+        <div id="chart-upstream"></div>
+        <div class="legend" id="legend-upstream"></div>
+      </div>
+      <div class="card">
         <h2>Dollars saved, cumulative</h2>
         <div id="chart-saved"></div>
+      </div>
+      <div class="card">
+        <h2>How responses end</h2>
+        <div id="table-finish"></div>
+      </div>
+      <div class="card">
+        <h2>Reasoning vs output tokens</h2>
+        <div id="meters-reasoning"></div>
       </div>
       <div class="card wide">
         <h2>Per model</h2>
         <div id="table-models"></div>
+      </div>
+    </div>
+  </section>
+
+  <section id="tab-compare" hidden>
+    <div class="cards">
+      <div class="card wide">
+        <h2>Model scorecard <span class="sub" style="font-weight:400">best in each column highlighted</span></h2>
+        <div id="compare-scorecard"></div>
+      </div>
+      <div class="card wide">
+        <h2>Head to head</h2>
+        <div id="compare-bars"></div>
+      </div>
+    </div>
+  </section>
+
+  <section id="tab-harnesses" hidden>
+    <div class="tiles">
+      <div class="tile"><div class="label">Harnesses</div><div class="value" id="h-count">0</div></div>
+      <div class="tile"><div class="label">Streaming share</div><div class="value" id="h-stream">–</div></div>
+      <div class="tile"><div class="label">Avg tools / request</div><div class="value" id="h-tools">–</div></div>
+      <div class="tile"><div class="label">Avg messages / request</div><div class="value" id="h-msgs">–</div></div>
+      <div class="tile"><div class="label">Tool-using requests</div><div class="value" id="h-toolpct">–</div></div>
+    </div>
+    <div class="cards">
+      <div class="card">
+        <h2>Tool intensity <span class="sub" style="font-weight:400">avg tools offered / request</span></h2>
+        <div id="h-toolint"></div>
+      </div>
+      <div class="card">
+        <h2>Conversation depth <span class="sub" style="font-weight:400">avg messages / request</span></h2>
+        <div id="h-depth"></div>
+      </div>
+      <div class="card">
+        <h2>Sampling fingerprint <span class="sub" style="font-weight:400">avg temperature</span></h2>
+        <div id="h-temp"></div>
+      </div>
+      <div class="card">
+        <h2>Streaming vs buffered</h2>
+        <div id="h-streammix"></div>
+      </div>
+      <div class="card wide">
+        <h2>Per harness</h2>
+        <div id="table-harness"></div>
       </div>
     </div>
   </section>
@@ -239,6 +345,14 @@ svg text { fill: var(--ink-3); font-size: 10.5px; font-variant-numeric: tabular-
         <h2>Activity by hour <button class="toggle" id="heatToggle">table</button></h2>
         <div id="heatmap"></div>
       </div>
+      <div class="card">
+        <h2>Reliability &amp; security</h2>
+        <div id="table-reliability"></div>
+      </div>
+      <div class="card">
+        <h2>Request types</h2>
+        <div id="table-reqtypes"></div>
+      </div>
       <div class="card wide">
         <h2>Per client</h2>
         <div id="table-clients"></div>
@@ -253,6 +367,8 @@ svg text { fill: var(--ink-3); font-size: 10.5px; font-variant-numeric: tabular-
       <div class="tile"><div class="label">Rate-limit hits (429)</div><div class="value" id="k-429">0</div></div>
       <div class="tile"><div class="label">Other benches</div><div class="value" id="k-5xx">0</div></div>
       <div class="tile"><div class="label">Conversation stickiness</div><div class="value" id="k-sticky">–</div></div>
+      <div class="tile"><div class="label">Headroom now</div><div class="value" id="k-headroom">–</div></div>
+      <div class="tile"><div class="label" title="Keys to keep peak demand under budget">Keys for peak</div><div class="value" id="k-needed">–</div></div>
     </div>
     <div class="cards">
       <div class="card">
@@ -450,6 +566,43 @@ function legend(el, series) {
     : '';
 }
 
+/* ---------- horizontal bar rows: one labeled, scaled bar per entity ----------
+   entries: [{name, v, color?}]; `fmtV` formats the value, bars scale to the
+   max. Reuses the .meter markup so it matches the lane utilization bars. */
+function barRows(el, entries, fmtV) {
+  const vals = entries.filter(e => isFinite(e.v));
+  if (!vals.length) { el.innerHTML = '<div class="empty">No data yet</div>'; return; }
+  const max = Math.max(1e-9, ...vals.map(e => e.v));
+  el.innerHTML = entries.map(e => {
+    const w = isFinite(e.v) ? Math.max(2, e.v / max * 100) : 0;
+    return `<div class="meter"><span class="name wide" title="${esc(e.name)}">${esc(e.name)}</span>` +
+      `<span class="track"><span class="fill" style="width:${w.toFixed(0)}%;background:${e.color || css('--s1')}"></span></span>` +
+      `<span class="val">${isFinite(e.v) ? fmtV(e.v) : '–'}</span></div>`;
+  }).join('');
+}
+
+/* ---------- scorecard: entities as rows, metrics as columns, best-in-column
+   highlighted. cols: [{label, get(row)->number, fmt, best:'min'|'max'}]. ---------- */
+function scorecard(el, rows, nameOf, cols) {
+  if (!rows.length) { el.innerHTML = '<div class="empty">No traffic yet</div>'; return; }
+  const bestOf = c => {
+    const vs = rows.map(c.get).filter(isFinite);
+    if (!vs.length) return null;
+    return c.best === 'max' ? Math.max(...vs) : Math.min(...vs);
+  };
+  const bests = cols.map(bestOf);
+  let h = '<table><tr><th>' + nameOf.head + '</th>' +
+    cols.map(c => `<th class="num">${esc(c.label)}</th>`).join('') + '</tr>';
+  for (const r of rows) {
+    h += '<tr><td>' + nameOf.cell(r) + '</td>' + cols.map((c, i) => {
+      const v = c.get(r);
+      const best = bests[i] !== null && isFinite(v) && v === bests[i] && rows.length > 1;
+      return `<td class="num${best ? ' best' : ''}">${isFinite(v) ? c.fmt(v) : '–'}</td>`;
+    }).join('') + '</tr>';
+  }
+  el.innerHTML = h + '</table>';
+}
+
 /* ---------- arc gauge: a meter bent into 270 degrees ----------
    `color` is a CSS var name (default --s1); pass a threshold color so the
    dial itself signals saturation/health, not just the number. */
@@ -549,12 +702,22 @@ function logoHtml(pub) {
   return `<span class="logo"><img alt="" src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/${pub.slug}.svg" onerror="${mono}"></span>`;
 }
 
-/* ---------- color-follows-entity ---------- */
+/* ---------- color-follows-entity ----------
+   First six distinct entities take the validated categorical slots; beyond
+   that, a stable hash-to-hue keeps every entity a consistent (if unreserved)
+   color instead of dropping to none. */
 const modelSlots = new Map();
 function slotFor(model) {
   if (!modelSlots.has(model) && modelSlots.size < SLOTS.length) modelSlots.set(model, SLOTS[modelSlots.size]);
   return modelSlots.get(model);
 }
+function hueFor(name) {
+  let h = 0;
+  for (const c of String(name)) h = (h * 31 + c.charCodeAt(0)) >>> 0;
+  return `hsl(${h % 360} 58% ${dark ? '62%' : '44%'})`;
+}
+/* Resolved color for an entity: a reserved slot if it has one, else a hue. */
+const colorFor = model => { const s = slotFor(model); return s ? css(s) : hueFor(model); };
 
 /* ---------- render ---------- */
 function render() {
@@ -587,7 +750,7 @@ function render() {
 
   const top = models.slice(0, 5);
   const tokSeries = top.map(m => ({
-    name: m.split('/').pop(), color: css(slotFor(m)),
+    name: m.split('/').pop(), color: colorFor(m),
     pts: rateSeries(s => sum(s.rows, 'nimproxy_completion_tokens_total', l => l.model === m)),
   }));
   lineChart($('chart-modeltok'), tokSeries, fmt);
@@ -657,15 +820,28 @@ function render() {
       </div></div>`;
   }).join('');
 
+  // Quality maps shared by the model table, finish-reason panel, and Compare.
+  const tpotMS = wgroups('nimproxy_tpot_seconds_sum', 'model'), tpotMC = wgroups('nimproxy_tpot_seconds_count', 'model');
+  const finTotal = wgroups('nimproxy_finish_reason_total', 'model');
+  const finLen = wgroups('nimproxy_finish_reason_total', 'model', l => l.reason === 'length');
+  const reasoningByModel = wgroups('nimproxy_reasoning_tokens_total', 'model');
+  const tpotAvg = m => tpotMC.get(m) ? tpotMS.get(m) / tpotMC.get(m) : NaN;
+  const truncPct = m => finTotal.get(m) ? (finLen.get(m) || 0) / finTotal.get(m) * 100 : NaN;
+  const reasonPct = m => ctok.get(m) ? (reasoningByModel.get(m) || 0) / ctok.get(m) * 100 : NaN;
+  const pct = v => isFinite(v) ? v.toFixed(v && v < 10 ? 1 : 0) + '%' : '–';
+
   $('table-models').innerHTML = !models.length ? '<div class="empty">No traffic yet</div>' :
-    `<table><tr><th>Model</th><th class="num">Requests</th><th class="num">Tokens out</th><th class="num">Avg TTFT</th><th class="num">Avg tok/s</th><th class="num">Avg reply</th><th class="num">Errors</th><th class="num">Saved</th></tr>` +
+    `<table><tr><th>Model</th><th class="num">Requests</th><th class="num">Tokens out</th><th class="num">Avg TTFT</th><th class="num">Avg tok/s</th><th class="num">TPOT</th><th class="num">Avg reply</th><th class="num">Truncated</th><th class="num">Reasoning</th><th class="num">Errors</th><th class="num">Saved</th></tr>` +
     models.map(m => {
       const c = ctok.get(m)||0, ok = okByModel.get(m)||0;
-      return `<tr><td>${modelSlots.has(m) ? `<i class="swatch" style="background:${css(slotFor(m))}"></i>` : ''}${esc(m)}</td>` +
+      return `<tr><td><i class="swatch" style="background:${colorFor(m)}"></i>${esc(m)}</td>` +
         `<td class="num">${fmt(reqModels.get(m)||0)}</td><td class="num">${fmt(c)}</td>` +
         `<td class="num">${ttftMC.get(m) ? secs(ttftMS.get(m)/ttftMC.get(m)) : '–'}</td>` +
         `<td class="num">${tpsMC.get(m) ? fmt(tpsMS.get(m)/tpsMC.get(m)) : '–'}</td>` +
+        `<td class="num">${isFinite(tpotAvg(m)) ? secs(tpotAvg(m)) : '–'}</td>` +
         `<td class="num">${ok ? fmt(c/ok) + ' tok' : '–'}</td>` +
+        `<td class="num">${pct(truncPct(m))}</td>` +
+        `<td class="num">${pct(reasonPct(m))}</td>` +
         `<td class="num">${errPct(m)}</td>` +
         `<td class="num">${money((ptok.get(m)||0)/1e6*cfg.price_in + c/1e6*cfg.price_out)}</td></tr>`;
     }).join('') + '</table>';
@@ -811,6 +987,165 @@ function render() {
   legend($('legend-benches'), benchSeries);
   $('table-lanes').innerHTML =
     `<table><tr><th>Lane</th><th class="num">Requests</th><th class="num">Share</th><th class="num">Last 60s</th><th class="num">429s</th><th class="num">Other benches</th></tr>${laneRows}</table>`;
+
+  /* ===== overview ===== */
+  $('o-savedLabel').textContent = `Dollars saved${windowLabel} (vs reference pricing)`;
+  $('o-reqsLabel').textContent = `Requests${windowLabel}`;
+  $('o-saved').textContent = money(saved);
+  arcGauge($('o-cap'), capRatio, Math.round(capRatio * 100) + '%', capColor);
+  arcGauge($('o-ok'), okRatio, wreq ? Math.round(okRatio * 100) + '%' : '–', okColor);
+  $('o-reqs').textContent = fmt(wreq);
+  $('o-ctok').textContent = fmt(allC);
+  $('o-ttft').textContent = ttftN ? secs(ttftS / ttftN) : '–';
+  $('o-tps').textContent = tpsN ? fmt(tpsS / tpsN) + ' tok/s' : '–';
+  lineChart($('spark-reqs'), [{ name: 'req/min', color: css('--s1'), pts: reqPts }], fmt);
+  lineChart($('spark-tok'), [{ name: 'tok/min', color: css('--s2'), pts: rateSeries(s => sum(s.rows, 'nimproxy_completion_tokens_total')) }], fmt);
+  lineChart($('spark-saved'), [{ name: 'saved', color: css('--s2'), pts: samples.map(s => ({ t: s.t, v: savedAt(s) })) }], money);
+
+  const shed = windowed(s => sum(s.rows, 'nimproxy_shed_total'));
+  const unauth = windowed(s => sum(s.rows, 'nimproxy_unauthorized_total'));
+  const logins = windowed(s => sum(s.rows, 'nimproxy_login_failures_total'));
+  const bench429 = windowed(s => sum(s.rows, 'nimproxy_lane_benched_total', l => l.status === '429'));
+  const healthRow = (l, v, warn) => `<tr><td>${l}</td><td class="num"${warn ? ' style="color:var(--critical)"' : ''}>${v}</td></tr>`;
+  $('o-health').innerHTML = '<table>' +
+    healthRow('Active now', fmt(sum(rows, 'nimproxy_active_requests'))) +
+    healthRow('Queued', fmt(sum(rows, 'nimproxy_queue_depth'))) +
+    healthRow('Rate-limit benches (429)', fmt(bench429)) +
+    healthRow('Shed (overload)', fmt(shed), shed > 0) +
+    healthRow('Unauthorized (401)', fmt(unauth), unauth > 0) +
+    healthRow('Failed logins', fmt(logins), logins > 0) +
+    '</table>';
+  const miniList = (el, entries, fmtV) => $(el).innerHTML = entries.length
+    ? entries.map(e => `<div class="meter"><span class="name wide" title="${esc(e.name)}">${esc(e.label ?? e.name)}</span>` +
+        `<span class="track"><span class="fill" style="width:${e.w}%;background:${e.color}"></span></span>` +
+        `<span class="val">${fmtV(e.v)}</span></div>`).join('')
+    : '<div class="empty">No traffic yet</div>';
+  const topM = models.slice(0, 3).map(m => ({ name: m, label: prettyName(m), v: ctok.get(m) || 0, color: colorFor(m) }));
+  const topMmax = Math.max(1, ...topM.map(e => e.v));
+  miniList('o-topmodels', topM.map(e => ({ ...e, w: (e.v / topMmax * 100).toFixed(0) })), fmt);
+  const topH = clients.slice(0, 3).map((c, i) => ({ name: c, v: cC.get(c) || 0, color: css(SLOTS[i % SLOTS.length]) }));
+  const topHmax = Math.max(1, ...topH.map(e => e.v));
+  miniList('o-topharness', topH.map(e => ({ ...e, w: (e.v / topHmax * 100).toFixed(0) })), fmt);
+
+  /* ===== models: extra quality charts ===== */
+  const quantSeries = (metric, filter) => [[0.5, 'median', css('--q-lo')], [0.95, 'p95', css('--q-hi')]].map(([q, name, color]) => ({
+    name, color,
+    pts: samples.slice(1).map((s, i) => {
+      const bA = s2 => buckets(s2.rows, metric, filter);
+      return { t: s.t, v: quantile(deltaBuckets(bA(s), bA(samples[i])), q) };
+    }).filter(p => isFinite(p.v)),
+  }));
+  const tpotSeries = quantSeries('nimproxy_tpot_seconds');
+  lineChart($('chart-tpot'), tpotSeries, secs);
+  legend($('legend-tpot'), tpotSeries);
+  const upSeries = quantSeries('nimproxy_upstream_seconds');
+  lineChart($('chart-upstream'), upSeries, secs);
+  legend($('legend-upstream'), upSeries);
+
+  const FINISH = [['stop', 'Completed', css('--s2')], ['length', 'Truncated', css('--s6')],
+    ['tool_calls', 'Tool call', css('--s1')], ['content_filter', 'Filtered', css('--s3')], ['other', 'Other', css('--ink-3')]];
+  const finByReason = Object.fromEntries(FINISH.map(([r]) => [r, wgroups('nimproxy_finish_reason_total', 'model', l => l.reason === r)]));
+  $('table-finish').innerHTML = !models.some(m => finTotal.get(m)) ? '<div class="empty">No completions yet</div>' :
+    '<table><tr><th>Model</th>' + FINISH.map(([, l]) => `<th class="num">${l}</th>`).join('') + '</tr>' +
+    models.filter(m => finTotal.get(m)).map(m => {
+      const tot = finTotal.get(m) || 1;
+      return `<tr><td><i class="swatch" style="background:${colorFor(m)}"></i>${esc(prettyName(m))}</td>` +
+        FINISH.map(([r]) => `<td class="num">${pct((finByReason[r].get(m) || 0) / tot * 100)}</td>`).join('') + '</tr>';
+    }).join('') + '</table>';
+
+  const reasoningModels = models.filter(m => (reasoningByModel.get(m) || 0) > 0);
+  barRows($('meters-reasoning'),
+    reasoningModels.map(m => ({ name: prettyName(m), v: reasonPct(m), color: colorFor(m) })),
+    pct);
+  if (!reasoningModels.length) $('meters-reasoning').innerHTML = '<div class="empty">No reasoning-token usage seen</div>';
+
+  /* ===== compare: head-to-head scorecard ===== */
+  const cmpModels = models.slice(0, 8);
+  const avgTtft = m => ttftMC.get(m) ? ttftMS.get(m) / ttftMC.get(m) : NaN;
+  const avgTps = m => tpsMC.get(m) ? tpsMS.get(m) / tpsMC.get(m) : NaN;
+  const errRate = m => { const e = errByModel.get(m) || 0, t = e + (okByModel.get(m) || 0); return t ? e / t * 100 : NaN; };
+  const avgReply = m => okByModel.get(m) ? (ctok.get(m) || 0) / okByModel.get(m) : NaN;
+  scorecard($('compare-scorecard'), cmpModels,
+    { head: 'Model', cell: m => `<i class="swatch" style="background:${colorFor(m)}"></i>${esc(prettyName(m))}` },
+    [
+      { label: 'Requests', get: m => reqModels.get(m) || 0, fmt: fmt, best: 'max' },
+      { label: 'TTFT', get: avgTtft, fmt: secs, best: 'min' },
+      { label: 'tok/s', get: avgTps, fmt: fmt, best: 'max' },
+      { label: 'TPOT', get: tpotAvg, fmt: secs, best: 'min' },
+      { label: 'Avg reply', get: avgReply, fmt: v => fmt(v) + ' tok', best: 'max' },
+      { label: 'Truncated', get: truncPct, fmt: pct, best: 'min' },
+      { label: 'Reasoning', get: reasonPct, fmt: pct, best: 'min' },
+      { label: 'Errors', get: errRate, fmt: pct, best: 'min' },
+    ]);
+  barRows($('compare-bars'), cmpModels.map(m => ({ name: prettyName(m), v: avgTps(m), color: colorFor(m) })), v => fmt(v) + ' tok/s');
+
+  /* ===== harnesses: what each agent is doing ===== */
+  const avgByKey = (sumN, cntN) => {
+    const s = wgroups(sumN, 'client'), n = wgroups(cntN, 'client');
+    return c => n.get(c) ? s.get(c) / n.get(c) : NaN;
+  };
+  const toolsAvg = avgByKey('nimproxy_request_tools_sum', 'nimproxy_request_tools_count');
+  const msgsAvg = avgByKey('nimproxy_request_messages_sum', 'nimproxy_request_messages_count');
+  const tempAvg = avgByKey('nimproxy_request_temperature_sum', 'nimproxy_request_temperature_count');
+  const streamT = wgroups('nimproxy_stream_requests_total', 'client', l => l.stream === 'true');
+  const streamF = wgroups('nimproxy_stream_requests_total', 'client', l => l.stream === 'false');
+  const toolReqs = wgroups('nimproxy_request_tools_count', 'client');
+  const genReq = c => (streamT.get(c) || 0) + (streamF.get(c) || 0);
+  const streamPct = c => genReq(c) ? (streamT.get(c) || 0) / genReq(c) * 100 : NaN;
+  const totStreamT = [...streamT.values()].reduce((a, b) => a + b, 0);
+  const totStreamF = [...streamF.values()].reduce((a, b) => a + b, 0);
+  const totGen = totStreamT + totStreamF;
+  const totToolReq = [...toolReqs.values()].reduce((a, b) => a + b, 0);
+  const oTools = wsum('nimproxy_request_tools_sum'), oToolsN = wsum('nimproxy_request_tools_count');
+  const oMsgs = wsum('nimproxy_request_messages_sum'), oMsgsN = wsum('nimproxy_request_messages_count');
+  $('h-count').textContent = clients.length;
+  $('h-stream').textContent = totGen ? Math.round(totStreamT / totGen * 100) + '%' : '–';
+  $('h-tools').textContent = oToolsN ? fmt(oTools / oToolsN) : '–';
+  $('h-msgs').textContent = oMsgsN ? fmt(oMsgs / oMsgsN) : '–';
+  $('h-toolpct').textContent = totGen ? Math.round(totToolReq / totGen * 100) + '%' : '–';
+  const hcolor = (c, i) => css(SLOTS[i % SLOTS.length]);
+  barRows($('h-toolint'), clients.map((c, i) => ({ name: c, v: toolsAvg(c), color: hcolor(c, i) })), fmt);
+  barRows($('h-depth'), clients.map((c, i) => ({ name: c, v: msgsAvg(c), color: hcolor(c, i) })), fmt);
+  barRows($('h-temp'), clients.map((c, i) => ({ name: c, v: tempAvg(c), color: hcolor(c, i) })), v => v.toFixed(2));
+  barRows($('h-streammix'), clients.map((c, i) => ({ name: c, v: streamPct(c), color: hcolor(c, i) })), v => Math.round(v) + '%');
+  $('table-harness').innerHTML = !clients.length ? '<div class="empty">No traffic yet</div>' :
+    '<table><tr><th>Harness</th><th class="num">Requests</th><th class="num">Tokens out</th><th class="num">Tools/req</th><th class="num">Msgs/req</th><th class="num">Streaming</th><th class="num">Saved</th></tr>' +
+    clients.map(c =>
+      `<tr><td>${esc(c)}</td><td class="num">${fmt(cReq.get(c) || 0)}</td><td class="num">${fmt(cC.get(c) || 0)}</td>` +
+      `<td class="num">${isFinite(toolsAvg(c)) ? fmt(toolsAvg(c)) : '–'}</td>` +
+      `<td class="num">${isFinite(msgsAvg(c)) ? fmt(msgsAvg(c)) : '–'}</td>` +
+      `<td class="num">${isFinite(streamPct(c)) ? Math.round(streamPct(c)) + '%' : '–'}</td>` +
+      `<td class="num">${money((cP.get(c) || 0) / 1e6 * cfg.price_in + (cC.get(c) || 0) / 1e6 * cfg.price_out)}</td></tr>`
+    ).join('') + '</table>';
+
+  /* ===== proxy: reliability & request-type panels ===== */
+  const relRow = (l, v, warn) => `<tr><td>${l}</td><td class="num"${warn ? ' style="color:var(--critical)"' : ''}>${v}</td></tr>`;
+  $('table-reliability').innerHTML = '<table>' +
+    relRow('Active now', fmt(sum(rows, 'nimproxy_active_requests'))) +
+    relRow('Queued', fmt(sum(rows, 'nimproxy_queue_depth'))) +
+    relRow('Shed (overload 503)', fmt(shed), shed > 0) +
+    relRow('Rate-limit benches (429)', fmt(bench429)) +
+    relRow('Other benches (5xx)', fmt(windowed(s => sum(s.rows, 'nimproxy_lane_benched_total', l => l.status !== '429')))) +
+    relRow('Unauthorized (401)', fmt(unauth), unauth > 0) +
+    relRow('Failed logins', fmt(logins), logins > 0) +
+    '</table>';
+  const jsonMode = windowed(s => sum(s.rows, 'nimproxy_json_mode_total'));
+  const tcModes = wgroups('nimproxy_tool_choice_total', 'mode');
+  const tcStr = [...tcModes.entries()].sort((a, b) => b[1] - a[1]).map(([m, n]) => `${esc(m)} ${fmt(n)}`).join(', ') || '–';
+  $('table-reqtypes').innerHTML = '<table>' +
+    relRow('Streaming', `${fmt(totStreamT)}${totGen ? ` (${Math.round(totStreamT / totGen * 100)}%)` : ''}`) +
+    relRow('Buffered', `${fmt(totStreamF)}${totGen ? ` (${Math.round(totStreamF / totGen * 100)}%)` : ''}`) +
+    relRow('Tool-offering', `${fmt(totToolReq)}${totGen ? ` (${Math.round(totToolReq / totGen * 100)}%)` : ''}`) +
+    relRow('JSON mode', fmt(jsonMode)) +
+    relRow('Tool choice', tcStr) +
+    '</table>';
+
+  /* ===== keys: headroom & sizing ===== */
+  const rpmForCap = mode.kind === 'live' ? curRpm : avgRpm;
+  const headroom = capacity - rpmForCap;
+  $('k-headroom').innerHTML = fmt(Math.max(0, headroom)) + '<span class="unit">rpm</span>';
+  const peakRpm = reqPts.length ? Math.max(...reqPts.map(p => p.v)) : 0;
+  $('k-needed').textContent = peakRpm > 0 ? Math.max(cfg.lanes, Math.ceil(peakRpm / cfg.rpm)) : '–';
 }
 
 /* ---------- data sources ---------- */

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,6 +272,34 @@ async fn main() {
             &[0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0],
         )
         .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Full("nimproxy_tpot_seconds".into()),
+            &[0.005, 0.01, 0.02, 0.04, 0.08, 0.16, 0.32],
+        )
+        .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Full("nimproxy_request_messages".into()),
+            &[1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0],
+        )
+        .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Full("nimproxy_request_tools".into()),
+            &[0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0],
+        )
+        .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Full("nimproxy_request_max_tokens".into()),
+            &[
+                128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0, 16384.0, 32768.0, 65536.0,
+                131072.0,
+            ],
+        )
+        .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Full("nimproxy_request_temperature".into()),
+            &[0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.5, 2.0],
+        )
+        .unwrap()
         .install_recorder()
         .expect("prometheus recorder");
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -172,6 +172,115 @@ fn record_tokens(ctx: &Ctx, prompt: Option<u64>, completion: Option<u64>, source
     }
 }
 
+/// Bound `finish_reason` to the known OpenAI set so an unexpected upstream
+/// value can't grow label cardinality. `length` is the truncation signal.
+fn finish_label(raw: &str) -> String {
+    match raw {
+        "stop" | "length" | "tool_calls" | "content_filter" | "function_call" => raw.to_owned(),
+        _ => "other".to_owned(),
+    }
+}
+
+/// The request's tool-selection mode, bounded to a small enum. Called only
+/// when the request offers tools, so a missing `tool_choice` means the
+/// provider default (auto).
+fn tool_choice_mode(v: &serde_json::Value) -> &'static str {
+    match v.get("tool_choice") {
+        Some(serde_json::Value::String(s)) => match s.as_str() {
+            "auto" => "auto",
+            "none" => "none",
+            "required" => "required",
+            _ => "other",
+        },
+        Some(serde_json::Value::Object(_)) => "named",
+        _ => "auto",
+    }
+}
+
+/// Count tools offered in a request body (`tools`, or legacy `functions`).
+fn count_tools(v: &serde_json::Value) -> Option<usize> {
+    v.get("tools")
+        .and_then(|t| t.as_array())
+        .map(|a| a.len())
+        .or_else(|| {
+            v.get("functions")
+                .and_then(|t| t.as_array())
+                .map(|a| a.len())
+        })
+}
+
+/// Whether the request asks for structured (JSON) output.
+fn is_json_mode(v: &serde_json::Value) -> bool {
+    v.get("response_format")
+        .and_then(|rf| rf.get("type"))
+        .and_then(|t| t.as_str())
+        .is_some_and(|t| t == "json_object" || t == "json_schema")
+}
+
+/// Record request-shape metrics: what the harness asked for (stream flag,
+/// conversation depth, tools offered, sampling params, output cap, JSON mode).
+/// Counts and sizes only — never message content. All heavy values go to
+/// histograms, never labels, so cardinality stays bounded.
+fn record_shape(ctx: &Ctx, parsed: Option<&serde_json::Value>, wants_stream: bool) {
+    counter!(
+        "nimproxy_stream_requests_total",
+        "model" => ctx.model.clone(),
+        "stream" => if wants_stream { "true" } else { "false" }.to_owned(),
+    )
+    .increment(1);
+    let Some(v) = parsed else { return };
+    if let Some(msgs) = v.get("messages").and_then(|m| m.as_array()) {
+        histogram!("nimproxy_request_messages", "model" => ctx.model.clone())
+            .record(msgs.len() as f64);
+    }
+    if let Some(n) = count_tools(v) {
+        histogram!("nimproxy_request_tools", "model" => ctx.model.clone()).record(n as f64);
+        counter!("nimproxy_tool_choice_total", "mode" => tool_choice_mode(v).to_owned())
+            .increment(1);
+    }
+    if let Some(mt) = v
+        .get("max_tokens")
+        .and_then(|x| x.as_u64())
+        .or_else(|| v.get("max_completion_tokens").and_then(|x| x.as_u64()))
+    {
+        histogram!("nimproxy_request_max_tokens").record(mt as f64);
+    }
+    if let Some(t) = v.get("temperature").and_then(|x| x.as_f64()) {
+        histogram!("nimproxy_request_temperature").record(t);
+    }
+    if is_json_mode(v) {
+        counter!("nimproxy_json_mode_total", "model" => ctx.model.clone()).increment(1);
+    }
+}
+
+/// Record response-quality signals available once a generation completes:
+/// how it ended (truncation), reasoning-token burn, and tool-call volume.
+fn record_quality(
+    ctx: &Ctx,
+    finish: Option<&str>,
+    reasoning: Option<u64>,
+    tool_calls: Option<u64>,
+) {
+    if let Some(fr) = finish {
+        counter!(
+            "nimproxy_finish_reason_total",
+            "model" => ctx.model.clone(),
+            "reason" => finish_label(fr),
+        )
+        .increment(1);
+    }
+    if let Some(r) = reasoning {
+        if r > 0 {
+            counter!("nimproxy_reasoning_tokens_total", "model" => ctx.model.clone()).increment(r);
+        }
+    }
+    if let Some(n) = tool_calls {
+        if n > 0 {
+            counter!("nimproxy_tool_calls_total", "model" => ctx.model.clone()).increment(n);
+        }
+    }
+}
+
 /// Watches an SSE byte stream for the `usage` object and counts data events
 /// (a rough one-token-per-event estimate when the upstream omits usage).
 /// Purely observational — bytes reach the client untouched.
@@ -181,6 +290,10 @@ struct SseScan {
     events: u64,
     prompt: Option<u64>,
     completion: Option<u64>,
+    reasoning: Option<u64>,
+    finish_reason: Option<String>,
+    /// Highest `tool_calls[].index` seen; +1 is the tool-call count.
+    tool_call_max: Option<u64>,
 }
 
 impl SseScan {
@@ -194,19 +307,50 @@ impl SseScan {
                     continue;
                 }
                 self.events += 1;
-                if data.contains("\"usage\"") {
-                    if let Some(u) = serde_json::from_str::<serde_json::Value>(data)
-                        .ok()
-                        .and_then(|v| v.get("usage").filter(|u| !u.is_null()).cloned())
-                    {
-                        self.prompt = u
-                            .get("prompt_tokens")
-                            .and_then(|x| x.as_u64())
-                            .or(self.prompt);
-                        self.completion = u
-                            .get("completion_tokens")
-                            .and_then(|x| x.as_u64())
-                            .or(self.completion);
+                // Only the events that carry usage, a concrete finish_reason
+                // (a string, not the per-chunk `null`), or tool_calls are worth
+                // a full JSON parse; plain content deltas are skipped.
+                let interesting = data.contains("\"usage\"")
+                    || data.contains("\"finish_reason\":\"")
+                    || data.contains("\"tool_calls\"");
+                if interesting {
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(data) {
+                        if let Some(u) = v.get("usage").filter(|u| !u.is_null()) {
+                            self.prompt = u
+                                .get("prompt_tokens")
+                                .and_then(|x| x.as_u64())
+                                .or(self.prompt);
+                            self.completion = u
+                                .get("completion_tokens")
+                                .and_then(|x| x.as_u64())
+                                .or(self.completion);
+                            self.reasoning = u
+                                .get("completion_tokens_details")
+                                .and_then(|d| d.get("reasoning_tokens"))
+                                .and_then(|x| x.as_u64())
+                                .or(self.reasoning);
+                        }
+                        if let Some(choices) = v.get("choices").and_then(|c| c.as_array()) {
+                            for ch in choices {
+                                if let Some(fr) = ch.get("finish_reason").and_then(|f| f.as_str()) {
+                                    self.finish_reason = Some(fr.to_owned());
+                                }
+                                if let Some(tcs) = ch
+                                    .get("delta")
+                                    .and_then(|d| d.get("tool_calls"))
+                                    .and_then(|t| t.as_array())
+                                {
+                                    for tc in tcs {
+                                        if let Some(idx) = tc.get("index").and_then(|i| i.as_u64())
+                                        {
+                                            self.tool_call_max = Some(
+                                                self.tool_call_max.map_or(idx, |m| m.max(idx)),
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -327,6 +471,11 @@ pub async fn handle(
         .and_then(|v| v.get("stream").and_then(|s| s.as_bool()))
         .unwrap_or(false);
     let prefer = parsed.as_ref().and_then(|v| affinity(v, state.pool.len()));
+
+    // Fingerprint what the harness asked for (generation endpoints only).
+    if ctx.path == "/v1/chat/completions" || ctx.path == "/v1/completions" {
+        record_shape(&ctx, parsed.as_ref(), wants_stream);
+    }
 
     // Usage injection: streamed responses only report exact token usage when
     // asked via stream_options, so ask on the client's behalf. `fallback`
@@ -567,13 +716,26 @@ async fn streaming(
             };
             let completion = scan.completion.or(Some(scan.events));
             record_tokens(&ctx, scan.prompt, completion, source);
+            record_quality(
+                &ctx,
+                scan.finish_reason.as_deref(),
+                scan.reasoning,
+                scan.tool_call_max.map(|m| m + 1),
+            );
             if let (Some(first), Some(c)) = (first_chunk, completion) {
                 let gen_secs = first.elapsed().as_secs_f64();
                 if gen_secs > 0.1 && c > 0 {
                     histogram!("nimproxy_tokens_per_second", "model" => ctx.model.clone(), "source" => source.to_owned())
                         .record(c as f64 / gen_secs);
+                    // Mean inter-token latency (time-per-output-token).
+                    histogram!("nimproxy_tpot_seconds", "model" => ctx.model.clone())
+                        .record(gen_secs / c as f64);
                 }
             }
+            // Total upstream time for streaming, for parity with the buffered
+            // path (which records upstream_seconds directly).
+            histogram!("nimproxy_upstream_seconds", "model" => ctx.model.clone())
+                .record(sent_at.elapsed().as_secs_f64());
             record_request(&ctx, "200");
             return;
         }
@@ -636,16 +798,36 @@ async fn relay(resp: reqwest::Response, ctx: &Ctx) -> Response {
         .to_owned();
     let body = resp.bytes().await.unwrap_or_default();
     if status.is_success() {
-        if let Some(u) = serde_json::from_slice::<serde_json::Value>(&body)
-            .ok()
-            .and_then(|v| v.get("usage").filter(|u| !u.is_null()).cloned())
-        {
-            record_tokens(
-                ctx,
-                u.get("prompt_tokens").and_then(|x| x.as_u64()),
-                u.get("completion_tokens").and_then(|x| x.as_u64()),
-                "usage",
-            );
+        if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&body) {
+            if let Some(u) = v.get("usage").filter(|u| !u.is_null()) {
+                record_tokens(
+                    ctx,
+                    u.get("prompt_tokens").and_then(|x| x.as_u64()),
+                    u.get("completion_tokens").and_then(|x| x.as_u64()),
+                    "usage",
+                );
+            }
+            let reasoning = v
+                .get("usage")
+                .and_then(|u| u.get("completion_tokens_details"))
+                .and_then(|d| d.get("reasoning_tokens"))
+                .and_then(|x| x.as_u64());
+            let choices = v.get("choices").and_then(|c| c.as_array());
+            let finish = choices
+                .and_then(|c| c.first())
+                .and_then(|c| c.get("finish_reason"))
+                .and_then(|f| f.as_str());
+            let tool_calls = choices.map(|cs| {
+                cs.iter()
+                    .filter_map(|c| {
+                        c.get("message")
+                            .and_then(|m| m.get("tool_calls"))
+                            .and_then(|t| t.as_array())
+                    })
+                    .map(|a| a.len() as u64)
+                    .sum::<u64>()
+            });
+            record_quality(ctx, finish, reasoning, tool_calls);
         }
     }
     Response::builder()
@@ -722,7 +904,10 @@ fn gateway_timeout(state: &AppState) -> Response {
 
 #[cfg(test)]
 mod tests {
-    use super::{bounded_label, label_path, sanitize_label, SseScan};
+    use super::{
+        bounded_label, count_tools, finish_label, is_json_mode, label_path, sanitize_label,
+        tool_choice_mode, SseScan,
+    };
     use std::collections::HashSet;
 
     #[test]
@@ -782,5 +967,63 @@ mod tests {
         scan.feed(b"data: {\"a\":1}\n\ndata: {\"b\":2}\n\ndata: {\"c\":3}\n\ndata: [DONE]\n\n");
         assert_eq!(scan.events, 3);
         assert_eq!(scan.completion, None);
+    }
+
+    #[test]
+    fn scan_captures_finish_reason_tool_calls_and_reasoning() {
+        let mut scan = SseScan::default();
+        // A content delta (finish_reason:null — skipped), two tool-call deltas
+        // (indices 0 and 1), then a final chunk with finish_reason + usage that
+        // carries reasoning-token details.
+        scan.feed(
+            b"data: {\"choices\":[{\"delta\":{\"content\":\"x\"},\"finish_reason\":null}]}\n\n",
+        );
+        scan.feed(b"data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"name\":\"a\"}}]}}]}\n\n");
+        scan.feed(b"data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"function\":{\"name\":\"b\"}}]}}]}\n\n");
+        scan.feed(b"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n");
+        scan.feed(b"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":8,\"completion_tokens_details\":{\"reasoning_tokens\":5}}}\n\ndata: [DONE]\n\n");
+        assert_eq!(scan.finish_reason.as_deref(), Some("tool_calls"));
+        assert_eq!(scan.tool_call_max, Some(1)); // +1 => 2 tool calls
+        assert_eq!(scan.reasoning, Some(5));
+        assert_eq!(scan.completion, Some(8));
+    }
+
+    #[test]
+    fn finish_label_bounds_unknown_values() {
+        assert_eq!(finish_label("stop"), "stop");
+        assert_eq!(finish_label("length"), "length");
+        assert_eq!(finish_label("tool_calls"), "tool_calls");
+        assert_eq!(finish_label("weird\"injection"), "other");
+    }
+
+    #[test]
+    fn tool_choice_and_shape_readers() {
+        let auto = serde_json::json!({"tools": [{}], "tool_choice": "auto"});
+        assert_eq!(tool_choice_mode(&auto), "auto");
+        let named = serde_json::json!({"tool_choice": {"type": "function"}});
+        assert_eq!(tool_choice_mode(&named), "named");
+        // tools present, no explicit choice -> provider default (auto)
+        assert_eq!(
+            tool_choice_mode(&serde_json::json!({"tools": [{}]})),
+            "auto"
+        );
+
+        assert_eq!(
+            count_tools(&serde_json::json!({"tools": [{}, {}, {}]})),
+            Some(3)
+        );
+        assert_eq!(
+            count_tools(&serde_json::json!({"functions": [{}]})),
+            Some(1)
+        );
+        assert_eq!(count_tools(&serde_json::json!({"model": "x"})), None);
+
+        assert!(is_json_mode(
+            &serde_json::json!({"response_format": {"type": "json_object"}})
+        ));
+        assert!(!is_json_mode(
+            &serde_json::json!({"response_format": {"type": "text"}})
+        ));
+        assert!(!is_json_mode(&serde_json::json!({"model": "x"})));
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -222,19 +222,21 @@ fn is_json_mode(v: &serde_json::Value) -> bool {
 /// Counts and sizes only — never message content. All heavy values go to
 /// histograms, never labels, so cardinality stays bounded.
 fn record_shape(ctx: &Ctx, parsed: Option<&serde_json::Value>, wants_stream: bool) {
+    // Labeled by client: request shape reflects the harness, not the model —
+    // this is what powers the Harnesses view ("what is each agent doing").
     counter!(
         "nimproxy_stream_requests_total",
-        "model" => ctx.model.clone(),
+        "client" => ctx.client.clone(),
         "stream" => if wants_stream { "true" } else { "false" }.to_owned(),
     )
     .increment(1);
     let Some(v) = parsed else { return };
     if let Some(msgs) = v.get("messages").and_then(|m| m.as_array()) {
-        histogram!("nimproxy_request_messages", "model" => ctx.model.clone())
+        histogram!("nimproxy_request_messages", "client" => ctx.client.clone())
             .record(msgs.len() as f64);
     }
     if let Some(n) = count_tools(v) {
-        histogram!("nimproxy_request_tools", "model" => ctx.model.clone()).record(n as f64);
+        histogram!("nimproxy_request_tools", "client" => ctx.client.clone()).record(n as f64);
         counter!("nimproxy_tool_choice_total", "mode" => tool_choice_mode(v).to_owned())
             .increment(1);
     }
@@ -243,13 +245,13 @@ fn record_shape(ctx: &Ctx, parsed: Option<&serde_json::Value>, wants_stream: boo
         .and_then(|x| x.as_u64())
         .or_else(|| v.get("max_completion_tokens").and_then(|x| x.as_u64()))
     {
-        histogram!("nimproxy_request_max_tokens").record(mt as f64);
+        histogram!("nimproxy_request_max_tokens", "client" => ctx.client.clone()).record(mt as f64);
     }
     if let Some(t) = v.get("temperature").and_then(|x| x.as_f64()) {
-        histogram!("nimproxy_request_temperature").record(t);
+        histogram!("nimproxy_request_temperature", "client" => ctx.client.clone()).record(t);
     }
     if is_json_mode(v) {
-        counter!("nimproxy_json_mode_total", "model" => ctx.model.clone()).increment(1);
+        counter!("nimproxy_json_mode_total", "client" => ctx.client.clone()).increment(1);
     }
 }
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -435,17 +435,17 @@ async fn request_shape_and_quality_metrics_are_recorded() {
         .await
         .unwrap();
 
-    // Request shape.
+    // Request shape (labeled by client — harness behavior).
     assert!(
-        metrics.contains(r#"nimproxy_stream_requests_total{model="mock/model-a",stream="true"}"#),
+        metrics.contains(r#"nimproxy_stream_requests_total{client="local",stream="true"}"#),
         "stream flag counted: {metrics}"
     );
     assert!(
-        metrics.contains(r#"nimproxy_request_messages_count{model="mock/model-a"}"#),
+        metrics.contains(r#"nimproxy_request_messages_count{client="local"}"#),
         "conversation depth histogram present"
     );
     assert!(
-        metrics.contains(r#"nimproxy_request_tools_count{model="mock/model-a"}"#),
+        metrics.contains(r#"nimproxy_request_tools_count{client="local"}"#),
         "tools-offered histogram present"
     );
     assert!(

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -492,6 +492,100 @@ async fn request_shape_and_quality_metrics_are_recorded() {
     }
 }
 
+/// The buffered (non-streaming) path extracts finish_reason, reasoning tokens,
+/// and tool-call count from `relay()`; an unknown finish_reason collapses to
+/// `other`; JSON mode and non-`auto` tool_choice are recorded. These paths are
+/// distinct from the streaming assertions above.
+#[tokio::test]
+async fn buffered_quality_and_edge_cases_are_recorded() {
+    let mock = start_mock().await;
+    let proxy = start_proxy(&mock.url, &[]).await;
+
+    let post = |body: serde_json::Value| {
+        let proxy = &proxy;
+        async move {
+            let r = client()
+                .post(proxy.url("/v1/chat/completions"))
+                .json(&body)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(r.status(), 200);
+            r.text().await.unwrap();
+        }
+    };
+
+    // Buffered tool call: mock answers with message.tool_calls + finish tool_calls.
+    post(serde_json::json!({
+        "model": "mock/model-a", "stream": false, "tool_choice": "required",
+        "tools": [{"type": "function", "function": {"name": "run"}}],
+        "messages": [{"role": "user", "content": "go"}]
+    }))
+    .await;
+
+    // Buffered JSON mode.
+    post(serde_json::json!({
+        "model": "mock/model-a", "stream": false,
+        "response_format": {"type": "json_object"},
+        "messages": [{"role": "user", "content": "as json"}]
+    }))
+    .await;
+
+    // Unknown upstream finish_reason must collapse to "other".
+    mock.state.push(Behavior::OddFinish);
+    post(serde_json::json!({
+        "model": "mock/model-a", "stream": false,
+        "messages": [{"role": "user", "content": "hi"}]
+    }))
+    .await;
+
+    let metrics = client()
+        .get(proxy.url("/metrics"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    // Buffered quality extraction (from relay()).
+    assert!(
+        metrics
+            .contains(r#"nimproxy_finish_reason_total{model="mock/model-a",reason="tool_calls"}"#),
+        "buffered tool_calls finish recorded: {metrics}"
+    );
+    assert!(
+        metrics.contains(r#"nimproxy_tool_calls_total{model="mock/model-a"}"#),
+        "buffered tool-call count recorded"
+    );
+    assert!(
+        metrics.contains(r#"nimproxy_reasoning_tokens_total{model="mock/model-a"}"#),
+        "buffered reasoning tokens recorded"
+    );
+    assert!(
+        metrics.contains(r#"nimproxy_upstream_seconds_count{model="mock/model-a"}"#),
+        "upstream latency recorded on the buffered path"
+    );
+
+    // Edge cases.
+    assert!(
+        metrics.contains(r#"nimproxy_tool_choice_total{mode="required"}"#),
+        "non-auto tool_choice mode recorded"
+    );
+    assert!(
+        metrics.contains(r#"nimproxy_json_mode_total{client="local"}"#),
+        "JSON mode recorded"
+    );
+    assert!(
+        metrics.contains(r#"nimproxy_finish_reason_total{model="mock/model-a",reason="other"}"#),
+        "unknown finish_reason collapsed to other: {metrics}"
+    );
+    assert!(
+        !metrics.contains(r#"reason="banana""#),
+        "raw upstream finish_reason never becomes a label"
+    );
+}
+
 #[tokio::test]
 async fn history_records_snapshots_and_survives_restart() {
     let dir = std::env::temp_dir().join(format!("nimproxy-test-{}", std::process::id()));

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -387,6 +387,112 @@ async fn metrics_report_traffic_tokens_and_affinity() {
 }
 
 #[tokio::test]
+async fn request_shape_and_quality_metrics_are_recorded() {
+    let mock = start_mock().await;
+    let proxy = start_proxy(&mock.url, &[]).await;
+
+    // A plain streaming request (finishes "stop").
+    read_sse(
+        client()
+            .post(proxy.url("/v1/chat/completions"))
+            .json(&chat_body("hi", true))
+            .send()
+            .await
+            .unwrap(),
+    )
+    .await;
+
+    // A tool-using request with sampling params: the mock answers with a
+    // tool_calls delta and finish_reason "tool_calls".
+    let tool_req = serde_json::json!({
+        "model": "mock/model-a",
+        "stream": true,
+        "temperature": 0.7,
+        "max_tokens": 4096,
+        "tools": [{"type": "function", "function": {"name": "get_weather"}}],
+        "tool_choice": "auto",
+        "messages": [
+            {"role": "system", "content": "you are a test"},
+            {"role": "user", "content": "weather?"}
+        ]
+    });
+    read_sse(
+        client()
+            .post(proxy.url("/v1/chat/completions"))
+            .json(&tool_req)
+            .send()
+            .await
+            .unwrap(),
+    )
+    .await;
+
+    let metrics = client()
+        .get(proxy.url("/metrics"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    // Request shape.
+    assert!(
+        metrics.contains(r#"nimproxy_stream_requests_total{model="mock/model-a",stream="true"}"#),
+        "stream flag counted: {metrics}"
+    );
+    assert!(
+        metrics.contains(r#"nimproxy_request_messages_count{model="mock/model-a"}"#),
+        "conversation depth histogram present"
+    );
+    assert!(
+        metrics.contains(r#"nimproxy_request_tools_count{model="mock/model-a"}"#),
+        "tools-offered histogram present"
+    );
+    assert!(
+        metrics.contains("nimproxy_request_temperature_count"),
+        "temperature histogram present"
+    );
+    assert!(
+        metrics.contains("nimproxy_request_max_tokens_count"),
+        "max_tokens histogram present"
+    );
+    assert!(
+        metrics.contains(r#"nimproxy_tool_choice_total{mode="auto"}"#),
+        "tool_choice mode counted"
+    );
+
+    // Response quality.
+    assert!(
+        metrics.contains(r#"nimproxy_finish_reason_total{model="mock/model-a",reason="stop"}"#),
+        "stop finish recorded: {metrics}"
+    );
+    assert!(
+        metrics
+            .contains(r#"nimproxy_finish_reason_total{model="mock/model-a",reason="tool_calls"}"#),
+        "tool_calls finish recorded"
+    );
+    assert!(
+        metrics.contains(r#"nimproxy_tool_calls_total{model="mock/model-a"}"#),
+        "tool-call volume recorded"
+    );
+    assert!(
+        metrics.contains(r#"nimproxy_reasoning_tokens_total{model="mock/model-a"}"#),
+        "reasoning tokens recorded"
+    );
+
+    // Cardinality stays bounded: the stream label is a two-value enum.
+    for line in metrics
+        .lines()
+        .filter(|l| l.starts_with("nimproxy_stream_requests_total{"))
+    {
+        assert!(
+            line.contains(r#"stream="true""#) || line.contains(r#"stream="false""#),
+            "stream label bounded to true/false: {line}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn history_records_snapshots_and_survives_restart() {
     let dir = std::env::temp_dir().join(format!("nimproxy-test-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -30,6 +30,9 @@ pub enum Behavior {
     BadRequestIfInjected,
     /// Send headers + one chunk, then stall forever.
     Hang,
+    /// Buffered response with an unknown `finish_reason` — exercises the
+    /// server-side clamp that collapses odd values to `other`.
+    OddFinish,
 }
 
 pub struct Hit {
@@ -132,6 +135,12 @@ async fn mock_chat(
             .unwrap(),
         Behavior::BadRequest => bad_request(),
         Behavior::BadRequestIfInjected if injected => bad_request(),
+        Behavior::OddFinish => axum::Json(serde_json::json!({
+            "id": "mock-1", "object": "chat.completion",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "banana"}],
+            "usage": {"prompt_tokens": 11, "completion_tokens": 2}
+        }))
+        .into_response(),
         Behavior::Hang => {
             let stream = futures_util::stream::once(async {
                 Ok::<_, std::io::Error>(Bytes::from("data: {\"choices\":[]}\n\n"))

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -140,25 +140,47 @@ async fn mock_chat(
             sse(Body::from_stream(stream))
         }
         Behavior::Ok | Behavior::BadRequestIfInjected => {
+            // Echo the request's shape so e2e can exercise the quality metrics:
+            // a request that offers tools gets a tool_calls response, otherwise
+            // a normal stop. Usage always carries reasoning-token details.
+            let offers_tools = parsed.get("tools").is_some();
+            let usage = "\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":2,\"completion_tokens_details\":{\"reasoning_tokens\":3}}";
             if wants_stream {
-                let chunks: Vec<Result<Bytes, std::io::Error>> = vec![
-                    Ok(Bytes::from(
+                let mut chunks: Vec<Result<Bytes, std::io::Error>> = Vec::new();
+                if offers_tools {
+                    chunks.push(Ok(Bytes::from(
+                        "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"name\":\"get_weather\"}}]}}]}\n\n",
+                    )));
+                    chunks.push(Ok(Bytes::from(
+                        "data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+                    )));
+                } else {
+                    chunks.push(Ok(Bytes::from(
                         "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hello\"}}]}\n\n",
-                    )),
-                    Ok(Bytes::from(
-                        "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\" world\"}}]}\n\n",
-                    )),
-                    Ok(Bytes::from(
-                        "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":2}}\n\n",
-                    )),
-                    Ok(Bytes::from("data: [DONE]\n\n")),
-                ];
+                    )));
+                    chunks.push(Ok(Bytes::from(
+                        "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\" world\"},\"finish_reason\":\"stop\"}]}\n\n",
+                    )));
+                }
+                chunks.push(Ok(Bytes::from(format!(
+                    "data: {{\"choices\":[],{usage}}}\n\n"
+                ))));
+                chunks.push(Ok(Bytes::from("data: [DONE]\n\n")));
                 sse(Body::from_stream(futures_util::stream::iter(chunks)))
+            } else if offers_tools {
+                axum::Json(serde_json::json!({
+                    "id": "mock-1", "object": "chat.completion",
+                    "choices": [{"index": 0, "message": {"role": "assistant", "tool_calls": [
+                        {"index": 0, "id": "c1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}
+                    ]}, "finish_reason": "tool_calls"}],
+                    "usage": {"prompt_tokens": 11, "completion_tokens": 2, "completion_tokens_details": {"reasoning_tokens": 3}}
+                }))
+                .into_response()
             } else {
                 axum::Json(serde_json::json!({
                     "id": "mock-1", "object": "chat.completion",
                     "choices": [{"index": 0, "message": {"role": "assistant", "content": "hello world"}, "finish_reason": "stop"}],
-                    "usage": {"prompt_tokens": 11, "completion_tokens": 2}
+                    "usage": {"prompt_tokens": 11, "completion_tokens": 2, "completion_tokens_details": {"reasoning_tokens": 3}}
                 }))
                 .into_response()
             }


### PR DESCRIPTION
Turns nim-proxy into a benchmarking / agent-observability tool. Because it sits in the request path for every harness and model, it can see *what agents actually do* — and most of that signal was already deserialized and simply discarded. This PR captures it as bounded-cardinality metrics and rebuilds the dashboard into six persona-aligned views.

This PR started as "dashboard reporting polish" and grew (by request) to include the full v0.4.0 benchmarking build. It's structured as three ordered commits:

1. **Dashboard polish** — generation-speed trend, non-success outcome breakdown, threshold-colored gauges.
2. **Server metrics** — capture request shape & response quality from the request path.
3. **Six-view dashboard** — consume it all + version bump.

## Server-side metrics (privacy-preserving: counts & sizes, never message content)

Read from the already-parsed request body / SSE scan, emitted as **histograms for counts/params** and **labels only for fixed enums** (clamped server-side), so cardinality stays bounded.

- **Request shape (per client / harness):** `stream_requests_total{stream}`, `request_messages`, `request_tools`, `request_max_tokens`, `request_temperature`, `tool_choice_total{mode}`, `json_mode_total`.
- **Response quality (per model):** `finish_reason_total{reason}` (→ truncation), `tool_calls_total`, `reasoning_tokens_total`, `tpot_seconds` (mean inter-token latency); streaming now records `upstream_seconds` too.

Shape is labeled by *client* (the harness determines tool use/sampling), quality by *model* — avoiding a client×model×buckets cardinality blow-up.

## Dashboard: three tabs → six views

Each view ordered **at-a-glance → trends → detail**:

- **Overview** (new) — hero KPIs, threshold gauges, request/token/savings sparklines, health strip, top models & harnesses.
- **Models** — adds TPOT & upstream-latency quantile charts, truncation breakdown, reasoning-vs-output share, richer per-model table.
- **Compare** (new) — head-to-head model scorecard, best-in-column highlighted, + generation-speed bar race.
- **Harnesses** (new) — tool intensity, conversation depth, sampling fingerprint, streaming mix, per-harness leaderboard.
- **Proxy** — adds reliability & security panel and request-types panel (surfaces previously-unused `shed`/`unauthorized`/`login_failures` counters).
- **Keys** — adds live headroom and a keys-for-peak sizing estimate.

New reusable helpers (`scorecard()`, `barRows()`) and a hash-to-hue `colorFor()` fallback past the six categorical slots.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, full `cargo test` (29 unit + 20 e2e) — all green. New unit tests for the readers/`SseScan`; new e2e asserting the metrics with bounded labels.
- **Headless Chromium** against a mock driving two named harnesses (opencode: tool-heavy/deep; codex: plain): all six tabs populate with live data, the Harnesses view distinguishes both with distinct fingerprints (tools=3 vs 0, depth 12 vs 1), gauges take threshold colors — **zero JS page errors**.
- No new dependencies.

## Docs / knowledge base (in lockstep)

- `README.md` — six-view dashboard section + expanded metrics table with the privacy note.
- `knowledge/decisions/request-shape-metrics.md` (new), `knowledge/architecture/dashboard.md`, `log.md`, `index.md`, `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC