### PR TITLE
Add CodeQL, workflow lint, dependency review, and a scheduled audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,33 @@
+name: Security audit
+
+# A new RUSTSEC advisory can publish between pushes; without a schedule it
+# would only surface at the next commit's CI run. This weekly run checks the
+# existing lockfile against the advisory database — same cargo-deny, same
+# deny.toml as the CI gate, so there is no second policy to maintain. A
+# failure shows as a red scheduled run and GitHub emails the maintainer.
+#
+# Note: GitHub auto-disables scheduled workflows after 60 days without repo
+# activity — acceptable; an inactive repo isn't shipping releases either.
+on:
+  schedule:
+    - cron: "42 6 * * 1" # weekly, Monday 06:42 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  advisories:
+    name: cargo-deny advisories
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+        with:
+          command: check advisories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,74 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  lint-workflows:
+    name: workflow lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # zizmor SARIF → code scanning
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      # actionlint: schema- and shellcheck-level correctness for the workflow
+      # YAML — any finding is a real bug, so it always gates. Not in
+      # install-action's registry, so it's a pinned release binary verified
+      # against the published checksum (bump version + checksum together).
+      - name: Install actionlint
+        run: |
+          curl -fsSLO https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint_1.7.12_linux_amd64.tar.gz" | sha256sum -c -
+          tar xzf actionlint_1.7.12_linux_amd64.tar.gz actionlint
+      - name: actionlint
+        run: ./actionlint -color
+      # zizmor: GitHub-Actions security lint (template injection, cache
+      # poisoning, unpinned actions, …). The action uploads SARIF so every
+      # severity is triageable in code scanning but never fails the build;
+      # the CLI step below is the gate, and only on high-severity findings so
+      # new low-noise rules can't block unrelated PRs.
+      - name: zizmor (SARIF → code scanning)
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+      - uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
+        with:
+          tool: zizmor
+      - name: zizmor (gate on high severity)
+        run: zizmor --min-severity high .github/workflows/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # enables the online audits (same set as the SARIF run)
+
+  dependency-review:
+    name: dependency review
+    # The action diffs the PR's dependency graph against the base via the
+    # GitHub API — it only makes sense (and only works) on pull requests.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # posts the failure summary as a PR comment
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      # Blocks PRs that introduce crates with known vulnerabilities
+      # (Cargo.lock is covered by the dependency graph). License policy stays
+      # cargo-deny's job — deny.toml is the single source of license truth,
+      # and double-gating against ClearlyDefined's spottier crate data would
+      # only drift.
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: low
+          license-check: false
+          comment-summary-in-pr: on-failure
+
   docker:
     name: docker build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
       # against the published checksum (bump version + checksum together).
       - name: Install actionlint
         run: |
+          set -euo pipefail
           curl -fsSLO https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
           echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint_1.7.12_linux_amd64.tar.gz" | sha256sum -c -
           tar xzf actionlint_1.7.12_linux_amd64.tar.gz actionlint
@@ -150,11 +151,11 @@ jobs:
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
       - uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
         with:
-          tool: zizmor
+          tool: zizmor@1 # gate pinned to the same major the SARIF action bundles
       - name: zizmor (gate on high severity)
         run: zizmor --min-severity high .github/workflows/
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # enables the online audits (same set as the SARIF run)
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # enables the online audits
 
   dependency-review:
     name: dependency review
@@ -170,9 +171,7 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
+      # No checkout: the action works purely against the dependency-graph API.
       # Blocks PRs that introduce crates with known vulnerabilities
       # (Cargo.lock is covered by the dependency graph). License policy stays
       # cargo-deny's job — deny.toml is the single source of license truth,
@@ -210,13 +209,14 @@ jobs:
           # since v0.6.0); /health is public regardless, and the built-in
           # HEALTHCHECK must go healthy on it.
           docker run -d --name smoke -p 8000:8000 nim-proxy:ci
-          for i in $(seq 1 30); do
+          ok=0
+          for _ in $(seq 1 30); do
             if curl -fsS http://127.0.0.1:8000/health > /dev/null 2>&1; then ok=1; break; fi
             sleep 1
           done
           [ "$ok" = 1 ] || { docker logs smoke; exit 1; }
           # HEALTHCHECK inside the container must also pass.
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             s=$(docker inspect -f '{{.State.Health.Status}}' smoke)
             [ "$s" = healthy ] && exit 0
             sleep 1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+# Static analysis (SAST) for the Rust source. CodeQL's Rust support runs with
