### PR TITLE
Release 5b: tag-driven multi-arch GHCR publish (signed, SBOM, binaries)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,122 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+# Least privilege by default; each job opts into exactly what it needs.
+permissions:
+  contents: read
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  image:
+    name: image → GHCR (multi-arch, signed)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push to GHCR
+      id-token: write # keyless cosign + provenance via OIDC
+      attestations: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+      - id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+          provenance: true
+          sbom: true
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Sign image (keyless)
+        run: cosign sign --yes "${IMAGE}@${{ steps.build.outputs.digest }}"
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+      # Extract the exact static binaries we just shipped (no separate cross
+      # toolchain): create — not run — a container per arch and copy /nim-proxy.
+      - name: Extract release binaries
+        run: |
+          set -euo pipefail
+          for arch in amd64 arm64; do
+            cid=$(docker create --platform "linux/$arch" "${IMAGE}@${{ steps.build.outputs.digest }}")
+            docker cp "$cid:/nim-proxy" "nim-proxy-$arch"
+            docker rm "$cid" >/dev/null
+            tar -czf "nim-proxy-${{ steps.meta.outputs.version }}-linux-$arch.tar.gz" "nim-proxy-$arch"
+            rm "nim-proxy-$arch"
+          done
+      - name: Generate SBOM (SPDX)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: nim-proxy-sbom.spdx.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-assets
+          path: |
+            nim-proxy-*.tar.gz
+            nim-proxy-sbom.spdx.json
+          if-no-files-found: error
+
+  release:
+    name: GitHub Release
+    needs: image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the release
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-assets
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            nim-proxy-*.tar.gz
+            nim-proxy-sbom.spdx.json
+          body: |
+            Container image (multi-arch, signed, with SBOM + provenance):
+
+            ```sh
+            docker pull ghcr.io/${{ github.repository }}:${{ needs.image.outputs.version }}
+            ```
+
+            Verify the signature:
+
+            ```sh
+            cosign verify ghcr.io/${{ github.repository }}:${{ needs.image.outputs.version }} \
+              --certificate-identity-regexp 'https://github.com/${{ github.repository }}/.github/workflows/release.yml@.*' \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com
+            ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,45 @@
 # Build a fully static musl binary, ship it on scratch: no distro, no shell,
 # no libc, no package manager. TLS roots are compiled into the binary
 # (rustls + webpki-roots), so not even CA certificates are needed.
+#
+# Multi-arch: buildx sets TARGETARCH per requested platform and runs this stage
+# emulated on that arch, so we build for the matching native musl target.
 FROM rust:1-alpine AS build
 RUN apk add --no-cache musl-dev gcc
 ENV RUSTFLAGS="-C target-feature=+crt-static"
-# The explicit --target below looks redundant (alpine's host IS musl) but is
-# load-bearing: with a --target set, cargo stops applying RUSTFLAGS to host
-# units like proc-macros, which must stay dylibs and can't be crt-static.
-ARG TARGET=x86_64-unknown-linux-musl
+# Map Docker's arch to the Rust musl target. The explicit --target (below) looks
+# redundant on alpine (host IS musl) but is load-bearing: with a --target set,
+# cargo stops applying crt-static RUSTFLAGS to host units like proc-macros,
+# which must stay dylibs. Empty TARGETARCH (plain `docker build`) defaults amd64.
+ARG TARGETARCH
+RUN case "${TARGETARCH:-amd64}" in \
+      amd64) t=x86_64-unknown-linux-musl ;; \
+      arm64) t=aarch64-unknown-linux-musl ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    rustup target add "$t"; \
+    echo "$t" > /tmp/target
 WORKDIR /app
 
 # Cache the dependency build separately from source changes.
 COPY Cargo.toml Cargo.lock ./
 RUN mkdir src && echo "fn main() {}" > src/main.rs \
-    && cargo build --release --target $TARGET && rm -rf src
+    && cargo build --release --target "$(cat /tmp/target)" && rm -rf src
 
 COPY src ./src
-RUN touch src/main.rs && cargo build --release --target $TARGET \
-    && cp target/$TARGET/release/nim-proxy /app/nim-proxy && mkdir /app/data
+RUN touch src/main.rs && cargo build --release --target "$(cat /tmp/target)" \
+    && cp "target/$(cat /tmp/target)/release/nim-proxy" /app/nim-proxy && mkdir /app/data
 
 FROM scratch
+# OCI image metadata so the image is self-describing. VERSION comes from the
+# release workflow (the git tag); "dev" for local builds.
+ARG VERSION=dev
+LABEL org.opencontainers.image.title="nim-proxy" \
+      org.opencontainers.image.description="Rate-limit-aware OpenAI-compatible proxy for NVIDIA NIM with multi-key load balancing" \
+      org.opencontainers.image.source="https://github.com/miztertea/nim-proxy" \
+      org.opencontainers.image.url="https://github.com/miztertea/nim-proxy" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${VERSION}"
 COPY --from=build /app/nim-proxy /nim-proxy
 # Empty dir owned by the runtime user: a named volume mounted at /data
 # inherits this ownership on first use, so history can persist.


### PR DESCRIPTION
Second of the public-readiness PRs (5a CI/security · **5b release/publish** · 5c OSS docs). Adds a release workflow and makes the Dockerfile multi-arch — **no `src/` changes**.

## What it does (on a `v*` tag)
- **Multi-arch image → GHCR** (`ghcr.io/miztertea/nim-proxy:<version>` + `:latest`) for `linux/amd64` + `linux/arm64` via buildx. **Zero stored secrets** — GHCR auth uses the built-in `GITHUB_TOKEN`.
- **Keyless cosign signing** + **SLSA build provenance** on the pushed digest (GitHub OIDC — no keys), plus buildx SBOM/provenance attestations.
- **Static release binaries** for both arches, extracted straight from the built images (no separate cross toolchain: `docker create` → `docker cp /nim-proxy` per arch → tarball).
- **SPDX SBOM** generated and attached; **GitHub Release** created with auto notes, binaries, SBOM, and a `cosign verify` snippet.

## Dockerfile
Now **arch-aware**: `TARGETARCH` selects the matching musl target (`x86_64` / `aarch64`), so the same scratch/static-binary recipe builds on both. Plain `docker build` still works (defaults amd64). Added OCI image labels (source, version, licenses, description).

## Verification
- Release YAML validated.
- The amd64 Dockerfile change is exercised by the existing `docker build` + health-smoke CI job on this PR.
- The multi-arch/publish path only runs on a tag — **please dry-run on a pre-release tag** (e.g. `v0.4.1-rc1`) once merged: it'll push to a GHCR pre-release tag you can `cosign verify` and `docker buildx imagetools inspect` for two platforms, then delete.

## Notes
- No secrets required for the default path. Docker Hub mirroring can be added later in ~10 lines if you ever want it (that path would need `DOCKERHUB_*` secrets).
- One-time after first publish: mark the GHCR package public in repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC)_