### PR TITLE
Add repo hygiene files, package metadata, and release-notes taxonomy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# Editor-agnostic formatting baseline. rustfmt remains the authority for
+# Rust; this keeps every other file type (YAML, TOML, Markdown, HTML)
+# consistent across editors.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.rs]
+indent_size = 4
+
+[*.md]
+# A trailing double-space is a hard line break in Markdown — don't strip it.
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Normalize line endings to LF in the repo and in checkouts (matches
+# .editorconfig), so Windows contributors can't introduce CRLF churn.
+* text=auto eol=lf
+
+# Binary assets — never diff, never normalize.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.ico binary
+
+# The design/ prototypes are reference documents (~220 KB of generated HTML),
+# not shipped source — keep them out of GitHub's language statistics so the
+# repo reads as the Rust project it is. src/*.html stays counted: the embedded
+# dashboard and setup wizard are real shipped source.
+design/** linguist-documentation

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+# Template for GitHub's generated release notes (the Release workflow passes
+# generate_release_notes: true). Categories key on PR labels; Dependabot
+# labels its PRs `dependencies` automatically, so its bumps bucket without
+# any manual labeling.
+changelog:
+  exclude:
+    labels: [skip-changelog]
+  categories:
+    - title: Security
+      labels: [security]
+    - title: Breaking changes
+      labels: [breaking-change]
+    - title: Features
+      labels: [enhancement]
+    - title: Fixes
+      labels: [bug]
+    - title: Documentation
+      labels: [documentation]
+    - title: Dependencies
+      labels: [dependencies]
+    - title: Other changes
+      labels: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,29 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
+  msrv:
+    name: msrv
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      # rust-toolchain.toml (channel = stable) outranks `rustup default`, so
+      # drop it here — this job's whole point is building with the declared
+      # minimum, not stable. Keep this toolchain in lockstep with
+      # `rust-version` in Cargo.toml.
+      - run: rm rust-toolchain.toml
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master (toolchain via input)
+        with:
+          toolchain: "1.87"
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Check with the minimum supported Rust
+        run: cargo check --locked --all-targets
+
   deny:
     name: cargo-deny
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,18 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      # The build-mode:none Rust extractor expands macros with rust-analyzer
+      # machinery, which needs the standard-library sources (rust-src) and the
+      # dependency sources in the cargo cache. Without them, run #1 reported
+      # every file "extracted with errors" — even format!/vec! failed to
+      # expand — and the scan ran hollow while the job stayed green.
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master (toolchain via input)
+        with:
+          toolchain: stable
+          components: rust-src
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Prefetch dependency sources for the extractor
+        run: cargo fetch --locked
       - uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3
         with:
           languages: rust

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,18 +36,14 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      # The build-mode:none Rust extractor expands macros with rust-analyzer
-      # machinery, which needs the standard-library sources (rust-src) and the
-      # dependency sources in the cargo cache. Without them, run #1 reported
-      # every file "extracted with errors" — even format!/vec! failed to
-      # expand — and the scan ran hollow while the job stayed green.
-      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master (toolchain via input)
-        with:
-          toolchain: stable
-          components: rust-src
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - name: Prefetch dependency sources for the extractor
-        run: cargo fetch --locked
+      # Known limitation, not a config problem: the Rust extractor reports
+      # every file "extracted with errors" because macro expansion (even of
+      # std macros like format!) is not fully supported yet — see
+      # github/codeql#19966, #19982, #20659. Verified empirically: adding a
+      # toolchain with rust-src plus `cargo fetch` changes nothing (identical
+      # diagnostics), so no setup steps are cargo-culted here. The queries
+      # still run on all non-macro code; expect the "extracted with errors"
+      # metric to drop as the extractor matures with CodeQL bundle updates.
       - uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3
         with:
           languages: rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Repo hygiene & metadata**: `.editorconfig`, `.gitattributes` (LF
+  normalization + language-stats fix so the repo reads as Rust, not HTML),
+  `rust-toolchain.toml` (stable + rustfmt/clippy for contributors),
+  `SUPPORT.md`, and a release-notes template (`.github/release.yml`) that
+  groups generated notes by PR label. Cargo.toml now declares
+  `rust-version = "1.87"` (measured with `cargo msrv find`) plus
+  keywords/categories/homepage, and a new CI `msrv` job builds with exactly
+  that toolchain. The Docker build base is digest-pinned. README gains the
+  OpenSSF Best Practices badge and a contributing/security/support section.
+
 - **CodeQL static analysis** for the Rust source on every PR, push to main,
   and a weekly re-scan (`build-mode: none` — no cargo build needed).
 - **Workflow lint job in CI**: `actionlint` (correctness, always gates) and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,13 @@ edition = "2021"
 description = "Rate-limit-aware OpenAI-compatible proxy for NVIDIA NIM with multi-key load balancing"
 license = "MIT"
 repository = "https://github.com/miztertea/nim-proxy"
+homepage = "https://github.com/miztertea/nim-proxy"
 readme = "README.md"
+# Measured with `cargo msrv find` and verified with --all-targets; CI's
+# `msrv` job builds with exactly this toolchain so the claim can't rot.
+rust-version = "1.87"
+keywords = ["proxy", "openai", "rate-limiting", "nvidia", "llm"]
+categories = ["network-programming", "web-programming::http-server"]
 
 [dependencies]
 axum = "0.8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@
 #
 # Multi-arch: buildx sets TARGETARCH per requested platform and runs this stage
 # emulated on that arch, so we build for the matching native musl target.
-FROM rust:1-alpine AS build
+# Digest-pinned so a retargeted tag can't silently change the build base;
+# Dependabot's docker ecosystem advances the digest as the tag moves.
+FROM rust:1-alpine@sha256:a41f7740f8b45d45795624eec13a8b42263cc700f19f7e4e86e04d3dda08a479 AS build
 RUN apk add --no-cache musl-dev gcc
 ENV RUSTFLAGS="-C target-feature=+crt-static"
 # Map Docker's arch to the Rust musl target. The explicit --target (below) looks

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ One job: obey the NIM speed limit so your agent harness never sees it.
 [![CI](https://github.com/miztertea/nim-proxy/actions/workflows/ci.yml/badge.svg)](https://github.com/miztertea/nim-proxy/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/miztertea/nim-proxy)](https://github.com/miztertea/nim-proxy/releases/latest)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/miztertea/nim-proxy/badge)](https://scorecard.dev/viewer/?uri=github.com/miztertea/nim-proxy)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13484/badge)](https://www.bestpractices.dev/projects/13484)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Container: GHCR](https://img.shields.io/badge/container-ghcr.io-2496ED?logo=docker&logoColor=white)](https://github.com/miztertea/nim-proxy/pkgs/container/nim-proxy)
 
@@ -292,6 +293,17 @@ It exits non-zero on any client-visible failure or a single upstream rate violat
 ## Project knowledge base
 
 The `knowledge/` directory holds the project's long-term memory — design decisions with their reasoning, validated research about NIM, per-component architecture notes, and runbooks, all cross-linked markdown. Start at [`knowledge/index.md`](knowledge/index.md). [`AGENTS.md`](AGENTS.md) tells AI agents how to maintain it.
+
+## Contributing, security & support
+
+- **Contributing** — PRs welcome; read [CONTRIBUTING.md](CONTRIBUTING.md)
+  first (build/test commands, the knowledge-base rules, and the zero-warning
+  bar). For anything beyond a small fix, open an issue before writing code.
+- **Security** — report vulnerabilities privately via
+  [SECURITY.md](SECURITY.md), never in a public issue.
+- **Support** — questions go to
+  [Discussions](https://github.com/miztertea/nim-proxy/discussions); see
+  [SUPPORT.md](SUPPORT.md) for the routing map.
 
 ## License
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,15 @@
+# Getting help
+
+- **Questions and usage help** — open a thread in
+  [GitHub Discussions](https://github.com/miztertea/nim-proxy/discussions).
+  Good first stops: the [README](README.md) (quick start, client recipes,
+  FAQ) and the [knowledge base](knowledge/index.md) (why things work the way
+  they do).
+- **Bugs** — file a
+  [bug report](https://github.com/miztertea/nim-proxy/issues/new/choose)
+  with the version, your `/v1` mode (keyed/open), and a minimal reproduction.
+- **Security problems** — never open a public issue; follow
+  [SECURITY.md](SECURITY.md) (private GitHub security advisory).
+
+nim-proxy is volunteer-maintained; Discussions and issues are checked
+regularly, but there is no SLA.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -27,6 +27,15 @@ description: Append-only record of ingests, decisions, and maintenance passes.
   1.XX rejected as weekly bump chores), SUPPORT.md, Best Practices badge
   (bestpractices.dev project 13484, registered by the maintainer same day),
   README contributing/security/support section.
+- **CodeQL Rust caveat (investigated, upstream)**: the maintainer spotted
+  "11/11 files extracted with errors" in a green CodeQL run. Every
+  diagnostic is a failed macro expansion — including std macros like
+  `format!` — which is an open limitation of the Rust extractor
+  (github/codeql#19966, #19982, #20659), not a local config problem: adding
+  a rust-src toolchain + `cargo fetch` produced byte-identical diagnostics
+  (195 suppressed, 0/11 clean) and was reverted rather than cargo-culted.
+  Queries still run on all non-macro code. Watch the "extracted with
+  errors" metric drop as CodeQL bundles update.
 
 ## [2026-07-04] ingest — repo-rigor pass 1: SAST, workflow lint, dep review, scheduled audit
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,28 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-04] ingest — repo-rigor pass 2: hygiene, metadata, MSRV, release-notes taxonomy
+
+- **MSRV**: measured honestly with `cargo msrv find` → **1.87.0**, re-verified
+  with `--all-targets` (dev-deps included). Declared in Cargo.toml
+  `rust-version` and enforced by a CI `msrv` job that must `rm
+  rust-toolchain.toml` first — the toolchain file (channel=stable) outranks
+  `rustup default`, so without the rm the job would silently test stable.
+- **Language stats**: GitHub listed the repo as an HTML project (design/
+  prototypes ≈220 KB HTML vs ≈198 KB Rust). `.gitattributes` marks `design/**`
+  linguist-documentation; `src/*.html` deliberately stays counted (shipped
+  source).
+- **Release notes**: `.github/release.yml` groups generated notes by PR label
+  (Dependabot's default `dependencies` label buckets its bumps for free);
+  `skip-changelog` opts a PR out. Labels to create in repo settings:
+  `security`, `breaking-change`, `skip-changelog`.
+- **Docker base digest-pinned** (`rust:1-alpine@sha256:a41f…`); Dependabot's
+  docker ecosystem advances the pin. `FROM scratch` has no digest to pin.
+- Also: `.editorconfig`, `rust-toolchain.toml` (stable channel — a pinned
+  1.XX rejected as weekly bump chores), SUPPORT.md, Best Practices badge
+  (bestpractices.dev project 13484, registered by the maintainer same day),
+  README contributing/security/support section.
+
 ## [2026-07-04] ingest — repo-rigor pass 1: SAST, workflow lint, dep review, scheduled audit
 
 Scorecard run #1 scored five checks at 0; the fixable ones drove this PR

--- a/knowledge/ops/release.md
+++ b/knowledge/ops/release.md
@@ -71,7 +71,11 @@ cosign verify ghcr.io/miztertea/nim-proxy:X.Y.Z \
 ```
 
 Also check the GitHub Release page: two `nim-proxy-X.Y.Z-linux-*.tar.gz` assets
-plus `nim-proxy-sbom.spdx.json`, and generated release notes.
+plus `nim-proxy-sbom.spdx.json`, and generated release notes. The notes are
+grouped by PR label via `.github/release.yml` (Security / Breaking changes /
+Features=`enhancement` / Fixes=`bug` / Documentation / Dependencies —
+Dependabot's default label / Other; `skip-changelog` excludes a PR) — so
+label PRs as they merge, not at release time.
 
 ## Fixing a bad release
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,9 @@
+# Contributor convenience: rustup auto-installs the matching toolchain and
+# the components the pre-PR checks need (cargo fmt / cargo clippy) on first
+# build. Tracks stable — CI installs the same channel — rather than a pinned
+# 1.XX, which would only create weekly bump chores. The declared minimum
+# supported version lives in Cargo.toml `rust-version` and is enforced by
+# CI's `msrv` job.
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## What & why

Repo-rigor pass 2 (of the approved plan) — hygiene, honest metadata, and release-notes structure:

- **`.gitattributes`** — LF normalization + `design/**` marked `linguist-documentation`, so GitHub's language stats stop reporting this Rust project as an HTML one (the ~220 KB of generated design-prototype HTML outweighed the ~198 KB of Rust). `src/*.html` deliberately stays counted — the embedded dashboard is shipped source.
- **`.editorconfig`** — utf-8/LF/final-newline baseline; rustfmt stays the authority for `.rs`.
- **`rust-toolchain.toml`** — `stable` + rustfmt/clippy components for contributors; a pinned 1.XX was rejected (weekly bump chores, no benefit).
- **`Cargo.toml`** — `rust-version = "1.87"`, measured with `cargo msrv find` and re-verified with `--all-targets`; plus keywords/categories/homepage. A new CI **`msrv` job** builds with exactly that toolchain — note it `rm`s `rust-toolchain.toml` first, because the toolchain file outranks `rustup default` and would silently retarget the job to stable.
- **`Dockerfile`** — `rust:1-alpine` digest-pinned (manifest-list digest, current as of 2026-07-01); Dependabot's docker ecosystem advances the pin.
- **`.github/release.yml`** — generated release notes grouped by PR label (Security / Breaking / Features / Fixes / Docs / Dependencies / Other, `skip-changelog` excludes). Dependabot's default `dependencies` label buckets its bumps with zero config.
- **`SUPPORT.md`** + **README** — routing map (Discussions / issue forms / SECURITY.md), the OpenSSF Best Practices badge (project 13484, registered today), and a contributing/security/support section.

## How it was tested

- `cargo check --locked --all-targets` under a locally installed **1.87.0** toolchain: clean (this is what the new msrv job runs).
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`: clean.
- `actionlint` (with shellcheck) and `zizmor --min-severity low`: no findings on the edited ci.yml.
- `git add --renormalize .` under the new `.gitattributes`: zero content changes (repo was already LF-clean).
- `cargo package --list` parses the new metadata without complaint.

## Checklist

- [x] **What/why** is explained above (and an issue is linked if one exists).
- [x] **Tests added or updated** — n/a (hygiene/metadata); the msrv CI job is itself the new enforcement.
- [x] `cargo fmt --check` is clean.
- [x] `cargo clippy --all-targets -- -D warnings` is clean (zero warnings).
- [x] `cargo test` passes locally.
- [x] **Docs updated in lockstep** — README section + badge; SUPPORT.md; release runbook notes the label taxonomy.
- [x] **Knowledge base updated in the same PR** — dated `knowledge/log.md` entry (incl. the rust-toolchain.toml-vs-rustup-default trap); `knowledge/ops/release.md` labeling note.
- [x] **Security considered** — digest-pinned build base; no auth/sanitizing/dashboard surface touched.
- [x] **Rate-limiting proven** — n/a, no pacing/pool/dispatcher/affinity changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av)_