### PR TITLE
Cut releases from the Actions UI; prepare v0.6.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,18 @@
 name: Release
 
+# Two entry points, one pipeline:
+#   - push of a v* tag (the classic path)
+#   - workflow_dispatch from the default branch: resolves the version from
+#     Cargo.toml, mints the tag itself, and continues — releases can be cut
+#     from the Actions UI (or an API call) with no local terminal.
+# The dispatch-minted tag is pushed with GITHUB_TOKEN, whose ref pushes
+# deliberately trigger no follow-on workflow runs (GitHub suppresses them to
+# prevent recursion) — which is exactly right here: THIS run carries the
+# release end-to-end and never depends on the tag-push event.
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch: {}
 
 # Least privilege by default; each job opts into exactly what it needs.
 permissions:
@@ -12,8 +22,53 @@ env:
   IMAGE: ghcr.io/${{ github.repository }}
 
 jobs:
+  prepare:
+    name: resolve version (mint tag on dispatch)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # mints the v* tag on the dispatch path
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      minor: ${{ steps.resolve.outputs.minor }}
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: resolve
+        name: Resolve version from Cargo.toml; mint the tag on dispatch
+        run: |
+          set -euo pipefail
+          version=$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "$GITHUB_REF_NAME" != "${{ github.event.repository.default_branch }}" ]; then
+              echo "::error::dispatch releases run from the default branch only (got $GITHUB_REF_NAME)"
+              exit 1
+            fi
+            if git ls-remote --exit-code origin "refs/tags/v$version" >/dev/null 2>&1; then
+              echo "::error::v$version already exists — bump Cargo.toml (and promote the CHANGELOG) first"
+              exit 1
+            fi
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "v$version" -m "nim-proxy $version" "$GITHUB_SHA"
+            git push origin "v$version"
+          else
+            # The binary reports CARGO_PKG_VERSION; the image is labeled with
+            # the git tag. Refuse to ship an image where the two disagree.
+            if [ "$GITHUB_REF_NAME" != "v$version" ]; then
+              echo "::error::tag $GITHUB_REF_NAME does not match Cargo.toml version $version"
+              grep '^version = ' Cargo.toml
+              exit 1
+            fi
+          fi
+          {
+            echo "version=$version"
+            echo "minor=${version%.*}"
+            echo "tag=v$version"
+          } >> "$GITHUB_OUTPUT"
+
   image:
     name: image → GHCR (multi-arch, signed)
+    needs: prepare
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -22,19 +77,8 @@ jobs:
       attestations: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
-      version: ${{ steps.meta.outputs.version }}
     steps:
       - uses: actions/checkout@v7
-      # The binary reports CARGO_PKG_VERSION; the image is labeled with the git
-      # tag. Refuse to ship an image where the two would disagree.
-      - name: Tag must match Cargo.toml version
-        run: |
-          tag="${GITHUB_REF_NAME#v}"
-          grep -Fxq "version = \"$tag\"" Cargo.toml || {
-            echo "::error::tag v$tag does not match Cargo.toml version:"
-            grep '^version = ' Cargo.toml
-            exit 1
-          }
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR
@@ -43,13 +87,15 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # Tags come from the prepare job, not from the git ref: the dispatch
+      # path has no tag ref at trigger time, so semver patterns would be empty.
       - id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ needs.prepare.outputs.version }}
+            type=raw,value=${{ needs.prepare.outputs.minor }}
             type=raw,value=latest
       - id: build
         uses: docker/build-push-action@v7
@@ -60,7 +106,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
+            VERSION=${{ needs.prepare.outputs.version }}
           provenance: true
           sbom: true
       - name: Install cosign
@@ -86,7 +132,7 @@ jobs:
             docker cp "$cid:/nim-proxy" "nim-proxy-$arch"
             docker rm "$cid" >/dev/null
             docker rmi "${IMAGE}@${{ steps.build.outputs.digest }}" >/dev/null
-            tar -czf "nim-proxy-${{ steps.meta.outputs.version }}-linux-$arch.tar.gz" "nim-proxy-$arch"
+            tar -czf "nim-proxy-${{ needs.prepare.outputs.version }}-linux-$arch.tar.gz" "nim-proxy-$arch"
             rm "nim-proxy-$arch"
           done
       - name: Generate SBOM (SPDX)
@@ -105,7 +151,7 @@ jobs:
 
   release:
     name: GitHub Release
-    needs: image
+    needs: [prepare, image]
     runs-on: ubuntu-latest
     permissions:
       contents: write # create the release
@@ -116,6 +162,9 @@ jobs:
       - name: Publish release
         uses: softprops/action-gh-release@v3
         with:
+          # Explicit: on the dispatch path the triggering ref is a branch, so
+          # the action must not derive the release tag from it.
+          tag_name: ${{ needs.prepare.outputs.tag }}
           generate_release_notes: true
           files: |
             nim-proxy-*.tar.gz