+# build-mode: none — the extractor parses source without a cargo build — so
+# the scan stays cheap. Findings land in Security → Code scanning; the weekly
+# cron re-scans unchanged code as new queries ship.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "31 6 * * 2" # weekly, Tuesday 06:31 UTC
+
+# Least privilege by default; the job opts into SARIF upload only.
+permissions:
+  contents: read
+
+# A new push to the same ref supersedes the running scan (but never cancel
+# main's post-merge runs).
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  analyze:
+    name: codeql (rust)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload analysis results to code scanning
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3
+        with:
+          languages: rust
+          build-mode: none
+      - uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3
+        with:
+          category: "/language:rust"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,9 @@ permissions:
 # One release at a time, never cancelled mid-flight: a cancelled run could
 # leave a signed manifest without its GitHub release, or a minted tag without
 # artifacts. A single global group (not per-ref) also serializes a dispatch
-# racing a tag push — concurrent runs queue instead.
+# racing a tag push. Note GitHub keeps at most ONE pending run per group —
+# a third trigger replaces the queued one (re-run it manually if that ever
+# happens); it never cancels the run in progress.
 concurrency:
   group: release
   cancel-in-progress: false
@@ -203,11 +205,14 @@ jobs:
         working-directory: ${{ runner.temp }}/digests
         run: |
           set -euo pipefail
+          # Each downloaded artifact file is named by its image digest hex.
+          refs=()
+          for d in *; do refs+=("${IMAGE}@sha256:${d}"); done
           docker buildx imagetools create \
             -t "${IMAGE}:${{ needs.prepare.outputs.version }}" \
             -t "${IMAGE}:${{ needs.prepare.outputs.minor }}" \
             -t "${IMAGE}:latest" \
-            $(printf "${IMAGE}@sha256:%s " *)
+            "${refs[@]}"
           digest=$(docker buildx imagetools inspect \
             "${IMAGE}:${{ needs.prepare.outputs.version }}" \
             --format '{{json .Manifest.Digest}}' | tr -d '"')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,14 @@ on:
 permissions:
   contents: read
 
+# One release at a time, never cancelled mid-flight: a cancelled run could
+# leave a signed manifest without its GitHub release, or a minted tag without
+# artifacts. A single global group (not per-ref) also serializes a dispatch
+# racing a tag push — concurrent runs queue instead.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 env:
   IMAGE: ghcr.io/${{ github.repository }}
 
@@ -43,16 +51,20 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        # credentials kept: this job pushes the minted v* tag
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 # zizmor: ignore[artipacked] credentials kept deliberately: this job pushes the minted v* tag
       - id: resolve
 
         name: Resolve version from Cargo.toml; mint the tag on dispatch
