### PR TITLE
6b: performance — opt-level 3, drop deep clone, static SSE frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Regression tests for all of the above; coverage raised to ~90%.
 
+### Performance
+
+- Build with `opt-level = 3` (was `"z"`): the release profile optimized for size,
+  throttling the JSON-parse and SSE-scan hot paths. Binary grows ~3.5→4.6 MB.
+- Drop a deep clone of the whole request body on the streaming injection path
+  (move it instead); use `Bytes::from_static` for the SSE control frames.
+- Routine `cargo update` (`rustc-hash` patch).
+
 ## [0.4.0] - 2026-07-02
 
 The proxy becomes a **benchmarking and agent-observability tool**: because it

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustls"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,8 @@ futures-util = "0.3"
 [profile.release]
 lto = true
 strip = true
-opt-level = "z"
+# Optimize for speed (the proxy's job): re-enables inlining/vectorization on the
+# JSON-parse and SSE-scan hot paths. lto + strip + codegen-units=1 keep the size
+# growth modest against opt-level="z".
+opt-level = 3
 codegen-units = 1

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -448,7 +448,7 @@ pub async fn handle(
         .map(|pq| pq.as_str().to_owned())
         .unwrap_or_else(|| uri.path().to_owned());
 
-    let parsed = serde_json::from_slice::<serde_json::Value>(&body).ok();
+    let mut parsed = serde_json::from_slice::<serde_json::Value>(&body).ok();
     let raw_model = parsed
         .as_ref()
         .and_then(|v| v.get("model").and_then(|m| m.as_str()))
@@ -490,7 +490,10 @@ pub async fn handle(
             .is_some_and(|v| v.is_object() && v.get("stream_options").is_none())
             && !state.no_inject.lock().unwrap().contains(&ctx.model);
         if injectable {
-            let mut v = parsed.clone().unwrap();
+            // `parsed` is unused after this point, so move it rather than deep-
+            // cloning the whole request body (the full conversation) to inject
+            // one field.
+            let mut v = parsed.take().unwrap();
             v["stream_options"] = serde_json::json!({ "include_usage": true });
             fallback = Some(std::mem::replace(
                 &mut body,
@@ -595,7 +598,8 @@ async fn streaming(
         gauge!("nimproxy_active_requests").increment(1.0);
         let send = |b: &'static str| {
             let tx = tx.clone();
-            async move { tx.send(Ok(Bytes::from(b))).await.is_ok() }
+            // Static control frames — no per-send alloc/copy.
+            async move { tx.send(Ok(Bytes::from_static(b.as_bytes()))).await.is_ok() }
         };
         if !send(": connected\n\n").await {
             record_request(&ctx, "disconnect");
@@ -605,7 +609,8 @@ async fn streaming(
         loop {
             // Queue for a slot, heartbeating so the harness doesn't hang up.
             let slot = reserve_slot(&state, deadline, prefer, || {
-                tx.try_send(Ok(Bytes::from(": heartbeat\n\n"))).is_ok()
+                tx.try_send(Ok(Bytes::from_static(b": heartbeat\n\n")))
+                    .is_ok()
             })
             .await;
             let Some((lane, key)) = slot else {


### PR DESCRIPTION
Second optimization-pass PR (6a fixes ✅ → **6b perf** → 6c rationalization). Only the changes that actually move a benchmark — the audit rejected the rest (metric-label clone caching, SseScan per-line alloc) as unmeasurable against the ≥100ms upstream call.

## Changes
- **`opt-level = "z"` → `3`.** The release profile was optimizing for *size*, suppressing inlining/vectorization on the CPU-bound `serde_json` parse and `SseScan::feed` loop — contrary to "screaming fast." `lto` / `strip` / `codegen-units = 1` retained. **Binary: 3.47 MB → 4.61 MB** (+33%, measured) — a small absolute cost for a scratch image, the deliberate size↔speed trade.
- **Drop the deep `parsed.clone()`** on the streaming injection path — move the parsed body into the `stream_options` injection instead (it's unused afterward). Avoids deep-copying the whole conversation JSON per injected streaming request.
- **`Bytes::from_static`** for the static SSE control frames (`: connected` / `: heartbeat` / `: retrying`) — no per-send alloc.
- **`cargo update`** (`rustc-hash 2.1.2 → 2.1.3`, transitive patch).

## Verification
- fmt / clippy clean; **30 unit + 26 e2e green**.
- Rate-limit logic is untouched (the changes are byte-identical on the wire), so the pacing/saturation/retry e2e tests cover correctness. *(The standalone load harness couldn't be re-run in this environment — it relies on `sleep` for the mock's token pacing, which the sandbox now blocks — but the rate path is unchanged from the last 0-violation run.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC)_