@@ -124,13 +173,13 @@ jobs:
             Container image (multi-arch, signed, with SBOM + provenance):
 
             ```sh
-            docker pull ghcr.io/${{ github.repository }}:${{ needs.image.outputs.version }}
+            docker pull ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.version }}
             ```
 
             Verify the signature:
 
             ```sh
-            cosign verify ghcr.io/${{ github.repository }}:${{ needs.image.outputs.version }} \
+            cosign verify ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.version }} \
               --certificate-identity-regexp 'https://github.com/${{ github.repository }}/.github/workflows/release.yml@.*' \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com
             ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Nothing yet.
 
+## [0.6.1] - 2026-07-04
+
+Maintenance release — no proxy behavior changes; it exists to ship and
+validate the new release automation.
+
+### Changed
+
+- **Releases can be cut from the Actions UI** (`workflow_dispatch` on the
+  Release workflow): a new `prepare` job resolves the version from Cargo.toml
+  on the default branch, refuses if that tag already exists, mints and pushes
+  the `v*` tag itself, and the same run carries the release end-to-end — no
+  local `git tag`/`git push` needed. The tag-push path still works and keeps
+  its tag-must-match-Cargo.toml guard; image tags and the GitHub Release tag
+  now come from the resolved version rather than the triggering git ref.
+
 ## [0.6.0] - 2026-07-04
 
 > **Breaking (v0.6.0):** app-level configuration moved from env vars into a
@@ -299,7 +314,8 @@ Initial rate-limit-aware proxy.
 - **Distroless image**: a static musl binary shipped `FROM scratch` (~3.5 MB,
   TLS roots compiled in), running non-root with hardened compose defaults.
 
-[Unreleased]: https://github.com/miztertea/nim-proxy/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/miztertea/nim-proxy/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/miztertea/nim-proxy/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/miztertea/nim-proxy/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/miztertea/nim-proxy/releases/tag/v0.5.0
 [0.4.0]: https://github.com/miztertea/nim-proxy/releases/tag/v0.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "nim-proxy"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nim-proxy"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Rate-limit-aware OpenAI-compatible proxy for NVIDIA NIM with multi-key load balancing"
 license = "MIT"

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,24 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-04] ingest — release automation: workflow_dispatch cuts releases (v0.6.1)
+
+Tagging by hand (`git tag` + `git push`) was the one release step that
+required a local terminal with tag-push rights — and restricted sessions
+(e.g. Claude Code remote, whose git proxy only allows the designated branch)
+cannot do it at all, which bit the v0.6.0 cut. The Release workflow gained a
+`workflow_dispatch` entry point: a new `prepare` job resolves the version
+from Cargo.toml on the default branch, refuses if the tag already exists,
+mints and pushes the tag itself, and the same run releases end-to-end.
+Design constraint that shaped it: tags pushed with `GITHUB_TOKEN` trigger no
+follow-on workflow runs (GitHub's recursion guard), so the dispatch path must
+never rely on the tag-push event — hence one workflow with two triggers, and
+image/release tags now derive from the resolved version, not the git ref.
+Full automation (release-plz/release-please) was considered and rejected:
+version choice is a scope decision and the CHANGELOG is deliberately
+hand-written. Runbook: [release](ops/release.md). v0.6.1 is the maintenance
+release that shipped and validated this path.
+
 ## [2026-07-04] ingest — v0.6.0 release cut: correctness fixes, wizard client key, outcome charts
 
 The 0.6.0 release closes the loose ends found during the config-store epic

--- a/knowledge/ops/release.md
+++ b/knowledge/ops/release.md
@@ -8,24 +8,35 @@ timestamp: 2026-07-03T00:00:00Z
 
 # Cutting a release
 
-Releases are tag-driven: pushing a `v*` tag runs `.github/workflows/release.yml`,
-which builds a multi-arch (amd64+arm64) image, pushes it to
-`ghcr.io/miztertea/nim-proxy`, signs it with keyless cosign, attests SLSA build
-provenance, generates an SPDX SBOM, and publishes a GitHub Release with the
-static binaries and the SBOM attached. SemVer + Keep a Changelog throughout.
+`.github/workflows/release.yml` builds a multi-arch (amd64+arm64) image,
+pushes it to `ghcr.io/miztertea/nim-proxy`, signs it with keyless cosign,
+attests SLSA build provenance, generates an SPDX SBOM, and publishes a GitHub
+Release with the static binaries and the SBOM attached. SemVer + Keep a
+Changelog throughout.
+
+It has two entry points: **Run workflow** in the Actions UI (the normal path
+since v0.6.1 — the workflow's `prepare` job resolves the version from
+Cargo.toml on `main`, refuses if that tag already exists, and mints/pushes the
+`v*` tag itself), or a manual `v*` tag push (the classic path, still guarded
+by tag-must-match-Cargo.toml). The dispatch-minted tag is pushed with
+`GITHUB_TOKEN`, whose ref pushes trigger no follow-on runs — by design the
+dispatch run carries the release end-to-end itself.
 
 ## 1. Prepare a release PR
 
 - Bump `version` in `Cargo.toml` and sync `Cargo.lock`
   (`cargo update --package nim-proxy`). The boot banner and dashboard status
-  report `CARGO_PKG_VERSION`, and the release workflow **fails if the tag does
-  not match Cargo.toml** (guard step in the `image` job).
+  report `CARGO_PKG_VERSION`; the workflow releases exactly this version.
 - `CHANGELOG.md`: promote `[Unreleased]` to `[X.Y.Z] - <date>`, leave a fresh
   empty `[Unreleased]`, and update the compare/tag links in the footer.
 - Update the supported-versions table in `SECURITY.md` to the new minor.
 - Open a PR, wait for all CI jobs, merge.
 
-## 2. Tag
+## 2. Release
+
+Actions → **Release** → *Run workflow* (from `main`), or ask the agent to
+trigger it (`workflow_dispatch` is an ordinary API call — unlike tag pushes,
+it works from restricted sessions). Equivalent manual path:
 
 ```sh
 git fetch origin main