+        # Context values reach the script via env, never inline `${{ }}` in
+        # the run block (template-injection hygiene).
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           version=$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [ "$GITHUB_REF_NAME" != "${{ github.event.repository.default_branch }}" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$GITHUB_REF_NAME" != "$DEFAULT_BRANCH" ]; then
               echo "::error::dispatch releases run from the default branch only (got $GITHUB_REF_NAME)"
               exit 1
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CodeQL static analysis** for the Rust source on every PR, push to main,
+  and a weekly re-scan (`build-mode: none` — no cargo build needed).
+- **Workflow lint job in CI**: `actionlint` (correctness, always gates) and
+  `zizmor` (Actions security lint; every severity is uploaded to code
+  scanning, high-severity findings fail the build).
+- **Dependency review on PRs**: introducing a crate with a known
+  vulnerability now fails the PR (licenses stay `cargo-deny`'s job).
+- **Weekly advisories audit** (`audit.yml`): the lockfile is checked against
+  the RUSTSEC database on a schedule, so a new advisory surfaces within a
+  week instead of at the next push.
+
 ### Changed
+
+- The release workflow now runs under a global concurrency group (one release
+  at a time, queued rather than cancelled), and the `prepare` script takes
+  workflow-context values via `env` instead of inline template expansion.
 
 - **Workflow hardening to the OpenSSF-recommended baseline**: every GitHub
   Actions step is pinned to a full commit SHA (Dependabot keeps the pins

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,7 +72,11 @@ reasoning behind the current defenses is documented in the knowledge base:
   a full commit SHA (Dependabot keeps pins fresh); every CI/release job runs
   [`step-security/harden-runner`](https://github.com/step-security/harden-runner)
   egress monitoring; an [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/miztertea/nim-proxy)
-  workflow scores the posture weekly (badge in the README). Release images are
+  workflow scores the posture weekly (badge in the README). CodeQL scans the
+  Rust source on every change; the workflows themselves are linted by
+  `actionlint` + `zizmor` in CI; PRs that introduce a known-vulnerable crate
+  are blocked by dependency review; and a weekly scheduled `cargo-deny`
+  advisories run catches new RUSTSEC advisories between pushes. Release images are
   built on native runners from the repo Dockerfile, signed with keyless cosign,
   and published with SLSA build provenance and an SPDX SBOM — all anchored to
   the multi-arch manifest digest. `v*` release tags are protected by a ruleset

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,34 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-04] ingest — repo-rigor pass 1: SAST, workflow lint, dep review, scheduled audit
+
+Scorecard run #1 scored five checks at 0; the fixable ones drove this PR
+(Code-Review and Maintained are structural for a 2-day-old single-maintainer
+repo — accepted, time fixes them):
+
+- **CodeQL for Rust** (`codeql.yml`): GA since CodeQL 2.23.3 with
+  `build-mode: none`, so the scan needs no cargo build (~4–8 min). Fixes
+  SAST=0. clippy-SARIF-to-code-scanning was rejected — Scorecard's SAST check
+  doesn't recognize it.
+- **Workflow lint** (`lint-workflows` in ci.yml): `actionlint` always gates
+  (correctness); `zizmor` uploads all severities as SARIF and gates only on
+  high so new low-noise rules can't block unrelated PRs. actionlint isn't in
+  install-action's registry → pinned release binary, checksum-verified.
+  zizmor immediately paid for itself: it flagged a real template-injection
+  (`${{ github.event.repository.default_branch }}` inline in the release
+  prepare script) — now passed via `env`. The prepare checkout's kept
+  credentials carry an inline `zizmor: ignore[artipacked]` with reason.
+- **Dependency review** on PRs (vulnerabilities only; `license-check: false`
+  because deny.toml is the single license policy — ClearlyDefined's crate
+  data is spottier and would double-gate with drift).
+- **Weekly advisories run** (`audit.yml`): same cargo-deny + deny.toml as CI
+  (rustsec/audit-check rejected — second ignore-list format). Failure = red
+  scheduled run + GitHub's failure email.
+- **Release concurrency**: global `release` group, `cancel-in-progress:
+  false` — queue, never cancel a half-done signed release; also serializes a
+  dispatch racing a tag push.
+
 ## [2026-07-04] ingest — actions hardening + native-runner releases (v0.6.2+)
 
 Two follow-ups to the release automation, in the order they shipped:


### PR DESCRIPTION
## What & why

Repo-rigor pass 1 (of the approved best-in-class plan), driven by Scorecard run #1 — SAST=0 was the biggest fixable gap:

- **`codeql.yml`** — CodeQL static analysis for the Rust source (`build-mode: none`, so no cargo build) on every PR, push to main, and a weekly cron. SARIF lands in Security → Code scanning. Fixes Scorecard SAST=0.
- **`ci.yml` `workflow lint` job** — `actionlint` (correctness, always gates) + `zizmor` (Actions security lint; every severity uploaded as SARIF, only high-severity findings fail the build). actionlint isn't in install-action's registry, so it installs as a pinned, checksum-verified release binary.
- **`ci.yml` `dependency review` job** — PRs that introduce a crate with a known vulnerability now fail. `license-check: false` deliberately: deny.toml is the single license policy.
- **`audit.yml`** — weekly `cargo-deny check advisories` against the same deny.toml, so a new RUSTSEC advisory surfaces within a week instead of at the next push.
- **`release.yml`** — global `release` concurrency group (queue, never cancel a half-done signed release; also serializes a dispatch racing a tag push), and the `prepare` script now takes workflow-context values via `env` instead of inline `${{ }}` — a genuine template-injection finding from zizmor's first local run.

All new steps follow the house baseline: SHA-pinned with version comments, harden-runner first, least-priv permissions, `persist-credentials: false`.

## How it was tested

- `actionlint` 1.7.12 (checksum-verified binary) clean on all five workflows.
- `zizmor` 1.26.1 at `--min-severity low` (offline audits): zero findings after fixing the template-injection it flagged and annotating the deliberate credential-keep in `prepare` (`zizmor: ignore[artipacked]`).
- No Rust changes — CI runs the full suite as usual.

## Checklist

- [x] **What/why** is explained above (and an issue is linked if one exists).
- [x] **Tests added or updated** — n/a, workflow-only change; the new jobs are themselves the verification and run on this PR.
- [x] `cargo fmt --check` is clean.
- [x] `cargo clippy --all-targets -- -D warnings` is clean (zero warnings).
- [x] `cargo test` passes locally.
- [x] **Docs updated in lockstep** — SECURITY.md supply-chain posture updated.
- [x] **Knowledge base updated in the same PR** — dated `knowledge/log.md` entry with the decisions and rejections (clippy-SARIF, rustsec/audit-check).
- [x] **Security considered** — this PR is the security change; no auth/sanitizing/dashboard surface touched.
- [x] **Rate-limiting proven** — n/a, no pacing/pool/dispatcher/affinity changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av)_