### PR TITLE
Harden workflows to the OpenSSF baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,18 @@ jobs:
     name: fmt, clippy, tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master (toolchain via input)
+        with:
+          toolchain: stable
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Format
         run: cargo fmt --check
       - name: Clippy
@@ -49,12 +56,19 @@ jobs:
     name: coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master (toolchain via input)
+        with:
+          toolchain: stable
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
         with:
           tool: cargo-llvm-cov
       # The e2e suite spawns the real binary; the test harness forwards the
@@ -72,8 +86,14 @@ jobs:
     name: cargo-deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
         with:
           command: check
 
@@ -84,10 +104,15 @@ jobs:
       contents: read
       pull-requests: read # gitleaks lists PR commits on pull_request runs
     steps:
-      - uses: actions/checkout@v7
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # full history for the secret sweep
-      - uses: gitleaks/gitleaks-action@v3
+          persist-credentials: false
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -95,10 +120,16 @@ jobs:
     name: docker build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Build image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           load: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,14 @@ jobs:
       minor: ${{ steps.resolve.outputs.minor }}
       tag: ${{ steps.resolve.outputs.tag }}
     steps:
-      - uses: actions/checkout@v7
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        # credentials kept: this job pushes the minted v* tag
       - id: resolve
+
         name: Resolve version from Cargo.toml; mint the tag on dispatch
         run: |
           set -euo pipefail
@@ -91,21 +97,27 @@ jobs:
       contents: read
       packages: write # push per-arch image by digest
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       # Labels only — tags are applied by the merge job on the manifest.
       - id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.IMAGE }}
       - id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -125,7 +137,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/digests"
           digest="${{ steps.build.outputs.digest }}"
           touch "$RUNNER_TEMP/digests/${digest#sha256:}"
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digest-${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
@@ -140,7 +152,7 @@ jobs:
           docker cp "$cid:/nim-proxy" "nim-proxy-${{ matrix.arch }}"
           docker rm "$cid" >/dev/null
           tar -czf "nim-proxy-${{ needs.prepare.outputs.version }}-linux-${{ matrix.arch }}.tar.gz" "nim-proxy-${{ matrix.arch }}"
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-${{ matrix.arch }}
           path: nim-proxy-*.tar.gz
@@ -158,14 +170,18 @@ jobs:
     outputs:
       digest: ${{ steps.manifest.outputs.digest }}
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@v4
-      - uses: actions/download-artifact@v8
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: digest-*
           path: ${{ runner.temp }}/digests
@@ -185,22 +201,22 @@ jobs:
             --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
       - name: Sign image (keyless)
         run: cosign sign --yes "${IMAGE}@${{ steps.manifest.outputs.digest }}"
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: ${{ env.IMAGE }}
           subject-digest: ${{ steps.manifest.outputs.digest }}
           push-to-registry: true
       - name: Generate SBOM (SPDX)
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.IMAGE }}@${{ steps.manifest.outputs.digest }}
           format: spdx-json
           output-file: nim-proxy-sbom.spdx.json
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: nim-proxy-sbom.spdx.json
@@ -213,12 +229,16 @@ jobs:
     permissions:
       contents: write # create the release
     steps:
