### PR TITLE
chore(actions): adopt the Node 24 action majors (supersedes Dependabot #21–#25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history for the secret sweep
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -34,7 +34,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE }}
           tags: |
@@ -42,7 +42,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
       - id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -96,7 +96,7 @@ jobs:
     permissions:
       contents: write # create the release
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: release-assets
       - name: Publish release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 
-- Bump `metrics-exporter-prometheus` 0.17 → 0.18 and refresh CI action versions.
+- Bump `metrics-exporter-prometheus` 0.17 → 0.18 and refresh CI/release action
+  versions, including the Node 24 runtime wave (gitleaks-action v3, the docker/*
+  build actions, download-artifact v8).
 - Hold the auth crypto/RNG stack (`hmac` 0.12, `sha2` 0.10, `getrandom` 0.2) on
   the proven-stable line — the proposed 0.13/0.11/0.3 majors are breaking with no
   security fix; Dependabot is configured to only take patches for these.


### PR DESCRIPTION
Consolidates the second Dependabot wave (opened minutes after #20 merged) into one reviewed change. All five are GitHub Actions **major** bumps from GitHub's Node 20 → Node 24 runner migration (Node 20 is deprecated June–Sept 2026); none change inputs, outputs, or behavior:

| Dependabot PR | Action | Bump | Workflow |
|---|---|---|---|
| #22 | `gitleaks/gitleaks-action` | v2 → v3 | `ci.yml` |
| #21 | `docker/setup-buildx-action` | v3 → v4 | `release.yml` |
| #24 | `docker/metadata-action` | v5 → v6 | `release.yml` |
| #25 | `docker/build-push-action` | v6 → v7 | `release.yml` |
| #23 | `actions/download-artifact` | v4 → v8 | `release.yml` |

Notes:
- The **gitleaks v3** bump is exercised directly by this PR's CI (the gitleaks job runs on the new major).
- The four **release.yml** bumps only run on tag pushes, so they'll be exercised by the first release dry-run — already on the go-public checklist. `download-artifact` v8 pairs with the `upload-artifact` v7 adopted in #20 (both on the v2 artifact backend).
- CHANGELOG's Unreleased → Dependencies entry updated to cover the wave.

Supersedes and closes Dependabot PRs #21, #22, #23, #24, #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC)_