### PR TITLE
Block link-local targets in the pre-setup key-validation probe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ the dashboard, not env vars ([config store](knowledge/decisions/ui-managed-confi
 All three must be clean before you open a PR — CI enforces every one of them:
 
 ```sh
-cargo test                                   # 65 unit + 44 end-to-end tests
+cargo test                                   # 66 unit + 45 end-to-end tests
 cargo fmt                                     # (CI runs `cargo fmt --check`)
 cargo clippy --all-targets -- -D warnings    # zero warnings — warnings are errors
 ```

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ inject into the exposition format or explode the registry.
 Three layers, all runnable locally:
 
 ```sh
-cargo test          # 65 unit + 44 end-to-end tests (real binary vs scripted mock NIM)
+cargo test          # 66 unit + 45 end-to-end tests (real binary vs scripted mock NIM)
 ```
 
 The e2e suite covers auth (client keys, multi-user login / session cookie / scraper Bearer, role and ownership enforcement, the fail-closed setup posture and the wizard), the config store (round-trip across restart, atomic-save, refusal on corrupt/future-version stores), 429 ride-out with key failover, per-model worker-exhaustion governing, Retry-After timing, pacing enforcement (incl. live pool rebuilds mid-run), fail-fast 504s, conversation affinity, models caching, usage injection (incl. rejection fallback), stalled-stream recovery, label-injection sanitizing, security headers, metrics accuracy (incl. request-shape & response-quality signal on both the streaming and buffered paths, and the finish-reason cardinality clamp), history persistence across restart, and SIGTERM. Tests boot the real binary against a pre-written `config.json` (or drive the `/setup` wizard) in a tempdir `DATA_DIR`.

--- a/knowledge/decisions/ui-managed-config-store.md
+++ b/knowledge/decisions/ui-managed-config-store.md
@@ -127,7 +127,12 @@ data plane is closed pre-setup, compose binds loopback, and boot logs a loud
 `SETUP REQUIRED — the FIRST VISITOR becomes the superuser` line telling the
 operator to finish setup immediately. No claim token — it would be one more
 secret to route to the operator for a window measured in seconds, with no
-deployments upgrading into it.
+deployments upgrading into it. The one pre-auth surface in that window, the
+wizard's key-validation probe (`/setup/validate-key`, which fetches the
+operator-supplied upstream to confirm a key), rejects link-local targets
+(`169.254.0.0/16`, `fe80::/10`) so it can't be turned into a cloud-metadata
+SSRF oracle — loopback and RFC1918 stay allowed because local and LAN
+self-hosted NIM are real upstreams (`config::check_base_url`).
 
 ## Consequences
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -375,6 +375,31 @@ fn label_ok(s: &str, max: usize) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
 }
 
