### PR TITLE
Prepare v0.5.0: first public release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,16 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
     steps:
       - uses: actions/checkout@v7
+      # The binary reports CARGO_PKG_VERSION; the image is labeled with the git
+      # tag. Refuse to ship an image where the two would disagree.
+      - name: Tag must match Cargo.toml version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          grep -Fxq "version = \"$tag\"" Cargo.toml || {
+            echo "::error::tag v$tag does not match Cargo.toml version:"
+            grep '^version = ' Cargo.toml
+            exit 1
+          }
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-03
+
+First public release: the repository is now public, and this tag publishes the
+first signed multi-arch container image to GHCR with SBOM and build provenance.
+
 ### Fixed
 
 - **Unauthenticated panic in the login handler.** A percent-escape followed by a
@@ -168,7 +173,8 @@ Initial rate-limit-aware proxy.
 - **Distroless image**: a static musl binary shipped `FROM scratch` (~3.5 MB,
   TLS roots compiled in), running non-root with hardened compose defaults.
 
-[Unreleased]: https://github.com/miztertea/nim-proxy/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/miztertea/nim-proxy/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/miztertea/nim-proxy/releases/tag/v0.5.0
 [0.4.0]: https://github.com/miztertea/nim-proxy/releases/tag/v0.4.0
 [0.3.0]: https://github.com/miztertea/nim-proxy/releases/tag/v0.3.0
 [0.2.0]: https://github.com/miztertea/nim-proxy/releases/tag/v0.2.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,10 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-`<CONDUCT-CONTACT-EMAIL — maintainer to fill in>`.
