### PR TITLE
Upgrade CodeQL Action v3 → v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,10 +44,10 @@ jobs:
       # diagnostics), so no setup steps are cargo-culted here. The queries
       # still run on all non-macro code; expect the "extracted with errors"
       # metric to drop as the extractor matures with CodeQL bundle updates.
-      - uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3
+      - uses: github/codeql-action/init@8533807ff379ac610d2b2c389c47e7c629d31d13 # v4.36.3
         with:
           languages: rust
           build-mode: none
-      - uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3
+      - uses: github/codeql-action/analyze@8533807ff379ac610d2b2c389c47e7c629d31d13 # v4.36.3
         with:
           category: "/language:rust"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -40,6 +40,6 @@ jobs:
           path: results.sarif
           retention-days: 5
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3
+        uses: github/codeql-action/upload-sarif@8533807ff379ac610d2b2c389c47e7c629d31d13 # v4.36.3
         with:
           sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded the CodeQL Action from v3 to v4 (both `codeql.yml` and the
+  Scorecard SARIF upload), clearing the Node 20 deprecation and the
+  December-2026 v3 sunset warnings.
+
 ### Added
 
 - **Fuzz testing** (`fuzz/` + a weekly smoke-fuzz workflow): cargo-fuzz


### PR DESCRIPTION
## What & why

The latest Scorecard run raised two workflow annotations, both caused by the pinned CodeQL Action still being **v3**:

1. *"Node.js 20 is deprecated … forced to run on Node.js 24: github/codeql-action/upload-sarif@411c4c9…"* — v3 declares `using: node20`.
2. *"CodeQL Action v3 will be deprecated in December 2026 … update to v4."*

Both clear by bumping `github/codeql-action` to **v4.36.3** in the three call sites:
- `codeql.yml` — `init` + `analyze`
- `scorecard.yml` — `upload-sarif`

The action inputs (`languages`, `build-mode`, `category`) are unchanged across the major version, so this is a pin-only change. Dependabot's `github-actions` ecosystem keeps the new SHA fresh.

## How it was tested

- `actionlint` (with shellcheck) + `zizmor --min-severity low`: no findings.
- The CodeQL and Scorecard jobs on this PR are the live verification — expect both green with the two annotations gone.

## Checklist

- [x] **What/why** is explained above.
- [x] **Tests added or updated** — n/a, CI action version bump; the jobs themselves verify.
- [x] `cargo fmt --check` / `cargo clippy -D warnings` / `cargo test` — unaffected (no source change).
- [x] **Docs updated in lockstep** — CHANGELOG `[Unreleased]` entry.
- [x] **Security considered** — keeps the SAST toolchain on a supported, non-deprecated runtime; SHA-pinned.
- [x] **Rate-limiting proven** — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av)_