### PR TITLE
Compose runs the published GHCR image; source builds via dev override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `docker compose up` now runs the published `ghcr.io/miztertea/nim-proxy:latest`
+  image instead of building from source; source builds move to an explicit dev
+  override (`docker-compose.dev.yml`, tagged `nim-proxy:dev`). README,
+  CONTRIBUTING, and the deploy runbook updated to match.
+
 ## [0.5.0] - 2026-07-03
 
 First public release: the repository is now public, and this tag publishes the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,10 @@ load harness.
 # Build and run locally, open mode (loopback only — see Security below):
 NIM_API_KEYS=nvapi-xxx,nvapi-yyy INSECURE_NO_AUTH=true cargo run --release
 
-# Or via Docker, exactly as a user would:
+# Or via Docker, building your working tree (a plain `docker compose up`
+# pulls the published GHCR image, not your local changes):
 cp .env.example .env      # paste keys, pick an auth mode
-docker compose up -d --build
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
 ```
 
 The dashboard is served at `http://localhost:8000/` and the OpenAI-compatible

--- a/README.md
+++ b/README.md
@@ -28,7 +28,14 @@ This tool is **not** designed to circumvent NVIDIA's terms of service. It maximi
 
 1. Get one or more API keys at [build.nvidia.com](https://build.nvidia.com) (free, `nvapi-...`; each account needs a unique email and phone number).
 
-2. Run the published image (multi-arch, signed, ~5 MB):
+2. Configure and run — compose pulls the published image (multi-arch, signed, ~5 MB) with hardened defaults and persistent history:
+
+```sh
+cp .env.example .env        # paste keys into NIM_API_KEYS, then pick an auth mode (below)
+docker compose up -d
+```
+
+Or without a checkout:
 
 ```sh
 docker run -d --name nim-proxy -p 127.0.0.1:8000:8000 \
@@ -36,14 +43,7 @@ docker run -d --name nim-proxy -p 127.0.0.1:8000:8000 \
   ghcr.io/miztertea/nim-proxy:latest
 ```
 
-Or build from source with the hardened compose defaults:
-
-```sh
-cp .env.example .env        # paste keys into NIM_API_KEYS, then pick an auth mode (below)
-docker compose up -d --build
-```
-
-Or without Docker: `NIM_API_KEYS=nvapi-xxx,nvapi-yyy INSECURE_NO_AUTH=true cargo run --release`
+Or build from source: `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build`, or without Docker: `NIM_API_KEYS=nvapi-xxx,nvapi-yyy INSECURE_NO_AUTH=true cargo run --release`
 
 3. Open the dashboard at `http://localhost:8000/` and point your client at `http://localhost:8000/v1`.
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,9 @@
+# Build-from-source override for development. Layers on top of the base file
+# so the hardened defaults stay identical to what users run:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+# The local image name deliberately differs from the published ghcr.io one so a
+# dev build can never shadow the pulled release image.
+services:
+  nim-proxy:
+    image: nim-proxy:dev
+    build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
+# Runs the published image. To build from source instead, layer the dev file:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
 services:
   nim-proxy:
-    build: .
-    image: nim-proxy:latest
+    image: ghcr.io/miztertea/nim-proxy:latest
     restart: unless-stopped
     ports:
       # Bound to loopback by default — reachable only from this host. To expose

--- a/knowledge/ops/deploy-docker.md
+++ b/knowledge/ops/deploy-docker.md
@@ -10,10 +10,15 @@ timestamp: 2026-07-02T00:00:00Z
 
 ```sh
 cp .env.example .env     # set NIM_API_KEYS + an auth mode (below)
-docker compose up -d --build
+docker compose up -d     # pulls ghcr.io/miztertea/nim-proxy:latest (signed, multi-arch)
 docker ps                # STATUS shows (healthy) via the built-in probe
 docker logs nim-proxy-nim-proxy-1
 ```
+
+To build from source instead (development):
+`docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build`
+— the dev override tags the local build `nim-proxy:dev` so it can't shadow the
+published image.
 
 **Auth is mandatory** ([posture](../decisions/auth-posture-and-dashboard-password.md)):
 set `ADMIN_PASSWORD` + `PROXY_API_KEYS` (secure), or `INSECURE_NO_AUTH=true`
@@ -44,5 +49,6 @@ Logs are one access line per request plus startup detail; ANSI is disabled
 automatically when stdout isn't a TTY. There is no shell to exec into — use
 logs, `/metrics`, and the dashboard.
 
-Upgrades: `docker compose up -d --build` — history persists in the volume;
-rate windows reset (a brief post-restart 429 burst is absorbed silently).
+Upgrades: `docker compose pull && docker compose up -d` — history persists in
+the volume; rate windows reset (a brief post-restart 429 burst is absorbed
+silently).


### PR DESCRIPTION
## What & why

`docker-compose.yml` still carried the pre-release setup: `build: .` with a locally-built `nim-proxy:latest`. Now that the signed multi-arch image is published, `docker compose up -d` should run **that**, not silently build from source under a name that shadows nothing.

- `docker-compose.yml`: `image: ghcr.io/miztertea/nim-proxy:latest`, `build:` removed; hardened defaults unchanged.
- **New `docker-compose.dev.yml`**: build-from-source override (`docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build`), deliberately tagged `nim-proxy:dev` so a dev build can never shadow the published image name.
- README quick start reordered: compose (pulls the release) first, `docker run` one-liner second, source builds last; CONTRIBUTING and `knowledge/ops/deploy-docker.md` updated to match, including the new upgrade flow `docker compose pull && docker compose up -d`.
- CHANGELOG `[Unreleased]` entry added.

## How it was tested

- `docker compose config --quiet` validates the base file (with a `.env` present, as users run it).
- `docker compose -f docker-compose.yml -f docker-compose.dev.yml config` confirms the merged dev config resolves to `image: nim-proxy:dev` + `build` context — the override layers correctly.
- Docs-only otherwise; no Rust or Dockerfile changes, so no release/tag is needed — the published `v0.5.0` image is untouched.

## Checklist

- [x] **What/why** is explained above (and an issue is linked if one exists).
- [x] **Tests added or updated** for the new behavior (unit and/or e2e). *(Compose/docs only — validated via `docker compose config`.)*
- [x] `cargo fmt --check` is clean. *(No Rust changes.)*
- [x] `cargo clippy --all-targets -- -D warnings` is clean (zero warnings). *(No Rust changes.)*
- [x] `cargo test` passes locally. *(No Rust changes.)*
- [x] **Docs updated in lockstep** — README, CONTRIBUTING, deploy runbook, CHANGELOG.
- [x] **Knowledge base updated in the same PR** — `knowledge/ops/deploy-docker.md`.
- [x] **Security considered** — hardened compose defaults (loopback publish, read_only, cap_drop, no-new-privileges) unchanged in both files.
- [x] **Rate-limiting proven** — n/a: pacing/key-pool/dispatcher/affinity untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai1dfAWZ2p86SQwE84c7sC)_