-      - uses: actions/download-artifact@v8
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: "{binary-*,sbom}"
           merge-multiple: true
       - name: Publish release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           # Explicit: on the dispatch path the triggering ref is a branch, so
           # the action must not derive the release tag from it.

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,45 @@
+name: OpenSSF Scorecard
+
+# Automated supply-chain-posture scoring (token permissions, pinned
+# dependencies, branch protection, dangerous workflow patterns, …). Results
+# land in the Security → Code scanning tab and feed the README badge via the
+# public Scorecard API.
+on:
+  schedule:
+    - cron: "27 7 * * 1" # weekly, Monday 07:27 UTC
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF to code scanning
+      id-token: write # publish results to the Scorecard API (badge)
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet.
+### Changed
+
+- **Workflow hardening to the OpenSSF-recommended baseline**: every GitHub
+  Actions step is pinned to a full commit SHA (Dependabot keeps the pins
+  fresh); all CI/release jobs start with `step-security/harden-runner` egress
+  monitoring (audit mode); checkouts that don't push drop their credentials
+  (`persist-credentials: false`); and a weekly OpenSSF Scorecard workflow
+  publishes the repo's supply-chain score to code scanning and the README
+  badge.
 
 ## [0.6.2] - 2026-07-04
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ One job: obey the NIM speed limit so your agent harness never sees it.
 
 [![CI](https://github.com/miztertea/nim-proxy/actions/workflows/ci.yml/badge.svg)](https://github.com/miztertea/nim-proxy/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/miztertea/nim-proxy)](https://github.com/miztertea/nim-proxy/releases/latest)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/miztertea/nim-proxy/badge)](https://scorecard.dev/viewer/?uri=github.com/miztertea/nim-proxy)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Container: GHCR](https://img.shields.io/badge/container-ghcr.io-2496ED?logo=docker&logoColor=white)](https://github.com/miztertea/nim-proxy/pkgs/container/nim-proxy)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,6 +68,17 @@ reasoning behind the current defenses is documented in the knowledge base:
   and all responses carry a strict `Content-Security-Policy` plus
   anti-framing/anti-sniffing headers.
 
+- **Supply chain / release integrity.** Every GitHub Actions step is pinned to
+  a full commit SHA (Dependabot keeps pins fresh); every CI/release job runs
+  [`step-security/harden-runner`](https://github.com/step-security/harden-runner)
+  egress monitoring; an [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/miztertea/nim-proxy)
+  workflow scores the posture weekly (badge in the README). Release images are
+  built on native runners from the repo Dockerfile, signed with keyless cosign,
+  and published with SLSA build provenance and an SPDX SBOM — all anchored to
+  the multi-arch manifest digest. `v*` release tags are protected by a ruleset
+  (no updates, deletions, or force pushes), so a published tag can never be
+  silently moved.
+
 **In scope** (please report):
 
 - Authentication or authorization bypass (reaching `/v1/*` in `keyed` mode, or

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,29 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-04] ingest — actions hardening + native-runner releases (v0.6.2+)
+
+Two follow-ups to the release automation, in the order they shipped:
+
+- **v0.6.2 — native-runner split**: the release image build moved from one
+  QEMU-emulated multi-arch buildx invocation to two parallel native jobs
+  (amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`), pushed by digest
+  and stitched by a `merge` job; cosign/provenance/SBOM anchor to the manifest
+  digest. Measured: v0.6.1 (QEMU) 34m12s → v0.6.2 (native) **5m18s**, same
+  artifact set. Buildx GHA caching + CI concurrency groups landed alongside.
+- **Workflow hardening (OpenSSF baseline)**: all actions pinned to full commit
+  SHAs (Dependabot's `github-actions` ecosystem keeps pins fresh);
+  `step-security/harden-runner` (egress audit) opens every job;
+  `persist-credentials: false` on non-pushing checkouts (the release `prepare`
+  job keeps credentials — it pushes the minted tag); a weekly OpenSSF
+  Scorecard workflow publishes to code scanning + a README badge. The SLSA L3
+  isolated builder was considered and deferred (documented in SECURITY.md
+  posture; revisit if consumers demand L3). A `v*` tag ruleset (no
+  update/delete/force-push; admin bypass) was applied in repo settings —
+  "Restrict creations" is deliberately unchecked because the built-in
+  github-actions app cannot be added to bypass lists on personal repos and
+  the dispatch path mints tags with `GITHUB_TOKEN`.
+
 ## [2026-07-04] ingest — release automation: workflow_dispatch cuts releases (v0.6.1)
 
 Tagging by hand (`git tag` + `git push`) was the one release step that


### PR DESCRIPTION
## What & why

Hardening PR (B) of the actions-optimization plan — adopts the three standards the "hardened workflow" ecosystem is built on:

1. **Full commit-SHA pins on every action** (with `# vX.Y.Z` comments). Mutable tags like `@v7` are the classic supply-chain hole — a compromised action repo can move them under you. All 16 distinct actions across CI + Release are resolved to their peeled commit SHAs; Dependabot's existing `github-actions` ecosystem watches and rewrites SHA pins, so they stay fresh without toil. `dtolnay/rust-toolchain` pins to a commit and selects `stable` via the `toolchain:` input (its ref doubles as the toolchain selector, so a bare pin would have frozen the toolchain too).
2. **`step-security/harden-runner`** as the first step of **every** job in CI, Release, and Scorecard — runner egress monitoring in `audit` mode (the mitigation class for tj-actions/codecov-style exfiltration). Tightening to `block` with per-job allowlists is a follow-up once a few runs of telemetry accumulate.
3. **OpenSSF Scorecard** (`.github/workflows/scorecard.yml`): weekly + on push to main, SARIF into the Security → Code scanning tab, results published to the Scorecard API, badge added to the README.

Plus the Scorecard-aligned detail: `persist-credentials: false` on every checkout that doesn't push — with one deliberate exception, the release `prepare` job, which keeps credentials because it pushes the minted `v*` tag (commented inline).

SECURITY.md gains a supply-chain-posture paragraph (pins, harden-runner, Scorecard, manifest-digest signing/provenance/SBOM, protected `v*` tags). Deliberately deferred, recorded in the knowledge log: the SLSA L3 isolated builder — real benefit only if consumers demand formal L3, and it takes build ownership away from the repo Dockerfile.

No version bump: these changes ride into the next release naturally (nothing here alters what ships).

## How it was tested

- All three workflow files parse as valid YAML; no unpinned `@vN` or `@stable` refs remain (verified by grep).
- CI on this PR exercises the pinned + hardened jobs directly — every check running is running on the new pins with harden-runner active.
- The Scorecard workflow runs on merge to main (and weekly thereafter); the badge populates after its first published run.
- Release-path pins get their live validation on the next dispatch release.

## Checklist

- [x] **What/why** is explained above (and an issue is linked if one exists).
- [ ] **Tests added or updated** — n/a: workflow/docs only; this PR's own CI is the test.
- [x] `cargo fmt --check` is clean (no Rust changes).
- [x] `cargo clippy --all-targets -- -D warnings` is clean (no Rust changes).
- [x] `cargo test` passes locally (no Rust changes).
- [x] **Docs updated in lockstep** — SECURITY.md posture section, README badge.
- [x] **Knowledge base updated in the same PR** — dated `log.md` entry covering the hardening set, the deferred SLSA L3 decision, and the tag-ruleset nuance (why "Restrict creations" stays unchecked).
- [x] **Security considered** — this PR *is* the security work: SHA pins, egress monitoring, credential-free checkouts, automated posture scoring.
- [ ] **Rate-limiting proven** — n/a: no proxy behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av)_