### PR TITLE
Fix release binary extraction for the second architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,9 @@ jobs:
           push-to-registry: true
       # Extract the exact static binaries we just shipped (no separate cross
       # toolchain): create — not run — a container per arch and copy /nim-proxy.
+      # The classic image store maps a digest ref to one platform at a time, so
+      # untag between arches or the second pull fails with "cannot overwrite
+      # digest".
       - name: Extract release binaries
         run: |
           set -euo pipefail
@@ -82,6 +85,7 @@ jobs:
             cid=$(docker create --platform "linux/$arch" "${IMAGE}@${{ steps.build.outputs.digest }}")
             docker cp "$cid:/nim-proxy" "nim-proxy-$arch"
             docker rm "$cid" >/dev/null
+            docker rmi "${IMAGE}@${{ steps.build.outputs.digest }}" >/dev/null
             tar -czf "nim-proxy-${{ steps.meta.outputs.version }}-linux-$arch.tar.gz" "nim-proxy-$arch"
             rm "nim-proxy-$arch"
           done

--- a/knowledge/ops/release.md
+++ b/knowledge/ops/release.md
@@ -59,6 +59,19 @@ Prefer roll-forward: fix on a branch, merge, tag the next patch version. Don't
 retag or force-move a published tag — the image, signature, and provenance are
 already public under the old digest.
 
+Exception: if the workflow failed **before the GitHub Release was published**
+(nothing user-facing exists yet beyond image tags), merging the fix and
+re-pushing the same tag at the fixed commit is acceptable — a re-run of the
+failed run won't help, because re-runs use the workflow file snapshot from the
+original (broken) commit:
+
+```sh
+git push origin :refs/tags/vX.Y.Z          # delete the remote tag
+git fetch origin main
+git tag -fa vX.Y.Z -m "nim-proxy X.Y.Z" origin/main
+git push origin vX.Y.Z
+```
+
 ## One-time repo settings (already done; recorded for reference)
 
 - **Private vulnerability reporting** enabled (Settings → Code security) —


### PR DESCRIPTION
## What & why

The first v0.5.0 Release run ([28633650429](https://github.com/miztertea/nim-proxy/actions/runs/28633650429)) failed in **Extract release binaries**: the step pulls the same image digest once per platform via `docker create --platform`, but the runner's classic image store maps a digest reference to a single platform at a time, so the second (arm64) pull died with `cannot overwrite digest`. That skipped the SBOM, the binary tarballs, and the GitHub Release publish.

Everything before that step succeeded — the multi-arch image was pushed to GHCR (`0.5.0`, `0.5`, `latest`), cosign-signed, and provenance-attested — so this is purely a packaging-step fix:

- `release.yml`: `docker rmi` the digest reference between architectures so each per-platform pull starts clean (one added line + comment).
- `knowledge/ops/release.md`: document when re-pushing a tag is acceptable (workflow failed **before** the Release page was published, and re-runs can't help because they use the broken workflow snapshot) vs. the default roll-forward policy.

After this merges, re-pushing the `v0.5.0` tag at the fixed commit re-runs the pipeline end-to-end.

## How it was tested

- The failure mode is deterministic and understood from the run 28633650429 logs (first arch extracts fine, second hits the digest-ref collision); `docker rmi <image>@<digest>` removes exactly that reference, which is what the second pull needs.
- `release.yml` re-validated with a YAML parse. This step only executes on tag push, so the real test is the `v0.5.0` re-tag immediately after merge.

## Checklist

- [x] **What/why** is explained above (and an issue is linked if one exists).
- [x] **Tests added or updated** for the new behavior (unit and/or e2e). *(CI workflow packaging step — no runtime behavior; exercised by the tag re-push.)*
- [x] `cargo fmt --check` is clean. *(No Rust changes.)*
- [x] `cargo clippy --all-targets -- -D warnings` is clean (zero warnings). *(No Rust changes.)*
- [x] `cargo test` passes locally. *(No Rust changes.)*
- [x] **Docs updated in lockstep** — release runbook updated with the re-tag exception.
- [x] **Knowledge base updated in the same PR** — `knowledge/ops/release.md`.
- [x] **Security considered** — no auth/sanitizing/dashboard surface touched; workflow permissions unchanged.
- [x] **Rate-limiting proven** — n/a: pacing/key-pool/dispatcher/affinity untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC)_