+reported to the community leaders responsible for enforcement by contacting the
+maintainer, [@miztertea](https://github.com/miztertea), directly on GitHub. For
+reports that should stay confidential, use a
+[private security advisory](https://github.com/miztertea/nim-proxy/security/advisories/new).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "nim-proxy"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "nim-proxy"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Rate-limit-aware OpenAI-compatible proxy for NVIDIA NIM with multi-key load balancing"
 license = "MIT"
+repository = "https://github.com/miztertea/nim-proxy"
+readme = "README.md"
 
 [dependencies]
 axum = "0.8"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # nim-proxy
 
 [![CI](https://github.com/miztertea/nim-proxy/actions/workflows/ci.yml/badge.svg)](https://github.com/miztertea/nim-proxy/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/miztertea/nim-proxy)](https://github.com/miztertea/nim-proxy/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Container: GHCR](https://img.shields.io/badge/container-ghcr.io-2496ED?logo=docker&logoColor=white)](https://github.com/miztertea/nim-proxy/pkgs/container/nim-proxy)
 
@@ -27,7 +28,15 @@ This tool is **not** designed to circumvent NVIDIA's terms of service. It maximi
 
 1. Get one or more API keys at [build.nvidia.com](https://build.nvidia.com) (free, `nvapi-...`; each account needs a unique email and phone number).
 
-2. Configure and run:
+2. Run the published image (multi-arch, signed, ~5 MB):
+
+```sh
+docker run -d --name nim-proxy -p 127.0.0.1:8000:8000 \
+  -e NIM_API_KEYS=nvapi-xxx,nvapi-yyy -e INSECURE_NO_AUTH=true \
+  ghcr.io/miztertea/nim-proxy:latest
+```
+
+Or build from source with the hardened compose defaults:
 
 ```sh
 cp .env.example .env        # paste keys into NIM_API_KEYS, then pick an auth mode (below)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,25 +6,23 @@ We take its security posture seriously and welcome private reports.
 
 ## Supported versions
 
-Security fixes land on the latest `0.4.x` release. Older minors are not
-patched — upgrade to the newest `0.4.x` tag.
+Security fixes land on the latest `0.5.x` release. Older minors are not
+patched — upgrade to the newest `0.5.x` tag.
 
 | Version | Supported          |
 |---------|--------------------|
-| 0.4.x   | :white_check_mark: |
-| < 0.4   | :x:                |
+| 0.5.x   | :white_check_mark: |
+| < 0.5   | :x:                |
 
 ## Reporting a vulnerability
 
 **Please do not open a public issue for security problems.**
 
-1. Preferred: open a private report through GitHub's
-   [Security Advisories](https://github.com/miztertea/nim-proxy/security/advisories/new)
-   ("Report a vulnerability"). This keeps the details confidential until a fix
-   ships.
-2. Alternatively, email the maintainer at
-   `<SECURITY-CONTACT-EMAIL — maintainer to fill in>`. Use a subject that makes
-   the nature clear (e.g. "nim-proxy security report").
+Open a private report through GitHub's
+[Security Advisories](https://github.com/miztertea/nim-proxy/security/advisories/new)
+("Report a vulnerability"). This keeps the details confidential until a fix
+ships, and it is the only reporting channel — no email is monitored for this
+project.
 
 Please include: affected version/commit, run mode (secure vs. `INSECURE_NO_AUTH`),
 a description of the impact, and a minimal reproduction (a request body, a
@@ -37,7 +35,7 @@ This is a small, volunteer-maintained project. We aim to:
 
 - **Acknowledge** your report within 3 business days.
 - **Triage** and confirm (or explain why it's out of scope) within 7 days.
-- **Fix** confirmed vulnerabilities in a `0.4.x` patch release and credit you in
+- **Fix** confirmed vulnerabilities in a `0.5.x` patch release and credit you in
   the advisory (unless you prefer to stay anonymous).
 
 Please give us a reasonable window to ship a fix before any public disclosure.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,23 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-03] ops — v0.5.0 first public release prep
+
+Repo went public; cutting the first tagged release (which also gives
+`release.yml` its first-ever run — GHCR multi-arch image, keyless cosign,
+provenance, SBOM, GitHub Release).
+
+- **New runbook** → [ops/release](ops/release.md): tag-driven release
+  procedure, post-release verification checklist, roll-forward policy, and the
+  one-time repo settings (private vulnerability reporting, auto-delete head
+  branches, recommended `main` ruleset).
+- Version 0.5.0; CHANGELOG `[Unreleased]` promoted. `release.yml` gained a
+  tag↔Cargo.toml version guard so the OCI label and boot banner can't disagree.
+- SECURITY.md now points **only** at private GitHub Security Advisories (no
+  maintainer email published); CODE_OF_CONDUCT reports go via the maintainer's
+  GitHub profile. README gained a release badge and a published-image
+  (`ghcr.io`) quick start.
+
 ## [2026-07-02] decision + ingest — Benchmarking observability (v0.4.0)
 
 Turned the proxy into a benchmarking / agent-observability tool. The request

--- a/knowledge/ops/index.md
+++ b/knowledge/ops/index.md
@@ -7,6 +7,7 @@ description: Deploying, configuring, sharing, and capacity planning.
 # Operations
 
 - [deploy-docker](deploy-docker.md)
+- [release](release.md)
 - [configure-env](configure-env.md)
 - [sharing-with-friends](sharing-with-friends.md)
 - [capacity-math](capacity-math.md)

--- a/knowledge/ops/release.md
+++ b/knowledge/ops/release.md
@@ -1,0 +1,72 @@
+---
+type: Runbook
+title: Cutting a release
+description: Version bump, changelog, tag, release workflow, and post-release verification.
+tags: [release, versioning, ghcr]
+timestamp: 2026-07-03T00:00:00Z
+---
+
+# Cutting a release
+
+Releases are tag-driven: pushing a `v*` tag runs `.github/workflows/release.yml`,
+which builds a multi-arch (amd64+arm64) image, pushes it to
+`ghcr.io/miztertea/nim-proxy`, signs it with keyless cosign, attests SLSA build
+provenance, generates an SPDX SBOM, and publishes a GitHub Release with the
+static binaries and the SBOM attached. SemVer + Keep a Changelog throughout.
+
+## 1. Prepare a release PR
+
+- Bump `version` in `Cargo.toml` and sync `Cargo.lock`
+  (`cargo update --package nim-proxy`). The boot banner and dashboard status
+  report `CARGO_PKG_VERSION`, and the release workflow **fails if the tag does
+  not match Cargo.toml** (guard step in the `image` job).
+- `CHANGELOG.md`: promote `[Unreleased]` to `[X.Y.Z] - <date>`, leave a fresh
+  empty `[Unreleased]`, and update the compare/tag links in the footer.
+- Update the supported-versions table in `SECURITY.md` to the new minor.
+- Open a PR, wait for all CI jobs, merge.
+
+## 2. Tag
+
+```sh
+git fetch origin main
+git tag -a vX.Y.Z -m "nim-proxy X.Y.Z" origin/main   # tag the merge commit
+git push origin vX.Y.Z
+```
+
+Watch the **Release** workflow (`image` job → `release` job) under Actions.
+
+## 3. Verify the shipped artifacts
+
+```sh
+docker pull ghcr.io/miztertea/nim-proxy:X.Y.Z
+docker buildx imagetools inspect ghcr.io/miztertea/nim-proxy:X.Y.Z   # amd64 + arm64
+docker run -d --name rel-smoke -e NIM_API_KEYS=test -e INSECURE_NO_AUTH=true \
+  -p 127.0.0.1:8000:8000 ghcr.io/miztertea/nim-proxy:X.Y.Z
+curl -fsS http://127.0.0.1:8000/health && docker logs rel-smoke | head -20  # banner shows vX.Y.Z
+docker rm -f rel-smoke
+
+cosign verify ghcr.io/miztertea/nim-proxy:X.Y.Z \
+  --certificate-identity-regexp 'https://github.com/miztertea/nim-proxy/.github/workflows/release.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Also check the GitHub Release page: two `nim-proxy-X.Y.Z-linux-*.tar.gz` assets
+plus `nim-proxy-sbom.spdx.json`, and generated release notes.
+
+## Fixing a bad release
+
+Prefer roll-forward: fix on a branch, merge, tag the next patch version. Don't
+retag or force-move a published tag — the image, signature, and provenance are
+already public under the old digest.
+
+## One-time repo settings (already done; recorded for reference)
+
+- **Private vulnerability reporting** enabled (Settings → Code security) —
+  `SECURITY.md` lists advisories as the only reporting channel.
+- **Auto-delete head branches** enabled.
+- **Branch protection / ruleset on `main`** (Settings → Rules → Rulesets):
+  require a pull request before merging (0 approvals acceptable solo — the
+  point is blocking direct pushes); require status checks
+  `fmt, clippy, tests`, `coverage`, `cargo-deny`, `gitleaks`, `docker build`
+  (strict/up-to-date); block force pushes and deletions. Do **not** require
+  signed commits — session commits are unsigned and would be blocked.


### PR DESCRIPTION
## What & why

Release-prep for **v0.5.0**, the first public release. Once this merges, tagging the merge commit `v0.5.0` fires `release.yml` for its first-ever run (GHCR multi-arch image, keyless cosign signature, SLSA provenance, SPDX SBOM, GitHub Release) — also the first live exercise of the docker/* v4/v6/v7 and download-artifact v8 action majors from #26.

- **Version 0.5.0** (`Cargo.toml` + `Cargo.lock`), plus previously-missing `repository`/`readme` package metadata. The boot banner and status JSON report `CARGO_PKG_VERSION`, so this is what makes the shipped binary say v0.5.0.
- **CHANGELOG**: `[Unreleased]` promoted to `[0.5.0] - 2026-07-03`; footer compare/tag links updated.
- **SECURITY.md**: reporting is now **advisories-only** (private vulnerability reporting is enabled on the repo; no maintainer email published); supported line bumped to `0.5.x`.
- **CODE_OF_CONDUCT.md**: placeholder contact replaced — reports via the maintainer's GitHub profile, or a private security advisory for confidential ones.
- **README**: release badge + a published-image quick start (`docker run … ghcr.io/miztertea/nim-proxy:latest`) ahead of the build-from-source path.
- **release.yml**: new fail-fast guard — the pushed tag must match `Cargo.toml`'s version, so the OCI `image.version` label and the boot banner can never disagree.
- **knowledge/ops/release.md** (new runbook, + index/log entries): tag-driven release procedure, post-release verification, roll-forward policy, and the one-time repo settings.

## How it was tested

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (26 e2e + unit suites) — all clean locally.
- Both workflow files re-validated with a YAML parse.
- The four release.yml docker/artifact action bumps and the new tag guard only execute on tag push — they get exercised by the `v0.5.0` tag immediately after this merges, with a full post-release verification (multi-arch pull, runtime smoke, cosign verify, release assets).

## Checklist

- [x] **What/why** is explained above (and an issue is linked if one exists).
- [x] **Tests added or updated** for the new behavior (unit and/or e2e). *(No behavior change — version/docs/CI metadata only; existing suite passes.)*
- [x] `cargo fmt --check` is clean.
- [x] `cargo clippy --all-targets -- -D warnings` is clean (zero warnings).
- [x] `cargo test` passes locally.
- [x] **Docs updated in lockstep** — README and/or `examples/` reflect the change.
- [x] **Knowledge base updated in the same PR** — new `knowledge/ops/release.md`, `ops/index.md` row, dated `knowledge/log.md` entry.
- [x] **Security considered** — SECURITY.md policy change only; no auth/sanitizing/dashboard code touched.
- [x] **Rate-limiting proven** — n/a: pacing/key-pool/dispatcher/affinity untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC)_