### PR TITLE
Pin CodeQL Action v4 to its commit SHA, not the tag object

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,10 +44,10 @@ jobs:
       # diagnostics), so no setup steps are cargo-culted here. The queries
       # still run on all non-macro code; expect the "extracted with errors"
       # metric to drop as the extractor matures with CodeQL bundle updates.
-      - uses: github/codeql-action/init@8533807ff379ac610d2b2c389c47e7c629d31d13 # v4.36.3
+      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: rust
           build-mode: none
-      - uses: github/codeql-action/analyze@8533807ff379ac610d2b2c389c47e7c629d31d13 # v4.36.3
+      - uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:rust"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -40,6 +40,6 @@ jobs:
           path: results.sarif
           retention-days: 5
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@8533807ff379ac610d2b2c389c47e7c629d31d13 # v4.36.3
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: results.sarif

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -32,6 +32,19 @@ description: Append-only record of ingests, decisions, and maintenance passes.
   `fuzz/corpus/` is the gitignored working corpus — a local run generates
   thousands of evolved entries that must never be committed.
 
+## [2026-07-04] gotcha — pin the PEELED commit SHA for annotated tags
+
+Bumping CodeQL Action v3→v4 broke the Scorecard `publish_results` step:
+`400 … imposter commit: 8533807f…`. Cause: the bulk `git ls-remote 'refs/tags/v4*'
+| grep -v '^{}'` dropped the peeled entries, so for github/codeql-action's
+**annotated** tags it returned the tag-OBJECT SHA, not the commit. GitHub
+Actions dereferences a tag-object SHA silently (init/analyze ran green), but
+Scorecard's imposter-commit check rejects any pin that isn't a real commit.
+Fix: pin the `refs/tags/vX^{}` peeled commit SHA
+(`54f647b7…` for v4.36.3). Rule going forward: always resolve pins with
+`git ls-remote <repo> refs/tags/TAG 'refs/tags/TAG^{}'` and take the `^{}`
+value when the two differ.
+
 ## [2026-07-04] ingest — repo-rigor pass 2: hygiene, metadata, MSRV, release-notes taxonomy
 
 - **MSRV**: measured honestly with `cargo msrv find` → **1.87.0**, re-verified


### PR DESCRIPTION
## What & why

Scorecard run #9 (on the PR #44 merge) failed. Root cause is a bad pin in that PR: the v3→v4 bump used `8533807f…`, which is **github/codeql-action's annotated-tag object SHA for v4.36.3, not the underlying commit**.

- GitHub Actions silently dereferences a tag-object SHA, so the CodeQL and CI jobs ran green — masking the problem.
- Scorecard's `publish_results` step runs a stricter **imposter-commit** check and correctly rejected it: `400 … workflow verification failed: imposter commit: 8533807f…`, which failed the whole Scorecard run (and skipped the SARIF upload).

Fix: repin to the peeled commit SHA `54f647b7e1bb85c95cddabcd46b0c578ec92bc1a` (`git ls-remote … refs/tags/v4.36.3^{}`) in `codeql.yml` (init + analyze) and `scorecard.yml` (upload-sarif). Every other pin in the repo is a real commit — Scorecard published fine on runs #5–8 — so this is isolated to the v4 bump.

## How it was tested

- Confirmed `8533807f` = tag object, `54f647b7` = commit via `git ls-remote github/codeql-action refs/tags/v4.36.3 'refs/tags/v4.36.3^{}'`.
- `actionlint` + `zizmor --min-severity low`: no findings.
- The Scorecard job on the next push to main is the live verification — expect it green with `publish_results` succeeding again.

## Checklist

- [x] **What/why** explained above.
- [x] **Tests** — n/a (CI pin correction); the Scorecard run itself verifies.
- [x] `cargo fmt` / `clippy` / `test` — unaffected (no source change).
- [x] **Docs updated in lockstep** — `knowledge/log.md` gotcha entry (pin the peeled `^{}` commit for annotated tags).
- [x] **Security considered** — restores the supply-chain publish path; SHA now a verified commit.
- [x] **Rate-limiting proven** — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av)_