### PR TITLE
CI 5a: coverage gate + native security scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Rust dependencies. Group minor/patch bumps into one PR to cut noise;
+  # major bumps come as individual PRs so they get real review.
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # GitHub Actions used in workflows (keeps pinned versions fresh / SHA-pinnable).
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        update-types: ["minor", "patch"]
+
+  # The Docker build base image (rust:1-alpine).
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
   gitleaks:
     name: gitleaks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read # gitleaks lists PR commits on pull_request runs
     steps:
       - uses: actions/checkout@v4
         with:
@@ -81,24 +84,6 @@ jobs:
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  trivy:
-    name: trivy image scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build image
-        run: docker build -t nim-proxy:ci .
-      # Scratch image with a static binary has no OS layer, so this mostly
-      # future-proofs against a base-image change; fail on any fixable HIGH/CRIT.
-      - name: Scan image
-        uses: aquasecurity/trivy-action@0.28.0
-        with:
-          image-ref: nim-proxy:ci
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
-          exit-code: "1"
-          format: table
 
   docker:
     name: docker build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+# Least privilege by default; jobs opt into more only if they need it.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -35,15 +39,66 @@ jobs:
           PY
           node --check "$RUNNER_TEMP/dash.js"
 
-  audit:
-    name: cargo audit
+  coverage:
+    name: coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: rustsec/audit-check@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      # The e2e suite spawns the real binary; the test harness forwards the
+      # coverage profile path to the child and shuts it down gracefully under
+      # llvm-cov, so subprocess coverage is captured. Gate at 80% lines.
+      - name: Coverage (gate >= 80% lines)
+        run: |
+          {
+            echo '```'
+            cargo llvm-cov --summary-only --fail-under-lines 80
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history for the secret sweep
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  trivy:
+    name: trivy image scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image
+        run: docker build -t nim-proxy:ci .
+      # Scratch image with a static binary has no OS layer, so this mostly
+      # future-proofs against a base-image change; fail on any fixable HIGH/CRIT.
+      - name: Scan image
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: nim-proxy:ci
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          format: table
 
   docker:
     name: docker build

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 /data
 __pycache__/
+.claude/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,23 @@
+# gitleaks configuration — extends the built-in ruleset.
+# The default rules catch real high-entropy / provider-format secrets; the
+# allowlist below keeps the intentional placeholders in docs from tripping it.
+title = "nim-proxy gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Documented placeholders and example configs — not real secrets"
+paths = [
+    '''\.env\.example''',
+    '''examples/.*''',
+    '''README\.md''',
+]
+regexes = [
+    '''nvapi-xxx''',
+    '''nvapi-yyy''',
+    '''nvapi-\.\.\.''',
+    '''your-proxy-secret''',
+    '''a-long-random-string''',
+    '''[a-z]+:[0-9a-f]{4}\.\.\.''',
+]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,39 @@
+# cargo-deny supply-chain policy — https://embarkstudios.github.io/cargo-deny/
+# Run locally with: cargo deny check
+
+[advisories]
+version = 2
+# RustSec advisories are always denied; yanked crates too. Add IDs to `ignore`
+# with a justification only when a fix is genuinely unavailable.
+yanked = "deny"
+ignore = []
+
+[licenses]
+version = 2
+confidence-threshold = 0.9
+# Permissive licenses compatible with redistributing an MIT binary. Anything
+# not on this list fails the build (tune deliberately, never blanket-allow).
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "Unicode-3.0",
+    # Community Data License Agreement — permissive; used by webpki-roots
+    # (the bundled Mozilla CA root set).
+    "CDLA-Permissive-2.0",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+allow = []
+deny = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -244,6 +244,21 @@ impl Proxy {
 
 impl Drop for Proxy {
     fn drop(&mut self) {
+        // A SIGKILLed process never flushes its coverage profile. Under
+        // `cargo llvm-cov` (detected via LLVM_PROFILE_FILE) ask for a graceful
+        // SIGTERM — which the proxy handles — and wait briefly so the child
+        // writes its profile; otherwise kill immediately to keep teardown fast.
+        if std::env::var_os("LLVM_PROFILE_FILE").is_some() {
+            let _ = std::process::Command::new("kill")
+                .args(["-TERM", &self.child.id().to_string()])
+                .status();
+            for _ in 0..150 {
+                if let Ok(Some(_)) = self.child.try_wait() {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        }
         let _ = self.child.kill();
         let _ = self.child.wait();
     }
@@ -292,6 +307,12 @@ fn base_cmd(port: u16, upstream: &str) -> std::process::Command {
         .env("RUST_LOG", "nim_proxy=warn")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
+    // Under `cargo llvm-cov` the spawned server must write its own coverage
+    // profile, but env_clear() above dropped the profile path — forward it back
+    // when present (a no-op in normal test runs).
+    if let Ok(v) = std::env::var("LLVM_PROFILE_FILE") {
+        cmd.env("LLVM_PROFILE_FILE", v);
+    }
     cmd
 }
 


### PR DESCRIPTION
First of three public-readiness PRs (5a CI/security → 5b release/publish → 5c OSS docs). Process/packaging only — no proxy logic changes beyond a test-harness coverage fix.

## Code coverage — measured honestly, gated
The e2e suite exercises the request path by spawning the real binary as a subprocess. A naive `cargo llvm-cov` reports a misleading **~35%** because the test harness `env_clear()`s the child (dropping `LLVM_PROFILE_FILE`) and `SIGKILL`s it (no profile flush). This makes the fix permanent and low-impact:
- `base_cmd()` forwards `LLVM_PROFILE_FILE` when present (no-op in normal runs).
- `Drop` uses a graceful `SIGTERM` + brief wait **only under coverage** (detected via `LLVM_PROFILE_FILE`), so the child flushes; normal runs keep the fast `SIGKILL`.

Real coverage is **88.6% lines** (proxy.rs 89%, main.rs 92%, dispatch 96%, pool 92%, auth 83%, history 81%). New `coverage` CI job runs `cargo-llvm-cov` and **fails under 80%**, printing the table to the job summary.

## Security scanning — native, zero external accounts
- **cargo-deny** (`deny.toml`): advisories + license allow-list + bans + registry pinning. **Replaces** the standalone `cargo audit` job (deny covers advisories and more).
- **gitleaks**: full git-history secret sweep + every PR — the pre-public gate.
- **trivy**: container image scan, fails on fixable HIGH/CRITICAL.
- **Dependabot** (`.github/dependabot.yml`): weekly cargo / github-actions / docker updates, grouped to cut noise.

## Hardening
Top-level least-privilege `permissions: contents: read`. Kept the dashboard JS syntax check from PR #4.

## Verified locally
- `cargo deny check` → advisories/bans/licenses/sources all ok.
- `cargo llvm-cov --fail-under-lines 80` → 88.58%, exit 0.
- Normal `cargo test` still ~3s (29 unit + 21 e2e green) — the graceful path only triggers under coverage.
- Manual history secret sweep found no provider keys; `.env` was never committed (only `.env.example`). CI's gitleaks job is the authoritative gate.
- Workflow + Dependabot YAML validated.

## Notes
- Third-party actions are at major-version tags for now; Dependabot (github-actions) will surface SHA-pin updates. CodeQL is intentionally absent — it doesn't support Rust; clippy + cargo-deny + trivy + gitleaks are the right native stack here.
- Trivy SARIF upload to the Security tab is deferred until the repo is public (private repos need GitHub Advanced Security); the job gates via exit-code instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC)_