### PR TITLE
OSS 5c: community & health files (SECURITY, CONTRIBUTING, CoC, CHANGELOG, templates)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in this repo.
+# Requested for review on every pull request.
+* @miztertea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,87 @@
+name: Bug report
+description: Something in nim-proxy isn't working as documented
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug! Please do **not** report security
+        vulnerabilities here — see [SECURITY.md](../blob/main/SECURITY.md) for
+        private reporting.
+
+        Never paste real API keys, `ADMIN_PASSWORD`, or session cookies into
+        this form.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you observe, and what did you expect instead?
+      placeholder: The harness aborted with a 429 even though the proxy was running...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: A minimal sequence — a curl one-liner, config, or load-harness invocation is ideal.
+      placeholder: |
+        1. Run with `NIM_API_KEYS=... INSECURE_NO_AUTH=true cargo run --release`
+        2. curl http://localhost:8000/v1/chat/completions -d '...'
+        3. ...
+    validations:
+      required: true
+  - type: dropdown
+    id: auth-mode
+    attributes:
+      label: Auth mode
+      description: How was the proxy running?
+      options:
+        - Open mode (INSECURE_NO_AUTH=true)
+        - Secure mode (PROXY_API_KEYS + ADMIN_PASSWORD)
+        - Not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: run-method
+    attributes:
+      label: How are you running it?
+      options:
+        - Docker / docker compose
+        - Cargo (cargo run / built binary)
+        - Other (describe below)
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: Output of `nim-proxy --version`, the image tag, or the git commit.
+      placeholder: "0.4.0"
+    validations:
+      required: true
+  - type: input
+    id: client
+    attributes:
+      label: Client / harness
+      description: What is pointed at the proxy (OpenCode, Codex, n8n, curl, ...) and which model id?
+      placeholder: "OpenCode, moonshotai/kimi-k2-instruct"
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Proxy access/startup logs or client output. **Redact secrets.** This is rendered as code, no backticks needed.
+      render: shell
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this isn't a duplicate.
+          required: true
+        - label: I removed any API keys, passwords, or session cookies from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/miztertea/nim-proxy/security/advisories/new
+    about: Please report security issues privately, not as public issues. See SECURITY.md.
+  - name: Question or usage help
+    url: https://github.com/miztertea/nim-proxy/discussions
+    about: Ask setup, configuration, or "how do I..." questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Suggest an improvement to nim-proxy
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! nim-proxy is deliberately small and focused —
+        keeping an agent harness within NIM's per-key rate limit. Proposals that
+        sharpen that job (or make it safer/faster/easier to run) fit best.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point, not just the solution.
+      placeholder: When I run N harnesses against K keys, I can't tell whether...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like nim-proxy to do? A new env var, metric, dashboard view, endpoint behavior?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed, or existing workarounds.
+    validations:
+      required: false
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Fit
+      options:
+        - label: This keeps the proxy focused on its rate-limit-aware job (not a general-purpose gateway).
+          required: false
+        - label: I searched existing issues and this isn't already proposed.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!--
+Thanks for contributing to nim-proxy! Please read CONTRIBUTING.md first.
+Keep the scope tight — nim-proxy is deliberately small.
+-->
+
+## What & why
+
+<!-- What does this change, and what problem does it solve? Link any issue: Fixes #123 -->
+
+## How it was tested
+
+<!-- Commands you ran and what you observed. -->
+
+## Checklist
+
+- [ ] **What/why** is explained above (and an issue is linked if one exists).
+- [ ] **Tests added or updated** for the new behavior (unit and/or e2e).
+- [ ] `cargo fmt --check` is clean.
+- [ ] `cargo clippy --all-targets -- -D warnings` is clean (zero warnings).
+- [ ] `cargo test` passes locally.
+- [ ] **Docs updated in lockstep** — README and/or `examples/` reflect the change.
+- [ ] **Knowledge base updated in the same PR** — affected `knowledge/` pages,
+      a new `decisions/` page + `index.md` row for new decisions, and a dated
+      `knowledge/log.md` entry (see AGENTS.md).
+- [ ] **Security considered** — if this touches auth, label sanitizing, or the
+      dashboard `innerHTML`, the fail-closed and escaping invariants are
+      preserved (see SECURITY.md and the auth/input-sanitizing decision pages).
+- [ ] **Rate-limiting proven** — if this touches pacing, the key pool, the
+      dispatcher, or affinity, the load harness shows **zero upstream rate
+      violations** (`scripts/mock_nim.py --enforce` + `scripts/loadtest.py`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,139 @@
+# Changelog
+
+All notable changes to nim-proxy are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+_Nothing yet._
+
+## [0.4.0] - 2026-07-02
+
+The proxy becomes a **benchmarking and agent-observability tool**: because it
+sits in the request path for every harness and model, it can now report *how*
+each agent behaves and *how well* each model responds — all from counts and
+sizes, never message content.
+
+### Added
+
+- **Request-shape & response-quality metrics**, captured from the request path
+  that was already deserialized and scanned: conversation depth, tools offered,
+  sampling temperature, `max_tokens`, stream-vs-buffered and JSON-mode mix
+  (labeled by client/harness), plus finish-reason/truncation, tool calls,
+  reasoning ("thinking") tokens, and mean TPOT (labeled by model). Everything is
+  bounded-cardinality with server-clamped enums — counts and sizes only, never
+  content. See `knowledge/decisions/request-shape-metrics.md`.
+- **Six persona-aligned dashboard views** (Overview, Models, Compare, Harnesses,
+  Proxy, Keys), rebuilt from the previous three tabs, each ordered
+  at-a-glance → trends → detail, in light and dark mode. Adds a head-to-head
+  model scorecard, per-harness fingerprints, and a hash-to-hue color fallback
+  past the six categorical slots.
+- Generation-speed (tok/s) median/p95 trend, a ranked non-success-outcome
+  breakdown, and threshold-colored capacity/success-rate gauges.
+- Example [`examples/opencode.json`](examples/opencode.json) config tuned for
+  GLM-5.2 (context, compaction, sampling), with rationale in
+  `examples/README.md`.
+
+### Changed
+
+- Test coverage extended to the buffered `relay()` quality path, an
+  unknown-`finish_reason` → `other` clamp, JSON mode, and non-`auto`
+  `tool_choice` — now **29 unit + 21 e2e** tests.
+- Load harness gained tool/JSON/sampling variety and a corrected boot command
+  (`INSECURE_NO_AUTH`); re-run clean at 240 requests, 0 failures, 0 upstream
+  rate violations, balanced across all keys.
+
+### Security
+
+- Pre-merge hardening pass: a dedicated dashboard-XSS audit plus a full security
+  review of the branch found **zero** vulnerabilities — every new `innerHTML`
+  value is escaped, every new label is a bounded enum/histogram, and no route
+  left the admin gate.
+
+## [0.3.0] - 2026-07-02
+
+Security-hardening release. A review of the merged proxy found a stored-XSS
+chain, unbounded metric-label cardinality, log injection, and an open-by-default
+posture. All fixed.
+
+### Added
+
+- **Fail-closed auth.** The proxy refuses to start on a network-reachable port
+  without auth. Secure mode requires `PROXY_API_KEYS` (gates `/v1/*`, any key
+  works, constant-time compare) and `ADMIN_PASSWORD` (gates the dashboard,
+  `/metrics`, and `/api/history` via an HMAC-signed, HttpOnly, SameSite=Strict
+  session cookie; Bearer/Basic for scrapers). Open mode is an explicit
+  `INSECURE_NO_AUTH=true` opt-in. See
+  `knowledge/decisions/auth-posture-and-dashboard-password.md`.
+- Failed-login throttle, a rejected-API-key delay, and a `MAX_INFLIGHT`
+  flood-shedding cap.
+- `cargo audit` in CI.
+
+### Security
+
+- **Input sanitizing.** Client-controlled `model`/`path` labels are sanitized to
+  a conservative charset, length-capped, and cardinality-bounded at ingest —
+  killing the exposition/log-injection and cardinality-blowup vectors. The
+  dashboard `esc()`-escapes every dynamic `innerHTML` sink, and all responses
+  carry a strict `Content-Security-Policy` plus anti-framing/anti-sniffing
+  headers. See `knowledge/decisions/input-sanitizing-and-xss.md`.
+- Compose now publishes `127.0.0.1:8000:8000` (loopback) by default, so a bare
+  `docker compose up` can't accidentally expose an open instance.
+- Verified with a real-browser XSS check (payload rendered inert), a secure-mode
+  load test (300/300, 0 rate violations), and a clean `cargo audit`.
+
+## [0.2.0] - 2026-07-02
+
+Observability and hardening enrichments on top of the core proxy.
+
+### Added
+
+- **Prometheus `/metrics`** exposition and optional client access keys
+  (`PROXY_API_KEYS`) for per-client attribution.
+- **Built-in dashboard** — a single embedded HTML file (no Grafana, no config) —
+  plus an ASCII boot banner, structured startup detail, one-line-per-request
+  access logs (TTY-detected ANSI color), and a self-probe healthcheck
+  (`nim-proxy --health`) that works `FROM scratch`.
+- **Metrics history**: a ~4 KB snapshot every 5 minutes, retained `HISTORY_DAYS`
+  days, powering time-range reports (1h/6h/24h/7d/30d + custom) that survive
+  restart.
+- Model cards with id-namespace enrichment (the `/v1/models` schema research
+  killed the idea of API-sourced descriptions).
+
+### Changed
+
+- Proxy hardened and given a full test suite (unit + e2e against a scripted mock
+  NIM) and a load harness (`scripts/mock_nim.py --enforce` + `scripts/loadtest.py`).
+- The `knowledge/` Open Knowledge Format bundle was compiled: design decisions,
+  validated NIM research, architecture notes, and runbooks.
+
+### Fixed
+
+- Docker build on the musl-host Alpine builder: pass an explicit `--target` so
+  global `crt-static` RUSTFLAGS skip proc-macro dylibs.
+
+## [0.1.0] - 2026-07-01
+
+Initial rate-limit-aware proxy.
+
+### Added
+
+- OpenAI-compatible pass-through to NVIDIA NIM with **per-key sliding-window
+  rate limiting** (40 requests per rolling 60 s, matching NIM's limiter) and
+  multi-key load balancing.
+- **Global FIFO dispatcher** — one queue for all clients, slots granted strictly
+  in arrival order, abandoned-waiter slots returned — for fair multi-client
+  allocation.
+- **Conversation affinity with least-loaded spillover**: each conversation pins
+  to one key to keep the server-side prefix cache warm, spilling to the
+  least-loaded ready lane when its lane is full.
+- **Distroless image**: a static musl binary shipped `FROM scratch` (~3.5 MB,
+  TLS roots compiled in), running non-root with hardened compose defaults.
+
+[Unreleased]: https://github.com/miztertea/nim-proxy/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/miztertea/nim-proxy/releases/tag/v0.4.0
+[0.3.0]: https://github.com/miztertea/nim-proxy/releases/tag/v0.3.0
+[0.2.0]: https://github.com/miztertea/nim-proxy/releases/tag/v0.2.0
+[0.1.0]: https://github.com/miztertea/nim-proxy/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+`<CONDUCT-CONTACT-EMAIL — maintainer to fill in>`.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,127 @@
+# Contributing to nim-proxy
+
+Thanks for your interest! nim-proxy is a small, focused Rust proxy with exactly
+one job: **keep an agent harness within NVIDIA NIM's per-key rate limit so it
+never sees a 429.** Contributions that make it better at that job — or safer,
+faster, or easier to run — are very welcome.
+
+By participating you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Before you start
+
+- **Read the design first.** The `knowledge/` directory is the project's
+  compiled memory — every non-obvious decision has a page explaining *why*.
+  Start at [`knowledge/index.md`](knowledge/index.md). The reasoning that
+  constrains your change is very likely already recorded there (rate-limit
+  window math, dispatcher fairness, auth posture, sanitizing, etc.).
+- **Read [`AGENTS.md`](AGENTS.md).** It is the source of truth for build/test/lint
+  commands and for the knowledge-base maintenance rules, and it maps the source
+  layout (`src/main.rs`, `proxy.rs`, `pool.rs`, `dispatch.rs`, `history.rs`,
+  `auth.rs`, `dashboard.html`).
+- For anything beyond a small fix, **open an issue first** so we can agree on the
+  approach before you write code.
+
+## Building and running
+
+You need a stable Rust toolchain (`rustup`, edition 2021) and Python 3 for the
+load harness.
+
+```sh
+# Build and run locally, open mode (loopback only — see Security below):
+NIM_API_KEYS=nvapi-xxx,nvapi-yyy INSECURE_NO_AUTH=true cargo run --release
+
+# Or via Docker, exactly as a user would:
+cp .env.example .env      # paste keys, pick an auth mode
+docker compose up -d --build
+```
+
+The dashboard is served at `http://localhost:8000/` and the OpenAI-compatible
+API at `http://localhost:8000/v1`.
+
+## Testing, formatting, linting
+
+All three must be clean before you open a PR — CI enforces every one of them:
+
+```sh
+cargo test                                   # 29 unit + 21 end-to-end tests
+cargo fmt                                     # (CI runs `cargo fmt --check`)
+cargo clippy --all-targets -- -D warnings    # zero warnings — warnings are errors
+```
+
+`cargo test` launches the **real binary** against a scriptable mock NIM (see
+`tests/support/mod.rs`); the e2e suite covers auth, 429 ride-out with key
+failover, Retry-After timing, pacing enforcement, conversation affinity, usage
+injection, stalled-stream recovery, label sanitizing, security headers, metrics
+accuracy, history persistence across restart, and graceful shutdown.
+
+### The fail-closed test posture
+
+nim-proxy **fails closed on purpose** — it refuses to start on a network port
+without auth. Tests assert this posture directly (boot-refusal cases, session
+flow, Bearer/Basic scraper auth, label sanitizing, security headers). If your
+change touches `src/auth.rs`, the API-key gate or label sanitizing in
+`src/proxy.rs`, or the dashboard's `innerHTML`, you **must** keep those
+invariants and the tests that guard them. Read the
+[auth-posture](knowledge/decisions/auth-posture-and-dashboard-password.md) and
+[input-sanitizing](knowledge/decisions/input-sanitizing-and-xss.md) decision
+pages before editing.
+
+### The load harness (required for anything touching rate-limiting)
+
+The proxy's core promise is *zero upstream rate violations*. If your change
+touches pacing, the key pool, the dispatcher, or affinity, prove it against a
+mock that **strictly enforces** NIM's per-key window and counts violations:
+
+```sh
+python3 scripts/mock_nim.py --enforce --rpm 40 --port 9999 &
+NIM_API_KEYS=k1,k2,k3 NIM_BASE_URL=http://127.0.0.1:9999 cargo run --release &
+python3 scripts/loadtest.py --clients 100 --requests 3
+```
+
+It exits non-zero on any client-visible failure **or a single upstream rate
+violation**. Zero violations is a hard requirement, not a target — this harness
+is what caught the boundary-jitter bug that motivated the 1 s window margin.
+
+### The dashboard
+
+The dashboard is **one embedded file**, `src/dashboard.html` — no build step and
+no external assets (optional CDN logos have an offline fallback). Edit the HTML
+directly. CI checks the embedded `<script>` block with `node --check`; every
+dynamic value written into `innerHTML` must go through the `esc()` escaper.
+
+## Keep the knowledge base in lockstep
+
+This is a hard rule, not a nicety. When a change alters behavior described in
+`knowledge/`, **update the affected pages in the same PR** — code and knowledge
+must not diverge (`AGENTS.md` §"The knowledge base"):
+
+1. **Ingest** — update any page whose described behavior your change alters.
+2. **New decisions** get a new page under `knowledge/decisions/` *and* a row in
+   [`knowledge/index.md`](knowledge/index.md), following the ADR shape
+   (Context → Options → Choice → Consequences).
+3. **Log** — append a dated entry to
+   [`knowledge/log.md`](knowledge/log.md)
+   (`## [YYYY-MM-DD] ingest|decision|lint — summary`).
+
+The code is the source of truth for *what*; the knowledge base for *why*. If you
+spot a contradiction between the two, fix the page and note it in your PR.
+
+## Pull request expectations
+
+Use the [PR template](.github/PULL_REQUEST_TEMPLATE.md). A PR is ready when:
+
+- **Tests and docs move in lockstep** — new behavior ships with tests, and the
+  README / `knowledge/` are updated in the same PR.
+- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and
+  `cargo test` are all green.
+- Rate-limit-adjacent changes show **zero upstream rate violations** from the
+  load harness.
+- Security-sensitive changes (auth, sanitizing, dashboard `innerHTML`) preserve
+  the fail-closed and escaping invariants — see [SECURITY.md](SECURITY.md).
+- Commits are focused and messages explain the *why*.
+
+Keep the scope tight — nim-proxy is deliberately small. A change that makes it do
+one thing well is worth more than one that makes it do many things.
+
+Thanks for contributing!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # nim-proxy
 
+[![CI](https://github.com/miztertea/nim-proxy/actions/workflows/ci.yml/badge.svg)](https://github.com/miztertea/nim-proxy/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Container: GHCR](https://img.shields.io/badge/container-ghcr.io-2496ED?logo=docker&logoColor=white)](https://github.com/miztertea/nim-proxy/pkgs/container/nim-proxy)
+
 A tiny, rate-limit-aware OpenAI-compatible proxy for the [NVIDIA NIM API](https://build.nvidia.com), built for agent harnesses like [OpenCode](https://opencode.ai), Codex, n8n, and anything else that speaks the OpenAI API.
 
 NIM's free tier has no credits and no token caps — just a ~40 requests-per-minute limit per API key. When an agent harness hits that limit, the upstream returns a 429 and most harnesses simply abort the task. This proxy fixes that, and it has exactly one job: **obey the NIM speed limit so your harness never sees it.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,93 @@
+# Security Policy
+
+nim-proxy sits in the request path for every harness and every API key it
+fronts, and it can be exposed to the public internet (VPS, ECS, Railway, Fly).
+We take its security posture seriously and welcome private reports.
+
+## Supported versions
+
+Security fixes land on the latest `0.4.x` release. Older minors are not
+patched — upgrade to the newest `0.4.x` tag.
+
+| Version | Supported          |
+|---------|--------------------|
+| 0.4.x   | :white_check_mark: |
+| < 0.4   | :x:                |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+1. Preferred: open a private report through GitHub's
+   [Security Advisories](https://github.com/miztertea/nim-proxy/security/advisories/new)
+   ("Report a vulnerability"). This keeps the details confidential until a fix
+   ships.
+2. Alternatively, email the maintainer at
+   `<SECURITY-CONTACT-EMAIL — maintainer to fill in>`. Use a subject that makes
+   the nature clear (e.g. "nim-proxy security report").
+
+Please include: affected version/commit, run mode (secure vs. `INSECURE_NO_AUTH`),
+a description of the impact, and a minimal reproduction (a request body, a
+config, or a curl one-liner is ideal). If you have a suggested fix, include it —
+but a clear report is enough.
+
+### Response expectations
+
+This is a small, volunteer-maintained project. We aim to:
+
+- **Acknowledge** your report within 3 business days.
+- **Triage** and confirm (or explain why it's out of scope) within 7 days.
+- **Fix** confirmed vulnerabilities in a `0.4.x` patch release and credit you in
+  the advisory (unless you prefer to stay anonymous).
+
+Please give us a reasonable window to ship a fix before any public disclosure.
+
+## Scope and current posture
+
+nim-proxy has already been through a dedicated security-hardening pass. The
+reasoning behind the current defenses is documented in the knowledge base:
+
+- **Auth / fail-closed posture** —
+  [`knowledge/decisions/auth-posture-and-dashboard-password.md`](knowledge/decisions/auth-posture-and-dashboard-password.md).
+  The proxy **refuses to start on a network-reachable port without auth**.
+  Secure mode requires both `PROXY_API_KEYS` (gates `/v1/*`) and `ADMIN_PASSWORD`
+  (gates the dashboard, `/metrics`, `/api/history` via an HMAC-signed, HttpOnly,
+  SameSite=Strict session cookie). Open mode (`INSECURE_NO_AUTH=true`) is an
+  explicit, loudly-warned opt-in for loopback/firewalled use only. Secret
+  comparison is constant-time; there is a failed-login throttle and a
+  rejected-key delay.
+- **Input sanitizing / XSS / injection** —
+  [`knowledge/decisions/input-sanitizing-and-xss.md`](knowledge/decisions/input-sanitizing-and-xss.md).
+  Client-controlled fields (`model`, `path`) are sanitized to a conservative
+  charset, length-capped, and cardinality-bounded at ingest, so they can't
+  inject into the Prometheus exposition format, access logs, or persisted
+  history. The embedded dashboard HTML-escapes every dynamic `innerHTML` sink,
+  and all responses carry a strict `Content-Security-Policy` plus
+  anti-framing/anti-sniffing headers.
+
+**In scope** (please report):
+
+- Authentication or authorization bypass (reaching `/v1/*`, the dashboard,
+  `/metrics`, or `/api/history` without valid credentials in secure mode).
+- Injection reaching the metrics exposition, logs, persisted history, or the
+  dashboard (XSS), including via request bodies or the `model`/`path` fields.
+- Ways to make the proxy **exceed a key's upstream rate limit** (its core
+  invariant) or otherwise misbehave against the upstream.
+- Secret leakage (API keys, `ADMIN_PASSWORD`, session cookie) via logs,
+  metrics, error responses, or history snapshots.
+- Denial of service that bypasses the in-flight cap (`MAX_INFLIGHT`) or the
+  failed-login throttle.
+
+**Out of scope:**
+
+- Running in `INSECURE_NO_AUTH=true` mode on a network-reachable interface — this
+  is a documented, opt-in "no auth" configuration, not a vulnerability.
+- Missing TLS. nim-proxy has **no built-in TLS by design**; terminate TLS at a
+  reverse proxy or platform edge for any exposed deployment (see the README's
+  Security & deployment section).
+- Rate-limit abuse of your own NVIDIA keys, or NVIDIA-side terms-of-service
+  questions — those are between you and NVIDIA.
+- Vulnerabilities in third-party dependencies already flagged by `cargo audit`
+  (CI runs it); report those upstream, though a note is still welcome.
+
+Thank you for helping keep nim-proxy and its users safe.


### PR DESCRIPTION
Third of the public-readiness PRs (5a CI/security · 5b release/publish · **5c OSS docs**). Docs and repo metadata only — no code, no workflows touched (README gets a badge row only).

Adds the standard community/health set GitHub expects of a public project, all written specifically for nim-proxy (not boilerplate):

- **SECURITY.md** — supported versions (0.4.x), private disclosure via GitHub Security Advisories, explicit in/out-of-scope (e.g. `INSECURE_NO_AUTH` and no-TLS-at-edge are out of scope by design), response expectations. Ties to the existing auth-posture and input-sanitizing decision pages. *(Contact line is a fillable placeholder.)*
- **CONTRIBUTING.md** — the real build/test/lint commands from `AGENTS.md` (`cargo test`, `fmt`, `clippy --all-targets -D warnings`, the `mock_nim.py --enforce` + `loadtest.py` harness), the fail-closed test posture, and the knowledge-base lockstep rule.
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1. *(Contact placeholder.)*
- **CHANGELOG.md** — Keep a Changelog, backfilled from `knowledge/log.md` + git history: 0.4.0 → 0.1.0.
- **Issue templates** (bug/feature forms + config), **PULL_REQUEST_TEMPLATE.md**, **CODEOWNERS**.
- **README** — a badge row (CI · MIT · GHCR container) under the title; rest untouched.

## Maintainer to-do before going public
Fill the two contact placeholders in `SECURITY.md` and `CODE_OF_CONDUCT.md`. The GHCR badge link resolves once 5b publishes the first image.

## Verified
Issue-template YAML parses; relative markdown links resolve; only the 10 intended files + README badge line changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC)_