### PR TITLE
Build release images on native runners in parallel; prepare v0.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# A new push to the same ref supersedes the running CI for it (but never
+# cancel main's post-merge runs — their results gate releases).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -90,11 +96,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
       - name: Build image
-        run: docker build -t nim-proxy:ci .
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          tags: nim-proxy:ci
+          cache-from: type=gha,scope=ci
+          cache-to: type=gha,mode=max,scope=ci
       - name: Smoke test image
         run: |
-          docker run -d --name smoke -e NIM_API_KEYS=test-key -e INSECURE_NO_AUTH=true -p 8000:8000 nim-proxy:ci
+          # A fresh container boots into setup-required mode (no env config
+          # since v0.6.0); /health is public regardless, and the built-in
+          # HEALTHCHECK must go healthy on it.
+          docker run -d --name smoke -p 8000:8000 nim-proxy:ci
           for i in $(seq 1 30); do
             if curl -fsS http://127.0.0.1:8000/health > /dev/null 2>&1; then ok=1; break; fi
             sleep 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,13 @@ name: Release
 # deliberately trigger no follow-on workflow runs (GitHub suppresses them to
 # prevent recursion) — which is exactly right here: THIS run carries the
 # release end-to-end and never depends on the tag-push event.
+#
+# The image is built per-arch on NATIVE runners in parallel (amd64 on
+# ubuntu-latest, arm64 on ubuntu-24.04-arm — free for public repos), pushed
+# by digest, then stitched into one multi-arch manifest. QEMU emulation made
+# the arm64 Rust compile the whole run's critical path (~30 min); native
+# builds bring the release to a few minutes. Signing, provenance attestation,
+# and the SBOM all target the final manifest digest.
 on:
   push:
     tags: ["v*"]
@@ -66,20 +73,25 @@ jobs:
             echo "tag=v$version"
           } >> "$GITHUB_OUTPUT"
 
-  image:
-    name: image → GHCR (multi-arch, signed)
+  build:
+    name: build ${{ matrix.arch }} (native)
     needs: prepare
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
-      packages: write # push to GHCR
-      id-token: write # keyless cosign + provenance via OIDC
-      attestations: write
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      packages: write # push per-arch image by digest
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -87,78 +99,124 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # Tags come from the prepare job, not from the git ref: the dispatch
-      # path has no tag ref at trigger time, so semver patterns would be empty.
+      # Labels only — tags are applied by the merge job on the manifest.
       - id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE }}
-          tags: |
-            type=raw,value=${{ needs.prepare.outputs.version }}
-            type=raw,value=${{ needs.prepare.outputs.minor }}
-            type=raw,value=latest
       - id: build
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ needs.prepare.outputs.version }}
+          # Push by digest only; the merge job stitches the tagged manifest.
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
           provenance: true
           sbom: true