+/// Guard an upstream URL: require an http(s) scheme, and refuse the
+/// link-local range (169.254.0.0/16 and IPv6 fe80::/10) — that's the cloud
+/// metadata endpoint (169.254.169.254) and has no legitimate NIM use, so
+/// blocking it defangs the setup-probe SSRF while still allowing loopback
+/// and RFC1918 hosts (local and LAN self-hosted NIM are real use cases).
+pub fn check_base_url(base: &str) -> Result<(), String> {
+    let rest = base
+        .strip_prefix("http://")
+        .or_else(|| base.strip_prefix("https://"))
+        .ok_or("upstream base_url must start with http:// or https://")?;
+    let authority = rest.split('/').next().unwrap_or("");
+    // A bracketed IPv6 literal keeps its inner colons; otherwise the host is
+    // everything up to the port separator.
+    let host = if let Some(inner) = authority.strip_prefix('[') {
+        inner.split(']').next().unwrap_or("")
+    } else {
+        authority.split(':').next().unwrap_or("")
+    };
+    let host = host.to_ascii_lowercase();
+    if host.starts_with("169.254.") || host.starts_with("fe80:") {
+        return Err("upstream base_url must not point at a link-local address".into());
+    }
+    Ok(())
+}
+
 /// One shared rulebook for the wizard, every settings endpoint, and boot.
 pub fn validate(sc: &StoredConfig) -> Result<(), String> {
     if sc.version != 1 {
@@ -400,10 +425,7 @@ pub fn validate(sc: &StoredConfig) -> Result<(), String> {
     {
         return Err("reference prices must be non-negative numbers".into());
     }
-    let base = &sc.upstream.base_url;
-    if !(base.starts_with("http://") || base.starts_with("https://")) {
-        return Err("upstream base_url must start with http:// or https://".into());
-    }
+    check_base_url(&sc.upstream.base_url)?;
 
     let mut names = std::collections::HashSet::new();
     for u in &sc.users {
@@ -543,6 +565,31 @@ mod tests {
                 }],
             },
             ..Default::default()
+        }
+    }
+
+    #[test]
+    fn check_base_url_blocks_link_local_but_allows_local_and_lan() {
+        // Legitimate NIM locations pass.
+        for ok in [
+            "https://integrate.api.nvidia.com",
+            "http://127.0.0.1:9999",
+            "http://localhost:8000",
+            "http://192.168.1.50:8000", // LAN self-hosted NIM
+            "http://10.0.0.4",
+        ] {
+            assert!(check_base_url(ok).is_ok(), "{ok} should be allowed");
+        }
+        // Link-local (cloud metadata) and non-http schemes are refused.
+        for bad in [
+            "http://169.254.169.254/latest/meta-data",
+            "http://169.254.169.254",
+            "http://[fe80::1]/x",
+            "file:///etc/passwd",
+            "gopher://169.254.169.254",
+            "integrate.api.nvidia.com", // no scheme
+        ] {
+            assert!(check_base_url(bad).is_err(), "{bad} should be rejected");
         }
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -186,6 +186,12 @@ pub async fn setup_validate_key(
         .clone()
         .unwrap_or_else(|| state.store.lock().unwrap().upstream.base_url.clone());
     let base = base.trim().trim_end_matches('/').to_owned();
+    // The wizard's advanced path lets an unauthenticated pre-claim caller
+    // supply base_url, so guard it against the link-local metadata range
+    // before probing (loopback/RFC1918 stay allowed for self-hosted NIM).
+    if let Err(e) = config::check_base_url(&base) {
+        return json_error(StatusCode::BAD_REQUEST, "invalid_base_url", e);
+    }
     axum::Json(match probe_key(&state.http, &base, req.key.trim()).await {
         Ok(models) => serde_json::json!({"ok": true, "models": models}),
         Err(e) => serde_json::json!({"ok": false, "error": e}),

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1887,3 +1887,31 @@ async fn authenticated_key_validation_ignores_caller_supplied_base_url() {
     );
     assert_eq!(v["models"], 1, "{v}");
 }
+
+#[tokio::test]
+async fn setup_key_validation_rejects_link_local_base_url() {
+    // Pre-auth setup probe must not be usable as an SSRF oracle against the
+    // cloud metadata endpoint; loopback/LAN upstreams stay allowed.
+    let mock = start_mock().await;
+    let proxy = support::start_proxy_fresh().await;
+
+    let bad = client()
+        .post(proxy.url("/setup/validate-key"))
+        .json(
+            &serde_json::json!({"key": "x", "base_url": "http://169.254.169.254/latest/meta-data"}),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(bad.status(), 400, "link-local base_url must be rejected");
+
+    // A normal (loopback mock) upstream still validates fine.
+    let ok = client()
+        .post(proxy.url("/setup/validate-key"))
+        .json(&serde_json::json!({"key": "x", "base_url": mock.url}))
+        .send()
+        .await
+        .unwrap();
+    let v: serde_json::Value = ok.json().await.unwrap();
+    assert_eq!(v["ok"], true, "loopback upstream still probes: {v}");
+}


### PR DESCRIPTION
## What & why

Follow-up hardening to the config-store epic (#33, merged). A security review of the epic flagged one below-threshold but real issue: the first-run wizard's key-validation probe (`POST /setup/validate-key`) is reachable **unauthenticated during the pre-claim window** and fetched an operator-supplied `base_url` verbatim. A first visitor could point it at `http://169.254.169.254/…` and read the reachable/rejected/unreachable response as a cloud-metadata **SSRF oracle**.

`config::check_base_url` now rejects the link-local range (`169.254.0.0/16`, `fe80::/10`) for both the stored upstream and the setup probe, while still allowing loopback and RFC1918 — local and LAN self-hosted NIM are legitimate upstreams, so blocking all private ranges would break a real use case. The authenticated `validate-key` already ignores caller-supplied `base_url` (fixed in the epic); this closes the remaining pre-auth path.

## How it was tested

- New unit test `check_base_url_blocks_link_local_but_allows_local_and_lan` (allows `integrate.api.nvidia.com`, `127.0.0.1`, `localhost`, `192.168.x`, `10.x`; rejects `169.254.169.254`, bracketed `[fe80::1]`, non-http schemes, and scheme-less URLs).
- New e2e test `setup_key_validation_rejects_link_local_base_url` (pre-auth probe → 400 for link-local, still validates a loopback mock upstream).
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (66 unit + 45 e2e) all clean.

## Checklist

- [x] **What/why** is explained above.
- [x] **Tests added or updated** for the new behavior (unit and e2e).
- [x] `cargo fmt --check` is clean.
- [x] `cargo clippy --all-targets -- -D warnings` is clean (zero warnings).
- [x] `cargo test` passes locally.
- [x] **Docs updated in lockstep** — README/CONTRIBUTING test counts.
- [x] **Knowledge base updated in the same PR** — the setup-claim-risk section of `decisions/ui-managed-config-store.md` notes the link-local guard.
- [x] **Security considered** — closes a pre-auth SSRF oracle without breaking self-hosted/local NIM.
- [x] **Rate-limiting proven** — N/A (no pacing/pool/dispatcher change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av)_