@@ -33,7 +44,9 @@ git tag -a vX.Y.Z -m "nim-proxy X.Y.Z" origin/main   # tag the merge commit
 git push origin vX.Y.Z
 ```
 
-Watch the **Release** workflow (`image` job → `release` job) under Actions.
+Watch the run (`prepare` → `image` → `release`) under Actions. If the
+`prepare` job fails with "already exists", the version in Cargo.toml was
+never bumped — do step 1 first.
 
 ## 3. Verify the shipped artifacts
 
@@ -72,7 +85,13 @@ git tag -fa vX.Y.Z -m "nim-proxy X.Y.Z" origin/main
 git push origin vX.Y.Z
 ```
 
-## One-time repo settings (already done; recorded for reference)
+## One-time repo settings (recorded for reference)
+
+- **Tag ruleset (recommended, not yet applied)**: Settings → Rules → Rulesets →
+  new ruleset targeting tags `v*`: restrict creation to the repository admin
+  role (GitHub Actions' `GITHUB_TOKEN` acts as the repo and passes), block
+  deletion and non-fast-forward updates. This codifies the "never retag a
+  published release" rule below instead of relying on discipline.
 
 - **Private vulnerability reporting** enabled (Settings → Code security) —
   `SECURITY.md` lists advisories as the only reporting channel.


### PR DESCRIPTION
## What & why

Tagging by hand (`git tag && git push`) was the one release step that required a local terminal with tag-push rights — restricted sessions can't do it at all, which bit the v0.6.0 cut. This PR adds a second entry point to the Release workflow and stages **v0.6.1** as the maintenance release that validates it.

- **`workflow_dispatch` on `release.yml`**: a new `prepare` job resolves the version from `Cargo.toml` on the default branch, refuses if that tag already exists (i.e. the release PR was never merged), mints and pushes the annotated `v*` tag itself, and the same run carries the release end-to-end.
- **Why one workflow with two triggers**: tags pushed with `GITHUB_TOKEN` deliberately trigger no follow-on workflow runs (GitHub's recursion guard), so a separate "tag-creator" workflow would silently release nothing. The dispatch path therefore never depends on the tag-push event — image tags (`X.Y.Z`, `X.Y`, `latest`) and the GitHub Release `tag_name` now derive from the resolved version instead of the triggering git ref.
- **The classic tag-push path is unchanged in behavior** and keeps its tag-must-match-Cargo.toml guard (now in `prepare`).
- **Version → 0.6.1**, CHANGELOG entry added, runbook (`knowledge/ops/release.md`) rewritten around the new flow with a recommended `v*` tag ruleset recorded, dated knowledge-log entry.

Full automation (release-plz / release-please) was considered and rejected: version choice here is a scope decision and the CHANGELOG is deliberately hand-written prose.

## How it was tested

- YAML validated; `cargo fmt --check` clean; full `cargo test` green (69 unit + 53 e2e — no proxy code changes, version bump only).
- The dispatch path's live validation is the point of this release: after merge, the plan is to trigger **Run workflow** and confirm v0.6.1 ships end-to-end (tag minted at `main` HEAD, image `0.6.1`/`0.6`/`latest` pushed + signed, GitHub Release with both tarballs + SBOM).

## Checklist

- [x] **What/why** is explained above (and an issue is linked if one exists).
- [ ] **Tests added or updated** for the new behavior (unit and/or e2e) — n/a: CI workflow + version metadata only; the live v0.6.1 dispatch run is the test.
- [x] `cargo fmt --check` is clean.
- [x] `cargo clippy --all-targets -- -D warnings` is clean (zero warnings).
- [x] `cargo test` passes locally.
- [x] **Docs updated in lockstep** — release runbook rewritten around the dispatch flow.
- [x] **Knowledge base updated in the same PR** — `ops/release.md` + dated `log.md` entry with the design constraint (GITHUB_TOKEN tag pushes trigger no runs).
- [x] **Security considered** — `prepare` is the only job with `contents: write` (tag creation); dispatch is restricted to the default branch; existing least-privilege job permissions unchanged; a `v*` tag ruleset is recommended in the runbook to block tag deletion/moves.
- [ ] **Rate-limiting proven** — n/a: no proxy behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av)_