+          cache-from: type=gha,scope=release-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=release-${{ matrix.arch }}
+      # The documented multi-runner pattern: matrix job outputs clobber each
+      # other, so each leg exports its digest as an artifact file instead.
+      - name: Export digest
+        run: |
+          mkdir -p "$RUNNER_TEMP/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "$RUNNER_TEMP/digests/${digest#sha256:}"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: digest-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+      # Extract the exact static binary we just shipped — natively on this
+      # runner: create (not run) a container and copy /nim-proxy out.
+      - name: Extract release binary
+        run: |
+          set -euo pipefail
+          cid=$(docker create --platform "${{ matrix.platform }}" "${IMAGE}@${{ steps.build.outputs.digest }}")
+          docker cp "$cid:/nim-proxy" "nim-proxy-${{ matrix.arch }}"
+          docker rm "$cid" >/dev/null
+          tar -czf "nim-proxy-${{ needs.prepare.outputs.version }}-linux-${{ matrix.arch }}.tar.gz" "nim-proxy-${{ matrix.arch }}"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: binary-${{ matrix.arch }}
+          path: nim-proxy-*.tar.gz
+          if-no-files-found: error
+
+  merge:
+    name: manifest → sign → attest → SBOM
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push the tagged multi-arch manifest
+      id-token: write # keyless cosign + provenance via OIDC
+      attestations: write
+    outputs:
+      digest: ${{ steps.manifest.outputs.digest }}
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v4
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: digest-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
+      - id: manifest
+        name: Stitch the multi-arch manifest and tag it
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            -t "${IMAGE}:${{ needs.prepare.outputs.version }}" \
+            -t "${IMAGE}:${{ needs.prepare.outputs.minor }}" \
+            -t "${IMAGE}:latest" \
+            $(printf "${IMAGE}@sha256:%s " *)
+          digest=$(docker buildx imagetools inspect \
+            "${IMAGE}:${{ needs.prepare.outputs.version }}" \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
       - name: Sign image (keyless)
-        run: cosign sign --yes "${IMAGE}@${{ steps.build.outputs.digest }}"
+        run: cosign sign --yes "${IMAGE}@${{ steps.manifest.outputs.digest }}"
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: ${{ env.IMAGE }}
-          subject-digest: ${{ steps.build.outputs.digest }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}
           push-to-registry: true
-      # Extract the exact static binaries we just shipped (no separate cross
-      # toolchain): create — not run — a container per arch and copy /nim-proxy.
-      # The classic image store maps a digest ref to one platform at a time, so
-      # untag between arches or the second pull fails with "cannot overwrite
-      # digest".
-      - name: Extract release binaries
-        run: |
-          set -euo pipefail
-          for arch in amd64 arm64; do
-            cid=$(docker create --platform "linux/$arch" "${IMAGE}@${{ steps.build.outputs.digest }}")
-            docker cp "$cid:/nim-proxy" "nim-proxy-$arch"
-            docker rm "$cid" >/dev/null
-            docker rmi "${IMAGE}@${{ steps.build.outputs.digest }}" >/dev/null
-            tar -czf "nim-proxy-${{ needs.prepare.outputs.version }}-linux-$arch.tar.gz" "nim-proxy-$arch"
-            rm "nim-proxy-$arch"
-          done
       - name: Generate SBOM (SPDX)
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+          image: ${{ env.IMAGE }}@${{ steps.manifest.outputs.digest }}
           format: spdx-json
           output-file: nim-proxy-sbom.spdx.json
       - uses: actions/upload-artifact@v7
         with:
-          name: release-assets
-          path: |
-            nim-proxy-*.tar.gz
-            nim-proxy-sbom.spdx.json
+          name: sbom
+          path: nim-proxy-sbom.spdx.json
           if-no-files-found: error
 
   release:
     name: GitHub Release
-    needs: [prepare, image]
+    needs: [prepare, merge]
     runs-on: ubuntu-latest
     permissions:
       contents: write # create the release
     steps:
       - uses: actions/download-artifact@v8
         with:
-          name: release-assets
+          pattern: "{binary-*,sbom}"
+          merge-multiple: true
       - name: Publish release
         uses: softprops/action-gh-release@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Nothing yet.
 
+## [0.6.2] - 2026-07-04
+
+CI/release infrastructure release — no proxy behavior changes.
+
+### Changed
+
+- **Release images build on native runners in parallel**: amd64 on
+  `ubuntu-latest` and arm64 on `ubuntu-24.04-arm`, each pushed by digest and
+  stitched into one multi-arch manifest; the cosign signature, provenance
+  attestation, and SBOM now target the manifest digest. This removes the
+  QEMU-emulated arm64 Rust compile that made releases take ~30 minutes.
+  Buildx layer caching added to the release and CI image builds.
+- CI runs superseded by a newer push to the same ref are cancelled
+  (concurrency groups; main is never cancelled), and the CI image smoke test
+  no longer sets legacy env vars retired in 0.6.0.
+
 ## [0.6.1] - 2026-07-04
 
 Maintenance release — no proxy behavior changes; it exists to ship and
@@ -314,7 +330,8 @@ Initial rate-limit-aware proxy.
 - **Distroless image**: a static musl binary shipped `FROM scratch` (~3.5 MB,
   TLS roots compiled in), running non-root with hardened compose defaults.
 
-[Unreleased]: https://github.com/miztertea/nim-proxy/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/miztertea/nim-proxy/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/miztertea/nim-proxy/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/miztertea/nim-proxy/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/miztertea/nim-proxy/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/miztertea/nim-proxy/releases/tag/v0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "nim-proxy"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nim-proxy"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Rate-limit-aware OpenAI-compatible proxy for NVIDIA NIM with multi-key load balancing"
 license = "MIT"

--- a/knowledge/ops/release.md
+++ b/knowledge/ops/release.md
@@ -44,9 +44,16 @@ git tag -a vX.Y.Z -m "nim-proxy X.Y.Z" origin/main   # tag the merge commit
 git push origin vX.Y.Z
 ```
 
-Watch the run (`prepare` → `image` → `release`) under Actions. If the
-`prepare` job fails with "already exists", the version in Cargo.toml was
-never bumped — do step 1 first.
+Watch the run (`prepare` → `build amd64`/`build arm64` in parallel on native
+runners → `merge` → `release`) under Actions — a few minutes end to end
+(the arm64 leg builds natively on `ubuntu-24.04-arm`; QEMU emulation used to
+make it ~30 minutes). If the `prepare` job fails with "already exists", the
+version in Cargo.toml was never bumped — do step 1 first.
+
+The cosign signature, provenance attestation, and SBOM all target the final
+**multi-arch manifest digest** (stitched by the `merge` job from the per-arch
+digests), so `cosign verify` on any release tag resolves and verifies the
+same manifest.
 
 ## 3. Verify the shipped artifacts
 


### PR DESCRIPTION
## What & why

Speed PR (A) of the actions-optimization plan. The v0.6.0/v0.6.1 releases took ~30 minutes because the arm64 leg compiled the entire Rust release build under QEMU user-mode emulation on an x86 runner. This PR removes emulation from the pipeline entirely and stages **v0.6.2** as the release that validates it.

**Release workflow:**
- The single QEMU multi-arch build becomes two parallel **native** build jobs — amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm` (GitHub's arm64 runners, free for public repos) — each pushing by digest with buildx GHA layer caching, following Docker's documented multi-runner pattern (digest files as artifacts; matrix outputs clobber).
- A new `merge` job stitches the per-arch digests into one multi-arch manifest (`imagetools create`) and tags `X.Y.Z`/`X.Y`/`latest`; the **cosign signature, provenance attestation, and SBOM now target the manifest digest**, so `cosign verify` on any release tag verifies the same manifest.
- Binary extraction moves into each build job and runs natively; the release job downloads the per-arch tarballs + SBOM artifacts.
- `prepare` (version resolution + dispatch tag-minting from #36) and the two entry points are unchanged.

**CI workflow:**
- `concurrency` groups cancel CI runs superseded by a newer push to the same ref (never `main` — its post-merge results gate releases).
- The docker job switches to buildx with GHA layer caching.
- The image smoke test drops `NIM_API_KEYS`/`INSECURE_NO_AUTH` — legacy env vars retired in 0.6.0 that the proxy ignores; a fresh container boots into setup mode and must go healthy on the public `/health` probe, which is what the test actually exercised all along.

**Version → 0.6.2** with a CHANGELOG entry (infrastructure-only release); the release runbook documents the new job shape and the manifest-digest signing.

## How it was tested

- Both workflow files parse as valid YAML; `cargo test` green (69 unit + 53 e2e — version bump is the only code-adjacent change).
- The CI changes validate themselves on this PR's own checks (including the rewritten docker job + smoke test).
- The release changes are validated by design with a **v0.6.2 dispatch release immediately after merge** — same live-test approach used for v0.6.1. Expected outcome: same artifact set as v0.6.1 (multi-arch image, signature, provenance, SBOM, two tarballs) in a fraction of the wall clock.

## Checklist

- [x] **What/why** is explained above (and an issue is linked if one exists).
- [ ] **Tests added or updated** for the new behavior — n/a: CI/release workflow + version metadata only; the live v0.6.2 dispatch run is the test.
- [x] `cargo fmt --check` is clean.
- [x] `cargo clippy --all-targets -- -D warnings` is clean (zero warnings).
- [x] `cargo test` passes locally.
- [x] **Docs updated in lockstep** — release runbook describes the native-runner split and manifest-digest signing.
- [x] **Knowledge base updated in the same PR** — `ops/release.md`.
- [x] **Security considered** — job permissions stay least-privilege (build jobs: `packages: write` only; OIDC/attestation permissions move to the `merge` job with the signing steps); signing/provenance/SBOM still cover exactly what ships, now anchored at the manifest digest.
- [ ] **Rate-limiting proven** — n/a: no proxy behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av)_