### PR TITLE
Release v0.6.3: asset signing, CodeQL triage, coverage 90%+, docs & PR-template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -57,7 +57,7 @@ body:
     attributes:
       label: Version or commit
       description: Output of `nim-proxy --version`, the image tag, or the git commit.
-      placeholder: "0.4.0"
+      placeholder: "0.6.3 / git commit / image tag"
     validations:
       required: true
   - type: input

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,30 +1,86 @@
 <!--
-Thanks for contributing to nim-proxy! Please read CONTRIBUTING.md first.
-Keep the scope tight — nim-proxy is deliberately small.
+Thanks for contributing to nim-proxy! Before opening this PR:
+  • Read CONTRIBUTING.md and AGENTS.md — they define the required checks and the
+    "knowledge base in lockstep" rule that CI and review enforce.
+  • Keep the scope tight — nim-proxy is deliberately small. One thing done well
+    beats many things done partway.
+
+Fill in every section below. Keep the headings even if a section is short; put
+"None" / "N/A" rather than deleting one. In the checklist, tick every box that
+applies and ~~strike through~~ any that genuinely don't with a one-line reason —
+an unexplained blank box reads as "not done", not "not applicable".
 -->
+
+## Summary
+
+<!-- What does this change, in 2-4 sentences? Lead with the outcome. -->
+
+## Type of change
+
+<!-- Tick all that apply. -->
+
+- [ ] Bug fix (no behavior change beyond the fix)
+- [ ] New feature / behavior change
+- [ ] Performance / rate-limiting
+- [ ] Security / hardening
+- [ ] Refactor (no behavior change)
+- [ ] Docs / knowledge base only
+- [ ] CI / build / release infrastructure
+- [ ] Release (version bump)
+
+## Related issues
+
+<!-- "Fixes #123" / "Closes #123" / "Relates to #123", or "None". For anything
+beyond a small fix, an issue should exist first (see CONTRIBUTING.md). -->
 
 ## What & why
 
-<!-- What does this change, and what problem does it solve? Link any issue: Fixes #123 -->
+<!-- The reasoning, not just the diff. What problem does this solve, and what
+alternatives did you weigh? If it changes a decision recorded under
+knowledge/decisions/, link that page (or add a new one — see the checklist). -->
 
 ## How it was tested
 
-<!-- Commands you ran and what you observed. -->
+<!-- The exact commands you ran and what you observed. Paste the key output;
+"tests pass" without evidence is not enough. -->
+
+```sh
+
+```
+
+## Screenshots / output
+
+<!-- Dashboard/UI or notable CLI-output changes. Delete this section if N/A. -->
+
+## Breaking changes & migration
+
+<!-- Anything an operator must act on: config keys, env vars, the `/v1` surface,
+or the on-disk config store format/version. Write "None" if there are none. -->
 
 ## Checklist
 
-- [ ] **What/why** is explained above (and an issue is linked if one exists).
-- [ ] **Tests added or updated** for the new behavior (unit and/or e2e).
+### Code quality
 - [ ] `cargo fmt --check` is clean.
 - [ ] `cargo clippy --all-targets -- -D warnings` is clean (zero warnings).
-- [ ] `cargo test` passes locally.
-- [ ] **Docs updated in lockstep** — README and/or `examples/` reflect the change.
-- [ ] **Knowledge base updated in the same PR** — affected `knowledge/` pages,
-      a new `decisions/` page + `index.md` row for new decisions, and a dated
-      `knowledge/log.md` entry (see AGENTS.md).
-- [ ] **Security considered** — if this touches auth, label sanitizing, or the
-      dashboard `innerHTML`, the fail-closed and escaping invariants are
-      preserved (see SECURITY.md and the auth/input-sanitizing decision pages).
-- [ ] **Rate-limiting proven** — if this touches pacing, the key pool, the
-      dispatcher, or affinity, the load harness shows **zero upstream rate
-      violations** (`scripts/mock_nim.py --enforce` + `scripts/loadtest.py`).
+- [ ] `cargo test` passes locally (unit + end-to-end).
+- [ ] New behavior ships with tests (unit and/or e2e), and existing guard tests still pass.
+- [ ] Scope is tight; commit messages explain the *why*.
+
+### Docs & knowledge base — lockstep is a hard rule (see AGENTS.md)
+- [ ] README / `examples/` updated if user-facing behavior or setup changed.
+- [ ] Affected `knowledge/` pages updated **in this PR** (code and knowledge must not diverge).
+- [ ] New decision → new `knowledge/decisions/` page **and** a `knowledge/index.md` row, in ADR shape (Context → Options → Choice → Consequences).
+- [ ] Dated entry appended to `knowledge/log.md` (`## [YYYY-MM-DD] ingest|decision|lint — summary`).
+- [ ] `CHANGELOG.md` `[Unreleased]` updated (Keep a Changelog format).
+
+### Security — required if this touches `src/auth.rs`, `src/config.rs`, `src/settings.rs`, the API-key gate or label sanitizing in `src/proxy.rs`, or the dashboard `innerHTML`
+- [ ] Fail-closed posture preserved (pre-setup data plane closed; post-setup surfaces require a session; corrupt/future-version store refuses to boot).
+- [ ] Every dynamic value written to `innerHTML` goes through `esc()`; label sanitizing invariants (non-empty, ≤64 chars, safe charset) hold.
+- [ ] Reviewed against [SECURITY.md](../SECURITY.md) and the auth-posture / input-sanitizing decision pages.
+
+### Rate-limiting — required if this touches pacing, the key pool, the dispatcher, or affinity
+- [ ] Load harness shows **zero upstream rate violations** (`scripts/mock_nim.py --enforce` + `scripts/loadtest.py`) — a hard requirement, not a target.
+
+### Workflows & supply chain — required if this touches `.github/workflows/**` or the release path
+- [ ] New/changed Actions are pinned to a full commit SHA with a `# vX.Y.Z` comment; `actionlint` + `zizmor` pass (the CI workflow-lint job).
+- [ ] Release or version changes follow [`knowledge/ops/release.md`](../knowledge/ops/release.md) (version bump + `Cargo.lock` sync, CHANGELOG promotion, SECURITY.md supported-versions table).

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,14 @@
+name: nim-proxy CodeQL config
+
+# The hard-coded-secret queries are exactly what we want on the operator-facing
+# surface (src/**), but test crates and the fuzz harness are *built* out of
+# intentional fixture credentials — throwaway passwords, hand-rolled low-cost
+# salts, RFC test vectors. Those are signal in shipped code and pure noise in
+# test-only code, so exclude those trees. Supported for Rust under
+# `build-mode: none` (source extraction), same as the interpreted languages.
+# Note: this cannot reach the `#[cfg(test)]` modules that live *inside* a
+# scanned src/ file — those few fixture alerts are dismissed in the code
+# scanning UI as "used in tests" instead.
+paths-ignore:
+  - tests/**
+  - fuzz/**

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,7 +10,7 @@ name: Security audit
 # activity — acceptable; an inactive repo isn't shipping releases either.
 on:
   schedule:
-    - cron: "43 6 * * 1" # weekly, Monday 06:42 UTC
+    - cron: "43 6 * * 1" # weekly, Monday 06:43 UTC
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,12 @@ jobs:
           tool: cargo-llvm-cov
       # The e2e suite spawns the real binary; the test harness forwards the
       # coverage profile path to the child and shuts it down gracefully under
-      # llvm-cov, so subprocess coverage is captured. Gate at 80% lines.
-      - name: Coverage (gate >= 80% lines)
+      # llvm-cov, so subprocess coverage is captured. Gate at 90% lines.
+      - name: Coverage (gate >= 90% lines)
         run: |
           {
             echo '```'
-            cargo llvm-cov --summary-only --fail-under-lines 80
+            cargo llvm-cov --summary-only --fail-under-lines 90
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,6 +48,10 @@ jobs:
         with:
           languages: rust
           build-mode: none
+          # Keeps the hard-coded-secret queries on src/** while excluding the
+          # fixture-credential noise in the test/fuzz trees (paths-ignore is
+          # honored for Rust under build-mode: none).
+          config-file: ./.github/codeql/codeql-config.yml
       - uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:rust"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,6 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # create the release
+      id-token: write # keyless cosign sign-blob over the downloadable assets
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -254,6 +255,23 @@ jobs:
         with:
           pattern: "{binary-*,sbom}"
           merge-multiple: true
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
+      # The container manifest is already signed in the merge job; this signs
+      # the *downloadable* assets (the per-arch tarballs and the SBOM) so a
+      # binary pulled from the Releases page is verifiable too, not just the
+      # image. Keyless: the OIDC identity is this workflow, verified below.
+      # Each blob gets a detached signature (.sig) + the signing certificate
+      # (.pem); both are attached to the release next to the artifact.
+      - name: Sign release assets (keyless)
+        run: |
+          set -euo pipefail
+          for f in nim-proxy-*.tar.gz nim-proxy-sbom.spdx.json; do
+            cosign sign-blob --yes \
+              --output-signature "$f.sig" \
+              --output-certificate "$f.pem" \
+              "$f"
+          done
       - name: Publish release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
@@ -263,7 +281,11 @@ jobs:
           generate_release_notes: true
           files: |
             nim-proxy-*.tar.gz
+            nim-proxy-*.tar.gz.sig
+            nim-proxy-*.tar.gz.pem
             nim-proxy-sbom.spdx.json
+            nim-proxy-sbom.spdx.json.sig
+            nim-proxy-sbom.spdx.json.pem
           body: |
             Container image (multi-arch, signed, with SBOM + provenance):
 
@@ -271,10 +293,20 @@ jobs:
             docker pull ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.version }}
             ```
 
-            Verify the signature:
+            Verify the image signature:
 
             ```sh
             cosign verify ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.version }} \
+              --certificate-identity-regexp 'https://github.com/${{ github.repository }}/.github/workflows/release.yml@.*' \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com
+            ```
+
+            Verify a downloaded asset (tarball or SBOM) against its `.sig` + `.pem`:
+
+            ```sh
+            cosign verify-blob nim-proxy-${{ needs.prepare.outputs.version }}-linux-amd64.tar.gz \
+              --signature nim-proxy-${{ needs.prepare.outputs.version }}-linux-amd64.tar.gz.sig \
+              --certificate nim-proxy-${{ needs.prepare.outputs.version }}-linux-amd64.tar.gz.pem \
               --certificate-identity-regexp 'https://github.com/${{ github.repository }}/.github/workflows/release.yml@.*' \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com
             ```

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,7 +6,7 @@ name: OpenSSF Scorecard
 # public Scorecard API.
 on:
   schedule:
-    - cron: "28 7 * * 1" # weekly, Monday 07:27 UTC
+    - cron: "28 7 * * 1" # weekly, Monday 07:28 UTC
   push:
     branches: [main]
   workflow_dispatch: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+## [0.6.3] - 2026-07-05
 
-- Upgraded the CodeQL Action from v3 to v4 (both `codeql.yml` and the
-  Scorecard SARIF upload), clearing the Node 20 deprecation and the
-  December-2026 v3 sunset warnings.
+Supply-chain and static-analysis release — no proxy behavior changes.
 
 ### Added
+
+- **Release assets are signed** (`cosign sign-blob`, keyless via OIDC): the
+  downloadable per-arch tarballs and the SBOM now ship with a detached
+  signature (`.sig`) and the signing certificate (`.pem`), so a binary pulled
+  from the Releases page is verifiable with `cosign verify-blob` — previously
+  only the container image was signed. The release notes carry the exact
+  verification command.
 
 - **Fuzz testing** (`fuzz/` + a weekly smoke-fuzz workflow): cargo-fuzz
   targets for the three untrusted-byte parsers — the upstream SSE scanner
@@ -45,6 +50,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   week instead of at the next push.
 
 ### Changed
+
+- Upgraded the CodeQL Action from v3 to v4 (both `codeql.yml` and the
+  Scorecard SARIF upload), clearing the Node 20 deprecation and the
+  December-2026 v3 sunset warnings.
+
+- **CodeQL scope**: a config file (`.github/codeql/codeql-config.yml`) now
+  excludes the `tests/**` and `fuzz/**` trees, so the hard-coded-secret
+  queries fire on the operator-facing source but not on intentional test
+  fixtures (throwaway passwords, RFC-vector salts). The handful of fixture
+  alerts inside `#[cfg(test)]` modules in scanned source are dismissed as
+  "used in tests".
 
 - The release workflow now runs under a global concurrency group (one release
   at a time, queued rather than cancelled), and the `prepare` script takes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Supply-chain and static-analysis release — no proxy behavior changes.
 
+### Documentation
+
+- Enriched the PR template into a standard, agent-legible form (Summary / Type
+  of change / Related issues / What & why / How it was tested / Breaking
+  changes, plus a checklist grouped by concern with each conditional section
+  labeled by its trigger).
+- Documentation-consistency pass across README, CONTRIBUTING, SECURITY, the
+  test-strategy and release runbooks, and the issue templates: recorded the
+  full current CI gate set (coverage, MSRV, workflow lint, dependency review,
+  CodeQL) and the applied `main`/`v*` rulesets, added the fuzzing test layer
+  and signed-release-asset notes, and corrected a stale `cargo audit` reference
+  (it is `cargo-deny`) and an old version placeholder.
+
 ### Added
 
 - **Release assets are signed** (`cosign sign-blob`, keyless via OIDC): the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ Supply-chain and static-analysis release — no proxy behavior changes.
   and signed-release-asset notes, and corrected a stale `cargo audit` reference
   (it is `cargo-deny`) and an old version placeholder.
 
+### Testing
+
+- **Coverage expansion** (91.4% → 94.8% lines): new unit tests for the auth
+  primitives (base64/unhex/session-shape/cookie-Secure/throttle-rollover —
+  `auth.rs` is now 100%), `config::validate` rejection branches, `parse_role`
+  (superuser is never assignable), the SSE 1 MiB guard, and history load +
+  daily-compaction; plus e2e tests for setup double-claim, orphan client-key
+  adoption, throttled/failed key probes, client/nim-key/user validation and
+  ownership legs, and the auth handler surface (HTTP Basic scrape creds, login
+  redirects, logout). The CI coverage gate is raised from 80% to 90%.
+
 ### Added
 
 - **Release assets are signed** (`cosign sign-blob`, keyless via OIDC): the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Supply-chain and static-analysis release — no proxy behavior changes.
 
 ### Testing
 
-- **Coverage expansion** (91.4% → 94.8% lines): new unit tests for the auth
+- **Coverage expansion** (91.4% → 96.1% lines): new unit tests for the auth
   primitives (base64/unhex/session-shape/cookie-Secure/throttle-rollover —
   `auth.rs` is now 100%), `config::validate` rejection branches, `parse_role`
   (superuser is never assignable), the SSE 1 MiB guard, and history load +

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,13 +44,22 @@ the dashboard, not env vars ([config store](knowledge/decisions/ui-managed-confi
 
 ## Testing, formatting, linting
 
-All three must be clean before you open a PR — CI enforces every one of them:
+These three must be clean before you open a PR — run them locally:
 
 ```sh
 cargo test                                   # 69 unit + 53 end-to-end tests
 cargo fmt                                     # (CI runs `cargo fmt --check`)
 cargo clippy --all-targets -- -D warnings    # zero warnings — warnings are errors
 ```
+
+CI enforces more on every PR, most of it reproducible locally: line coverage
+≥80% (`cargo llvm-cov`), a build against the declared MSRV
+(`cargo +1.87 check --locked --all-targets`), `cargo deny check` (advisories,
+bans, licenses), a `gitleaks` secret scan, workflow linting (`actionlint` +
+`zizmor`, only relevant if you touch `.github/workflows/**`), dependency
+review, and a Docker build with a healthcheck smoke. Static analysis (CodeQL)
+and a weekly fuzz smoke run as separate workflows. If you edit a workflow,
+keep every Action SHA-pinned with a `# vX.Y.Z` comment.
 
 `cargo test` launches the **real binary** against a scriptable mock NIM (see
 `tests/support/mod.rs`) — booted with a pre-written `config.json` or by driving

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ cargo clippy --all-targets -- -D warnings    # zero warnings — warnings are er
 ```
 
 CI enforces more on every PR, most of it reproducible locally: line coverage
-≥80% (`cargo llvm-cov`), a build against the declared MSRV
+≥90% (`cargo llvm-cov`), a build against the declared MSRV
 (`cargo +1.87 check --locked --all-targets`), `cargo deny check` (advisories,
 bans, licenses), a `gitleaks` secret scan, workflow linting (`actionlint` +
 `zizmor`, only relevant if you touch `.github/workflows/**`), dependency

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "nim-proxy"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nim-proxy"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "Rate-limit-aware OpenAI-compatible proxy for NVIDIA NIM with multi-key load balancing"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ scrape_configs:
 
 **TLS is not built in** — passwords and keys must travel over HTTPS, so terminate TLS at a reverse proxy or platform edge for any exposed deployment. Additional hardening in place: a strict `Content-Security-Policy` and anti-framing/sniffing headers on all responses, a failed-login throttle, and an in-flight cap (`max_inflight`) that sheds floods with a 503.
 
+### Supply chain
+
+The build and release path is hardened to the OpenSSF baseline (scored weekly by the [Scorecard badge](https://scorecard.dev/viewer/?uri=github.com/miztertea/nim-proxy) above): every GitHub Actions step is SHA-pinned, CI runs **CodeQL** static analysis, workflow linting (`actionlint` + `zizmor`), dependency review, and `cargo-deny` (advisories on every PR plus a weekly audit), and the untrusted-byte parsers are **fuzzed** weekly. Releases are signed with keyless [cosign](https://docs.sigstore.dev/): the multi-arch image carries a signature, SLSA build provenance, and an SPDX SBOM, and the downloadable tarballs + SBOM each ship a `.sig` + `.pem` you can check with `cosign verify-blob` (the exact command is in every release's notes). Published `v*` tags are protected against retagging.
+
 ## Operations
 
 - **Image**: built `FROM scratch` — a ~5 MB static musl binary with TLS roots compiled in. No shell, no libc, no CA bundle. Runs as a non-root UID with `read_only`, `cap_drop: ALL`, `no-new-privileges`; rootless Docker/Podman compatible.
@@ -261,7 +265,7 @@ Request shape (messages, tools, sampling params) is captured as **counts and siz
 
 ## Testing
 
-Three layers, all runnable locally:
+Four layers (unit, end-to-end, load, fuzz), all runnable locally:
 
 ```sh
 cargo test          # unit + end-to-end tests (real binary vs a scripted mock NIM)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -79,7 +79,10 @@ reasoning behind the current defenses is documented in the knowledge base:
   advisories run catches new RUSTSEC advisories between pushes. Release images are
   built on native runners from the repo Dockerfile, signed with keyless cosign,
   and published with SLSA build provenance and an SPDX SBOM — all anchored to
-  the multi-arch manifest digest. `v*` release tags are protected by a ruleset
+  the multi-arch manifest digest; the downloadable release assets (tarballs and
+  SBOM) carry their own cosign `sign-blob` signatures, so a binary from the
+  Releases page is verifiable without pulling the image. `v*` release tags are
+  protected by a ruleset
   (no updates, deletions, or force pushes), so a published tag can never be
   silently moved.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -116,7 +116,8 @@ reasoning behind the current defenses is documented in the knowledge base:
   Security & deployment section).
 - Rate-limit abuse of your own NVIDIA keys, or NVIDIA-side terms-of-service
   questions — those are between you and NVIDIA.
-- Vulnerabilities in third-party dependencies already flagged by `cargo audit`
-  (CI runs it); report those upstream, though a note is still welcome.
+- Vulnerabilities in third-party dependencies already flagged by `cargo-deny`
+  (CI runs it on every PR, plus a weekly scheduled advisories audit); report
+  those upstream, though a note is still welcome.
 
 Thank you for helping keep nim-proxy and its users safe.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,31 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-05] v0.6.3 — release-asset signing + CodeQL fixture-noise triage
+
+Maintenance release closing two loose ends from the rigor pass.
+
+- **Release assets are signed** (`cosign sign-blob`, keyless): the `release`
+  job now signs each downloadable tarball and the SBOM, attaching a `.sig` +
+  `.pem` per asset (needed `id-token: write` on the job). The container
+  manifest was already cosign-signed; this extends verifiability to a binary
+  pulled straight from the Releases page. Feeds Scorecard's Signed-Releases
+  lever. Release notes carry the `cosign verify-blob` command.
+- **CodeQL hard-coded-secret triage**: the 5 Critical `rust/hardcoded-
+  cryptographic-value` alerts were all false positives — test fixtures (fake
+  passwords, RFC-7914 vector salts) plus one scratch buffer (`let mut salt =
+  [0u8; 16]` in `hash_password`, immediately overwritten by `getrandom`, but
+  the extractor doesn't model the `&mut` overwrite). Added
+  `.github/codeql/codeql-config.yml` with `paths-ignore: [tests/**, fuzz/**]`
+  (verified: honored for Rust under `build-mode: none`) to kill the separate
+  test-crate alert and prevent future fixture noise. The 4 alerts inside
+  `#[cfg(test)]` modules in scanned `src/` can't be path-excluded without
+  dropping the whole file — dismissed in the code-scanning UI as "used in
+  tests" / false-positive. Deliberately did NOT `query-filter` the rule
+  globally: it must keep firing on a real hard-coded key in shipped code.
+- Fixed two off-by-a-minute cron comments (audit.yml 06:42→06:43,
+  scorecard.yml 07:27→07:28) — comments now match the actual cron minute.
+
 ## [2026-07-04] ingest — repo-rigor pass 3: fuzzing the untrusted-byte parsers
 
 - **cargo-fuzz harnesses** for the three surfaces that parse bytes we don't

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -30,6 +30,19 @@ Maintenance release closing two loose ends from the rigor pass.
   globally: it must keep firing on a real hard-coded key in shipped code.
 - Fixed two off-by-a-minute cron comments (audit.yml 06:42→06:43,
   scorecard.yml 07:27→07:28) — comments now match the actual cron minute.
+- **PR template** rewritten into a standard, agent-legible form (typed
+  sections + a checklist whose conditional groups name their trigger, so an
+  agent pulling the template sees which gates apply). Requirements sourced from
+  CONTRIBUTING.md + AGENTS.md.
+- **Doc-consistency lint** (agent sweep) fixed post-rigor-pass drift: SECURITY
+  said `cargo audit` runs in CI (it's `cargo-deny`, self-contradicting the same
+  file); release.md's required-checks list and rulesets were stale (missing
+  msrv/workflow-lint/dependency-review/codeql, and marked "not yet applied"
+  when both `main` and `v*` rulesets are live); the test-strategy page had no
+  fuzz layer and an incomplete CI description; CONTRIBUTING framed the gate set
+  as "three"; README lacked a supply-chain section and called testing "three
+  layers"; bug_report.yml still placeheld `0.4.0`. Test counts (69+53) and all
+  internal doc links verified clean — no change needed.
 
 ## [2026-07-04] ingest — repo-rigor pass 3: fuzzing the untrusted-byte parsers
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -30,6 +30,22 @@ Maintenance release closing two loose ends from the rigor pass.
   globally: it must keep firing on a real hard-coded key in shipped code.
 - Fixed two off-by-a-minute cron comments (audit.yml 06:42→06:43,
   scorecard.yml 07:27→07:28) — comments now match the actual cron minute.
+- **Coverage expansion 91.4%→94.8% lines** (gate raised 80→90). Applied the
+  YAGNI gates to eliminate a planned clock/injection seam: the throttle
+  window-rollover branch is reachable by setting `Throttle.window_start`
+  directly from an in-module test, and the password-change HashRotated/UserGone
+  logic was *already* unit-tested — so no production code changed. Wave 1: pure
+  in-module unit tests (auth primitives → `auth.rs` 100%; `config::validate`
+  branches; `parse_role`; SSE 1 MiB guard; history load + compaction). Wave 2:
+  e2e legs via the existing harness (setup double-claim/orphan-adoption/throttle,
+  key-probe non-success + unreachable, client/nim-key/user validation +
+  ownership, auth Basic/logout/login redirects). Deliberately left uncovered
+  (documented residual): every handler's `role_of==None` stale-session arm and
+  the account first-read/commit-error arms (only reachable by a TOCTOU race
+  that `verify_session` already precludes — would need an invasive test hook);
+  `lib.rs` boot/`health_probe`/`process::exit`/startup logging; OS-error paths
+  (unreadable/unwritable files); and the proxy request-flow branches (Wave 3,
+  out of scope for this release).
 - **PR template** rewritten into a standard, agent-legible form (typed
   sections + a checklist whose conditional groups name their trigger, so an
   agent pulling the template sees which gates apply). Requirements sourced from

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -30,7 +30,7 @@ Maintenance release closing two loose ends from the rigor pass.
   globally: it must keep firing on a real hard-coded key in shipped code.
 - Fixed two off-by-a-minute cron comments (audit.yml 06:42→06:43,
   scorecard.yml 07:27→07:28) — comments now match the actual cron minute.
-- **Coverage expansion 91.4%→94.8% lines** (gate raised 80→90). Applied the
+- **Coverage expansion 91.4%→96.1% lines** (gate raised 80→90). Applied the
   YAGNI gates to eliminate a planned clock/injection seam: the throttle
   window-rollover branch is reachable by setting `Throttle.window_start`
   directly from an in-module test, and the password-change HashRotated/UserGone
@@ -39,13 +39,24 @@ Maintenance release closing two loose ends from the rigor pass.
   branches; `parse_role`; SSE 1 MiB guard; history load + compaction). Wave 2:
   e2e legs via the existing harness (setup double-claim/orphan-adoption/throttle,
   key-probe non-success + unreachable, client/nim-key/user validation +
-  ownership, auth Basic/logout/login redirects). Deliberately left uncovered
-  (documented residual): every handler's `role_of==None` stale-session arm and
-  the account first-read/commit-error arms (only reachable by a TOCTOU race
-  that `verify_session` already precludes — would need an invasive test hook);
-  `lib.rs` boot/`health_probe`/`process::exit`/startup logging; OS-error paths
-  (unreadable/unwritable files); and the proxy request-flow branches (Wave 3,
-  out of scope for this release).
+  ownership, auth Basic/logout/login redirects). A second blind auditor then
+  showed several "excluded" filesystem/boot paths were in fact cheaply and
+  deterministically reachable with tricks already used in the harness, so those
+  WERE added (round 2): `config` serde-defaults + unreadable-store (invalid
+  UTF-8), `history` dir-create/file-open/write failures (dir-as-file trick),
+  `lib` empty-`DATA_DIR` and the `--health` probe (subprocess exit codes), and
+  the `setup` commit `invalid_config` leg. Genuinely left uncovered (documented
+  residual): every handler's `role_of==None` stale-session arm and account's
+  own None/commit arms — a REAL TOCTOU race (the auth middleware validates the
+  session under one store-lock and releases it; each handler re-locks
+  separately, and a concurrent user-deletion must land in that window), not
+  deterministically triggerable through the black-box harness without a
+  test-only sync hook (the pure logic — `apply_password_change`'s
+  UserGone/HashRotated — is already unit-tested); `lib.rs` banner/`tracing`
+  logging, `warn_legacy_env`, and the unused `GovernorSettings::default`;
+  `tracing!` argument lines the test subscriber never evaluates; and the proxy
+  request-flow branches (streaming/models/relay/buffered — Wave 3, out of
+  scope this release).
 - **PR template** rewritten into a standard, agent-legible form (typed
   sections + a checklist whose conditional groups name their trigger, so an
   agent pulling the template sees which gates apply). Requirements sourced from

--- a/knowledge/ops/release.md
+++ b/knowledge/ops/release.md
@@ -107,20 +107,23 @@ git tag -fa vX.Y.Z -m "nim-proxy X.Y.Z" origin/main
 git push origin vX.Y.Z
 ```
 
-## One-time repo settings (recorded for reference)
+## Repo settings (applied — recorded for reference)
 
-- **Tag ruleset (recommended, not yet applied)**: Settings → Rules → Rulesets →
-  new ruleset targeting tags `v*`: restrict creation to the repository admin
-  role (GitHub Actions' `GITHUB_TOKEN` acts as the repo and passes), block
-  deletion and non-fast-forward updates. This codifies the "never retag a
-  published release" rule below instead of relying on discipline.
-
+- **Tag ruleset on `v*`** (Settings → Rules → Rulesets): restrict creation to
+  the repository admin role (GitHub Actions' `GITHUB_TOKEN` acts as the repo
+  and passes), block deletion and non-fast-forward updates. This codifies the
+  "never retag a published release" rule above instead of relying on
+  discipline.
+- **Branch ruleset on `main`** (Settings → Rules → Rulesets): require a pull
+  request before merging (0 approvals — solo maintainer; the point is blocking
+  direct pushes, and 1 approval would deadlock a solo repo); require these
+  status checks, which must stay in sync with the CI job list in
+  `.github/workflows/ci.yml` (+ `codeql.yml`): `fmt, clippy, tests`,
+  `coverage`, `msrv`, `cargo-deny`, `gitleaks`, `workflow lint`,
+  `dependency review`, `docker build`, `codeql (rust)`; block force pushes and
+  deletions. Do **not** require signed commits — session commits are unsigned
+  and would be blocked. Leave "require branches up to date" off so Dependabot
+  PRs don't need a rebase per merge.
 - **Private vulnerability reporting** enabled (Settings → Code security) —
   `SECURITY.md` lists advisories as the only reporting channel.
 - **Auto-delete head branches** enabled.
-- **Branch protection / ruleset on `main`** (Settings → Rules → Rulesets):
-  require a pull request before merging (0 approvals acceptable solo — the
-  point is blocking direct pushes); require status checks
-  `fmt, clippy, tests`, `coverage`, `cargo-deny`, `gitleaks`, `docker build`
-  (strict/up-to-date); block force pushes and deletions. Do **not** require
-  signed commits — session commits are unsigned and would be blocked.

--- a/knowledge/ops/release.md
+++ b/knowledge/ops/release.md
@@ -11,8 +11,9 @@ timestamp: 2026-07-03T00:00:00Z
 `.github/workflows/release.yml` builds a multi-arch (amd64+arm64) image,
 pushes it to `ghcr.io/miztertea/nim-proxy`, signs it with keyless cosign,
 attests SLSA build provenance, generates an SPDX SBOM, and publishes a GitHub
-Release with the static binaries and the SBOM attached. SemVer + Keep a
-Changelog throughout.
+Release with the static binaries and the SBOM attached. The downloadable
+assets (tarballs + SBOM) are themselves signed with `cosign sign-blob`, each
+getting a `.sig` + `.pem` alongside it. SemVer + Keep a Changelog throughout.
 
 It has two entry points: **Run workflow** in the Actions UI (the normal path
 since v0.6.1 — the workflow's `prepare` job resolves the version from
@@ -50,10 +51,12 @@ runners → `merge` → `release`) under Actions — a few minutes end to end
 make it ~30 minutes). If the `prepare` job fails with "already exists", the
 version in Cargo.toml was never bumped — do step 1 first.
 
-The cosign signature, provenance attestation, and SBOM all target the final
-**multi-arch manifest digest** (stitched by the `merge` job from the per-arch
-digests), so `cosign verify` on any release tag resolves and verifies the
-same manifest.
+The cosign image signature, provenance attestation, and SBOM all target the
+final **multi-arch manifest digest** (stitched by the `merge` job from the
+per-arch digests), so `cosign verify` on any release tag resolves and verifies
+the same manifest. The `release` job additionally signs each downloadable
+asset (`cosign sign-blob`, same keyless workflow identity) so a tarball or the
+SBOM pulled from the Releases page is verifiable without the registry.
 
 ## 3. Verify the shipped artifacts
 
@@ -68,10 +71,18 @@ docker rm -f rel-smoke
 cosign verify ghcr.io/miztertea/nim-proxy:X.Y.Z \
   --certificate-identity-regexp 'https://github.com/miztertea/nim-proxy/.github/workflows/release.yml@.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# and a downloaded asset against its detached .sig + .pem:
+cosign verify-blob nim-proxy-X.Y.Z-linux-amd64.tar.gz \
+  --signature nim-proxy-X.Y.Z-linux-amd64.tar.gz.sig \
+  --certificate nim-proxy-X.Y.Z-linux-amd64.tar.gz.pem \
+  --certificate-identity-regexp 'https://github.com/miztertea/nim-proxy/.github/workflows/release.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
 Also check the GitHub Release page: two `nim-proxy-X.Y.Z-linux-*.tar.gz` assets
-plus `nim-proxy-sbom.spdx.json`, and generated release notes. The notes are
+plus `nim-proxy-sbom.spdx.json`, each with its `.sig` + `.pem`, and generated
+release notes. The notes are
 grouped by PR label via `.github/release.yml` (Security / Breaking changes /
 Features=`enhancement` / Fixes=`bug` / Documentation / Dependencies —
 Dependabot's default label / Other; `skip-changelog` excludes a PR) — so

--- a/knowledge/testing/index.md
+++ b/knowledge/testing/index.md
@@ -1,7 +1,7 @@
 ---
 type: Index
 title: Testing
-description: The three verification layers.
+description: The four verification layers (unit, e2e, load, fuzz).
 ---
 
 # Testing

--- a/knowledge/testing/test-strategy.md
+++ b/knowledge/testing/test-strategy.md
@@ -1,15 +1,23 @@
 ---
 type: Runbook
 title: Test strategy
-description: Unit, end-to-end, and load layers — what each catches and how to run them.
+description: Unit, end-to-end, load, and fuzz layers — what each catches and how to run them.
 tags: [testing, ci]
 timestamp: 2026-07-02T00:00:00Z
 ---
 
 # Test strategy
 
-Three layers; CI (`.github/workflows/ci.yml`) runs the first two plus fmt,
-clippy `-D warnings`, and a Docker build with a container healthcheck smoke.
+Four layers (unit, end-to-end, load, fuzz). CI (`.github/workflows/ci.yml`)
+runs the unit + e2e suites plus a full gate set on every PR: `fmt` + `clippy
+-D warnings` + tests (the `check` job), `coverage` (≥80%, `cargo-llvm-cov`),
+an `msrv` build against Rust 1.87, `cargo-deny` (advisories + bans + licenses),
+`gitleaks` secret scan, `workflow lint` (`actionlint` + `zizmor`),
+`dependency review`, and a `docker build` with a container healthcheck smoke.
+Three more workflows run outside PR CI: **CodeQL** SAST (`codeql.yml` — PR +
+push + weekly), a weekly **cargo-deny advisories** audit (`audit.yml`), a
+weekly **fuzz** smoke (`fuzz.yml`, layer 4 below), and the weekly **OpenSSF
+Scorecard** scan.
 
 ## 1. Unit — `cargo test` (in `src/`)
 
@@ -60,7 +68,25 @@ violations that unit and e2e tests structurally cannot see, leading to
 the governor's convergence and zero-violation invariant across live pool
 rebuilds.
 
-Dashboard changes get a fourth check: real-browser screenshots (headless
+## 4. Fuzz — `cargo +nightly fuzz run <target>` (in `fuzz/`)
+
+libFuzzer/cargo-fuzz harnesses over the three surfaces that parse bytes we
+don't control, asserting *never panics* plus each surface's invariant:
+`sse_scan` (upstream SSE arrives arbitrarily fragmented — fed whole and
+re-fragmented, asserting the 1 MiB pathological-line guard), `sanitize_label`
+(the metric-injection defense: output is non-empty, ≤64 chars, safe charset),
+and `config_roundtrip` (operator-edited `config.json`: parse never panics,
+serialize→parse→serialize is a fixpoint). `fuzz.yml` smoke-fuzzes each target
+60s weekly, on demand, and on PRs touching `src/proxy.rs`, `src/config.rs`, or
+`fuzz/**`; it is deliberately **not** a required merge check. Seed corpora live
+in `fuzz/seeds/` (real SSE shapes, hostile label bytes, a full store); the
+evolved working corpus in `fuzz/corpus/` is gitignored. Run one locally:
+
+```sh
+cargo +nightly fuzz run sse_scan -- -max_total_time=60
+```
+
+Dashboard changes get one more check: real-browser screenshots (headless
 Chromium) under live traffic (the UI is dark-only since the operator-console
 redesign), inspected by eye — as superuser/admin/user, confirming each role
 sees the right Settings sections.

--- a/knowledge/testing/test-strategy.md
+++ b/knowledge/testing/test-strategy.md
@@ -10,7 +10,7 @@ timestamp: 2026-07-02T00:00:00Z
 
 Four layers (unit, end-to-end, load, fuzz). CI (`.github/workflows/ci.yml`)
 runs the unit + e2e suites plus a full gate set on every PR: `fmt` + `clippy
--D warnings` + tests (the `check` job), `coverage` (≥80%, `cargo-llvm-cov`),
+-D warnings` + tests (the `check` job), `coverage` (≥90%, `cargo-llvm-cov`),
 an `msrv` build against Rust 1.87, `cargo-deny` (advisories + bans + licenses),
 `gitleaks` secret scan, `workflow lint` (`actionlint` + `zizmor`),
 `dependency review`, and a `docker build` with a container healthcheck smoke.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -669,6 +669,74 @@ mod tests {
     }
 
     #[test]
+    fn base64_decode_handles_alphabet_padding_and_rejects_garbage() {
+        // Round-trips a real Basic credential (letters, digits, ':').
+        assert_eq!(
+            base64_decode("dXNlcjpwYXNz").unwrap(),
+            b"user:pass".to_vec()
+        );
+        // The '+' (62) and '/' (63) alphabet slots.
+        assert_eq!(base64_decode("+AAA").unwrap(), vec![248u8, 0, 0]);
+        assert_eq!(base64_decode("/AAA").unwrap(), vec![252u8, 0, 0]);
+        assert_eq!(base64_decode("+/AA").unwrap(), vec![251u8, 240, 0]);
+        // A 2-byte tail (3-char chunk + one '=' pad).
+        assert_eq!(base64_decode("TWE=").unwrap(), b"Ma".to_vec());
+        // An illegal character and a lone 1-char chunk both fail closed.
+        assert!(base64_decode("ab*c").is_none());
+        assert!(base64_decode("A").is_none());
+    }
+
+    #[test]
+    fn unhex_rejects_odd_length() {
+        assert!(unhex("abc").is_none());
+        assert_eq!(unhex("0a0b").unwrap(), vec![0x0au8, 0x0b]);
+    }
+
+    #[test]
+    fn verify_session_rejects_malformed_token_shape() {
+        let a = admin();
+        let sc = store_with("alice", "hash-v1");
+        // A token that isn't exactly 5 dotted parts fails closed before any crypto.
+        assert!(a.verify_session("a.b.c", &sc).is_none());
+        assert!(a
+            .verify_session("too.many.dots.here.and.more", &sc)
+            .is_none());
+    }
+
+    #[test]
+    fn cookie_marks_secure_only_behind_a_trusted_https_proxy() {
+        let mut https = HeaderMap::new();
+        https.insert("x-forwarded-proto", "https".parse().unwrap());
+        // trust_proxy = true AND forwarded https -> Secure attribute set.
+        assert!(Admin::new(true)
+            .cookie(&https, "tok", 3600)
+            .contains("; Secure"));
+        // The same header is untrusted when trust_proxy = false (can't believe it).
+        assert!(!Admin::new(false)
+            .cookie(&https, "tok", 3600)
+            .contains("; Secure"));
+        // Trusted proxy but plain http -> no Secure.
+        let mut http = HeaderMap::new();
+        http.insert("x-forwarded-proto", "http".parse().unwrap());
+        assert!(!Admin::new(true)
+            .cookie(&http, "tok", 3600)
+            .contains("; Secure"));
+    }
+
+    #[test]
+    fn note_failure_resets_after_the_throttle_window_rolls_over() {
+        let a = admin();
+        {
+            let mut t = a.throttle.lock().unwrap();
+            t.window_start = now() - THROTTLE_WINDOW_SECS - 1;
+            t.failures = 10_000; // would be throttled if the window hadn't rolled
+        }
+        // The rolled-over window resets the counter, so one fresh failure is
+        // well under the limit.
+        assert!(!a.note_failure());
+    }
+
+    #[test]
     fn malformed_hash_strings_fail_closed() {
         for bad in [
             "",

--- a/src/config.rs
+++ b/src/config.rs
@@ -646,6 +646,27 @@ mod tests {
     }
 
     #[test]
+    fn unreadable_store_is_a_hard_error() {
+        let dir = TestDir::new();
+        // Invalid UTF-8 is a read error (not the corrupt-but-valid-UTF-8 JSON
+        // path) — it must still fail closed, never fall through to setup mode.
+        fs::write(store_path(&dir.0), [0xff, 0xfe, 0xfd]).unwrap();
+        let err = load(&dir.0).unwrap_err();
+        assert!(err.contains("cannot read"), "{err}");
+    }
+
+    #[test]
+    fn serde_defaults_fill_omitted_fields() {
+        // A NIM key missing enabled/rpm inherits the documented defaults
+        // (backward compat for stores written before those fields existed).
+        let k: NimKey = serde_json::from_str(r#"{"key":"k","owner":"o"}"#).unwrap();
+        assert!(k.enabled);
+        assert_eq!(k.rpm, 40);
+        let g: GovernorCfg = serde_json::from_str("{}").unwrap();
+        assert!(g.enabled);
+    }
+
+    #[test]
     fn future_version_refuses_to_load() {
         let dir = TestDir::new();
         fs::write(store_path(&dir.0), r#"{"version": 2}"#).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -725,6 +725,54 @@ mod tests {
                     sc.governor.overrides.insert("m".into(), 0);
                 }),
             ),
+            ("version not 1", Box::new(|sc| sc.version = 2)),
+            (
+                "heartbeat zero",
+                Box::new(|sc| sc.limits.heartbeat_secs = 0),
+            ),
+            (
+                "request timeout zero",
+                Box::new(|sc| sc.limits.request_timeout_secs = 0),
+            ),
+            (
+                "empty nim key",
+                Box::new(|sc| sc.upstream.nim_keys[0].key = "   ".into()),
+            ),
+            (
+                "bad client key name",
+                Box::new(|sc| {
+                    sc.client_auth.keys.push(ClientKey {
+                        name: "a b".into(),
+                        secret_sha256: "a".repeat(64),
+                        last4: "aaaa".into(),
+                        owner: "root".into(),
+                    })
+                }),
+            ),
+            (
+                "duplicate client key name",
+                Box::new(|sc| {
+                    for _ in 0..2 {
+                        sc.client_auth.keys.push(ClientKey {
+                            name: "dup".into(),
+                            secret_sha256: "b".repeat(64),
+                            last4: "bbbb".into(),
+                            owner: "root".into(),
+                        });
+                    }
+                }),
+            ),
+            (
+                "client key dangling owner",
+                Box::new(|sc| {
+                    sc.client_auth.keys.push(ClientKey {
+                        name: "ck".into(),
+                        secret_sha256: "c".repeat(64),
+                        last4: "cccc".into(),
+                        owner: "ghost".into(),
+                    })
+                }),
+            ),
         ];
         for (name, mutate) in cases {
             let mut sc = claimed();

--- a/src/history.rs
+++ b/src/history.rs
@@ -225,4 +225,50 @@ mod tests {
             "expired snapshot compacted out of the file"
         );
     }
+
+    #[test]
+    fn load_disables_persistence_when_the_dir_cant_be_created() {
+        let dir = TestDir::new();
+        // A file sits where the history directory should be, so create_dir_all
+        // fails and persistence falls back to in-memory only.
+        let blocker = dir.0.join("blocker");
+        fs::write(&blocker, b"x").unwrap();
+        let h = History::load(Some(blocker.join("sub")), 1);
+        assert!(
+            h.file.is_none(),
+            "persistence disabled on dir-create failure"
+        );
+    }
+
+    #[test]
+    fn load_disables_persistence_when_the_path_isnt_a_writable_file() {
+        let dir = TestDir::new();
+        // A directory sits where history.jsonl should be, so opening it for
+        // append fails (EISDIR) and persistence stays in-memory.
+        fs::create_dir_all(dir.0.join("history.jsonl")).unwrap();
+        let h = History::load(Some(dir.0.clone()), 1);
+        assert!(
+            h.file.is_none(),
+            "persistence disabled when the path isn't a file"
+        );
+    }
+
+    #[test]
+    fn append_survives_a_write_failure_without_panicking() {
+        let dir = TestDir::new();
+        // `file` points at a directory: the append write errors and is logged,
+        // but the in-memory record still updates and nothing panics.
+        let h = History {
+            points: Mutex::new(Vec::new()),
+            file: Some(dir.0.clone()),
+            days: AtomicU64::new(0),
+            dropped_since_compact: Mutex::new(0),
+        };
+        h.append(1, "snap".into());
+        assert_eq!(
+            h.range(0, u64::MAX, 10).len(),
+            1,
+            "in-memory append still works"
+        );
+    }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -161,4 +161,68 @@ mod tests {
         assert!(r.len() <= 101, "got {}", r.len());
         assert_eq!(r.last().unwrap().0, 999, "endpoint kept");
     }
+
+    /// A unique per-test scratch dir (std-only; removed on drop).
+    struct TestDir(PathBuf);
+    impl TestDir {
+        fn new() -> Self {
+            static N: AtomicU64 = AtomicU64::new(0);
+            let dir = std::env::temp_dir().join(format!(
+                "nimproxy-history-test-{}-{}",
+                std::process::id(),
+                N.fetch_add(1, Ordering::SeqCst)
+            ));
+            fs::create_dir_all(&dir).unwrap();
+            Self(dir)
+        }
+    }
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn load_reads_existing_snapshots_and_skips_junk() {
+        let dir = TestDir::new();
+        let path = dir.0.join("history.jsonl");
+        // Two valid lines, one unparseable line (skipped), one out-of-order.
+        fs::write(
+            &path,
+            "{\"t\":10,\"m\":\"a\"}\nnot json\n{\"t\":20,\"m\":\"b\"}\n{\"t\":5,\"m\":\"c\"}\n",
+        )
+        .unwrap();
+        // days = 0 exercises the "infinite" retention log branch.
+        let h = History::load(Some(dir.0.clone()), 0);
+        let all = h.range(0, u64::MAX, 100);
+        assert_eq!(all.len(), 3, "3 valid lines parsed, junk skipped");
+        assert_eq!(all[0].0, 5, "snapshots sorted by timestamp on load");
+        // days > 0 exercises the "{days} days" retention log branch.
+        let h2 = History::load(Some(dir.0.clone()), 7);
+        assert_eq!(h2.range(0, u64::MAX, 100).len(), 3);
+    }
+
+    #[test]
+    fn append_compacts_the_file_after_a_days_worth_of_expiry() {
+        let dir = TestDir::new();
+        let path = dir.0.join("history.jsonl");
+        fs::write(&path, "{\"t\":1,\"m\":\"old\"}\n").unwrap();
+        let h = History {
+            points: Mutex::new(vec![(1, "old".into())]),
+            file: Some(path.clone()),
+            days: AtomicU64::new(1),
+            // One more expiry crosses the >288 compaction threshold.
+            dropped_since_compact: Mutex::new(288),
+        };
+        // days = 1: cutoff = 200_000 - 86_400 = 113_600, so the t=1 snapshot
+        // expires; that pushes the drop count to 289 (>288) and triggers a full
+        // file rewrite rather than an append.
+        h.append(200_000, "new".into());
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("new"), "surviving snapshot rewritten");
+        assert!(
+            !contents.contains("old"),
+            "expired snapshot compacted out of the file"
+        );
+    }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1154,6 +1154,11 @@ mod tests {
         scan.feed(&vec![b'x'; 1_048_577]);
         assert!(scan.buf.is_empty(), "oversized line buffer must be dropped");
         assert_eq!(scan.events, 0);
+        // The guard drops the runaway buffer without wedging the scanner: a
+        // normal event still parses immediately afterward.
+        scan.feed(b"data: {\"choices\":[],\"usage\":{\"completion_tokens\":3}}\n\n");
+        assert_eq!(scan.events, 1);
+        assert_eq!(scan.completion, Some(3));
     }
 
     #[test]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1137,6 +1137,26 @@ mod tests {
     }
 
     #[test]
+    fn tool_choice_mode_maps_unknown_strings_to_other() {
+        // auto / none / required / named are covered elsewhere; an unrecognized
+        // string must collapse to the bounded "other" label, not pass through.
+        assert_eq!(
+            tool_choice_mode(&serde_json::json!({"tool_choice": "banana"})),
+            "other"
+        );
+    }
+
+    #[test]
+    fn sse_scan_clears_a_pathological_unterminated_line() {
+        let mut scan = SseScan::default();
+        // >1 MiB with no newline: the guard clears the buffer instead of letting
+        // an abusive upstream grow it without bound.
+        scan.feed(&vec![b'x'; 1_048_577]);
+        assert!(scan.buf.is_empty(), "oversized line buffer must be dropped");
+        assert_eq!(scan.events, 0);
+    }
+
+    #[test]
     fn scan_counts_events_and_finds_usage() {
         let mut scan = SseScan::default();
         // Feed in awkwardly split chunks to exercise line reassembly.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -991,6 +991,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_role_maps_admin_and_user_but_never_superuser() {
+        assert_eq!(parse_role("admin"), Some(Role::Admin));
+        assert_eq!(parse_role("user"), Some(Role::User));
+        // Superuser is intentionally NOT assignable through the users API.
+        assert_eq!(parse_role("superuser"), None);
+        assert_eq!(parse_role("root"), None);
+        assert_eq!(parse_role(""), None);
+    }
+
+    #[test]
     fn password_change_applies_when_the_verified_hash_is_current() {
         let mut sc = store_with_user("alice", "old-hash");
         assert_eq!(

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -2792,3 +2792,57 @@ async fn logout_clears_the_session_cookie() {
     assert!(set.contains("nimproxy_session="), "{set}");
     assert!(set.contains("Max-Age=0"), "{set}");
 }
+
+/// The wizard's strong-password gate passes, but a candidate that fails
+/// `validate()` at commit surfaces as `invalid_config` (not a panic/500).
+#[tokio::test]
+async fn setup_rejects_an_invalid_config_on_commit() {
+    let proxy = start_proxy_fresh().await;
+    let resp = client()
+        .post(proxy.url("/setup"))
+        .json(&serde_json::json!({
+            "username": "bad user!", // fails the username charset check in validate()
+            "password": "hunter2hunter2",
+            "base_url": "http://127.0.0.1:9999",
+            "nim_keys": [{"key": "k", "rpm": 40}],
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let v: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(v["error"]["code"], "invalid_config", "{v}");
+}
+
+/// An empty DATA_DIR is a fatal misconfiguration — the store home must be a
+/// real writable directory.
+#[tokio::test]
+async fn boot_refuses_an_empty_data_dir() {
+    support::expect_refuses_to_start(std::path::PathBuf::from("")).await;
+}
+
+/// `nim-proxy --health` probes /health on $PORT and exits 0 (healthy) or 1
+/// (unreachable) — the scratch image's shell-less HEALTHCHECK.
+#[tokio::test]
+async fn health_probe_flag_reports_liveness() {
+    let mock = start_mock().await;
+    let proxy = start_proxy(&mock.url, &[]).await;
+    let run_health = |port: String| {
+        let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_nim-proxy"));
+        cmd.arg("--health").env("PORT", port);
+        // Forward the coverage profile path so the probe subprocess is counted
+        // under `cargo llvm-cov` (a no-op in a normal test run).
+        if let Ok(v) = std::env::var("LLVM_PROFILE_FILE") {
+            cmd.env("LLVM_PROFILE_FILE", v);
+        }
+        cmd.status().unwrap()
+    };
+    assert!(
+        run_health(proxy.port.to_string()).success(),
+        "--health exits 0 against a healthy proxy"
+    );
+    assert!(
+        !run_health("1".into()).success(),
+        "--health exits non-zero against a dead port"
+    );
+}

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -2671,8 +2671,9 @@ async fn users_reject_invalid_role_unknown_target_and_bad_action() {
     }
 }
 
-/// Scraper header auth: HTTP Basic works (and repeats hit the credential memo),
-/// while an unknown scheme, a wrong password, and a foreign cookie all 401.
+/// Scraper header auth: HTTP Basic works (a second identical call also drives
+/// the credential-memo fast path), while an unknown scheme, a wrong password,
+/// and a foreign cookie all 401.
 #[tokio::test]
 async fn scraper_header_auth_variants() {
     let mock = start_mock().await;

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -2276,3 +2276,518 @@ async fn disconnected_stream_releases_its_inflight_slot() {
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
 }
+
+// ===========================================================================
+// Coverage wave 2: setup edge cases, settings error/ownership legs, and the
+// auth handler surface (Basic scrape creds, login redirects, logout). These
+// drive previously-uncovered branches through the real HTTP surface.
+// ===========================================================================
+
+/// Two wizard claims race; the store mutex admits exactly one.
+#[tokio::test]
+async fn setup_double_claim_is_rejected_with_409() {
+    let proxy = start_proxy_fresh().await;
+    let body = serde_json::json!({
+        "username": "admin",
+        "password": "hunter2hunter2",
+        "base_url": "http://127.0.0.1:9999",
+        "nim_keys": [{"key": "nvapi-x", "rpm": 40}],
+    });
+    // Both requests pass the setup_required check before either finishes the
+    // 600k-iteration PBKDF2 hash, so the mutex arbitrates one winner.
+    let (a, b) = tokio::join!(
+        client().post(proxy.url("/setup")).json(&body).send(),
+        client().post(proxy.url("/setup")).json(&body).send(),
+    );
+    let mut statuses = [a.unwrap().status().as_u16(), b.unwrap().status().as_u16()];
+    statuses.sort_unstable();
+    assert_eq!(
+        statuses,
+        [200, 409],
+        "exactly one claim wins, the other 409s"
+    );
+}
+
+/// A lockout-recovery store (users hand-emptied) keeps orphan-owned client
+/// keys; claiming the proxy re-owns them to the new superuser.
+#[tokio::test]
+async fn setup_adopts_orphan_client_keys_on_claim() {
+    let mock = start_mock().await;
+    let dir = scratch_data_dir();
+    let fixture = serde_json::json!({
+        "version": 1,
+        "upstream": {
+            "base_url": mock.url,
+            "nim_keys": [{"key": "orphan-key", "owner": "ghost", "enabled": true, "rpm": 40}],
+        },
+        "client_auth": {
+            "mode": "keyed",
+            "keys": [{
+                "name": "orphan-client",
+                "secret_sha256": support::sha256_hex("orphan-secret"),
+                "owner": "ghost",
+            }],
+        },
+        "users": [],
+    });
+    std::fs::write(
+        dir.join("config.json"),
+        serde_json::to_string_pretty(&fixture).unwrap(),
+    )
+    .unwrap();
+
+    let proxy = start_proxy_in(dir, &[]).await;
+    let root = complete_setup(&proxy, "admin", support::TEST_PASSWORD, &mock.url, &[]).await;
+
+    // The orphan client key is re-owned by the new superuser...
+    let cfg = api_config(&proxy, &root).await;
+    assert_eq!(cfg["client_keys"][0]["owner"], "admin", "{cfg}");
+    // ...and its secret still authenticates on keyed /v1.
+    let r = client()
+        .post(proxy.url("/v1/chat/completions"))
+        .bearer_auth("orphan-secret")
+        .json(&chat_body("hi", false))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 200, "adopted client key authenticates");
+}
+
+/// The pre-auth key probe shares the login throttle; hammering it trips 429.
+#[tokio::test]
+async fn setup_validate_key_throttles_after_repeated_probes() {
+    let proxy = start_proxy_fresh().await;
+    // A dead loopback fails fast (no real egress) but still burns throttle
+    // budget on each probe.
+    let body = serde_json::json!({"key": "x", "base_url": "http://127.0.0.1:1"});
+    let mut last = 0u16;
+    for _ in 0..12 {
+        last = client()
+            .post(proxy.url("/setup/validate-key"))
+            .json(&body)
+            .send()
+            .await
+            .unwrap()
+            .status()
+            .as_u16();
+    }
+    assert_eq!(last, 429, "the throttle trips after repeated failed probes");
+}
+
+/// A reachable upstream that 404s the models route is a key rejection, not a
+/// connection failure (probe_key's non-success branch).
+#[tokio::test]
+async fn key_probe_reports_upstream_rejection() {
+    let mock = start_mock().await;
+    let proxy = start_proxy_fresh().await;
+    let resp = client()
+        .post(proxy.url("/setup/validate-key"))
+        // A bogus path prefix 404s on the mock's own router.
+        .json(&serde_json::json!({"key": "x", "base_url": format!("{}/bogus", mock.url)}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let v: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(v["ok"], false, "{v}");
+    assert!(v["error"].as_str().unwrap().contains("rejected"), "{v}");
+}
+
+/// The authenticated key validator reports an unreachable upstream (probe_key's
+/// connect-error branch, via /api/settings/validate-key).
+#[tokio::test]
+async fn authenticated_key_validation_reports_unreachable_upstream() {
+    let proxy = start_proxy_with("http://127.0.0.1:1", support::StoreOpts::default(), &[]).await;
+    let root = support::login(&proxy).await;
+    let (status, v) = post_json(
+        &proxy,
+        &root,
+        "/api/settings/validate-key",
+        serde_json::json!({"key": "x"}),
+    )
+    .await;
+    assert_eq!(status, 200, "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert!(v["error"].as_str().unwrap().contains("reach"), "{v}");
+}
+
+/// Removing or reconfiguring a NIM key that doesn't exist is a 400, and the
+/// action selector requires exactly one of add/remove/set.
+#[tokio::test]
+async fn nim_keys_reject_unknown_fingerprint_and_empty_action() {
+    let mock = start_mock().await;
+    let proxy = start_proxy_with(&mock.url, support::StoreOpts::default(), &[]).await;
+    let root = support::login(&proxy).await;
+    for body in [
+        serde_json::json!({"remove": "deadbeef"}),
+        serde_json::json!({"set": {"fingerprint": "deadbeef", "enabled": true}}),
+    ] {
+        let (status, v) = post_json(&proxy, &root, "/api/settings/nim-keys", body).await;
+        assert_eq!(status, 400, "{v}");
+        assert!(
+            v["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("no such key"),
+            "{v}"
+        );
+    }
+    let (status, _) = post_json(
+        &proxy,
+        &root,
+        "/api/settings/nim-keys",
+        serde_json::json!({}),
+    )
+    .await;
+    assert_eq!(status, 400, "empty action rejected");
+}
+
+/// Client-key endpoint: unknown name, bad mode, empty oneof, empty name on
+/// commit, and cross-owner revoke are all rejected with the right status.
+#[tokio::test]
+async fn clients_reject_unknown_bad_input_and_cross_owner_revoke() {
+    let mock = start_mock().await;
+    let opts = support::StoreOpts {
+        extra_users: vec![("alice".into(), "user".into())],
+        ..Default::default()
+    };
+    let proxy = start_proxy_with(&mock.url, opts, &[]).await;
+    let root = support::login(&proxy).await;
+    let alice = support::login_as(&proxy, "alice").await;
+
+    let (s, v) = post_json(
+        &proxy,
+        &root,
+        "/api/settings/clients",
+        serde_json::json!({"remove": "nope"}),
+    )
+    .await;
+    assert_eq!(s, 400, "{v}");
+    assert!(
+        v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("no such client key"),
+        "{v}"
+    );
+
+    let (s, _) = post_json(
+        &proxy,
+        &root,
+        "/api/settings/clients",
+        serde_json::json!({"mode": "bogus"}),
+    )
+    .await;
+    assert_eq!(s, 400, "bad mode rejected");
+    let (s, _) = post_json(
+        &proxy,
+        &root,
+        "/api/settings/clients",
+        serde_json::json!({}),
+    )
+    .await;
+    assert_eq!(s, 400, "empty action rejected");
+    let (s, v) = post_json(
+        &proxy,
+        &root,
+        "/api/settings/clients",
+        serde_json::json!({"add": {"name": ""}}),
+    )
+    .await;
+    assert_eq!(s, 400, "empty name rejected on commit: {v}");
+
+    // Root mints a key; alice may not revoke someone else's.
+    let (s, _) = post_json(
+        &proxy,
+        &root,
+        "/api/settings/clients",
+        serde_json::json!({"add": {"name": "root-key"}}),
+    )
+    .await;
+    assert_eq!(s, 200);
+    let (s, v) = post_json(
+        &proxy,
+        &alice,
+        "/api/settings/clients",
+        serde_json::json!({"remove": "root-key"}),
+    )
+    .await;
+    assert_eq!(s, 403, "{v}");
+    assert!(
+        v["error"]["message"].as_str().unwrap().contains("your own"),
+        "{v}"
+    );
+}
+
+/// The upstream base_url is re-validated on write: a link-local target (SSRF /
+/// cloud-metadata) is refused.
+#[tokio::test]
+async fn upstream_rejects_link_local_base_url() {
+    let mock = start_mock().await;
+    let proxy = start_proxy_with(&mock.url, support::StoreOpts::default(), &[]).await;
+    let root = support::login(&proxy).await;
+    let (s, v) = post_json(
+        &proxy,
+        &root,
+        "/api/settings/upstream",
+        serde_json::json!({"base_url": "http://169.254.169.254"}),
+    )
+    .await;
+    assert_eq!(s, 400, "{v}");
+    assert!(
+        v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("link-local"),
+        "{v}"
+    );
+}
+
+/// User management: weak-password rejection on add and reset, commit-error on a
+/// blank username, the add+hashing happy path, reset of an unknown user, and
+/// role changes (promote a user; the superuser's role is immutable).
+#[tokio::test]
+async fn users_add_reset_and_set_role_paths() {
+    let mock = start_mock().await;
+    let opts = support::StoreOpts {
+        extra_users: vec![
+            ("adm".into(), "admin".into()),
+            ("bob".into(), "user".into()),
+        ],
+        ..Default::default()
+    };
+    let proxy = start_proxy_with(&mock.url, opts, &[]).await;
+    let root = support::login(&proxy).await;
+
+    // Add: weak password rejected.
+    let (s, v) = post_json(
+        &proxy,
+        &root,
+        "/api/settings/users",
+        serde_json::json!({"add": {"username": "eve", "password": "short", "role": "user"}}),
+    )
+    .await;
+    assert_eq!(s, 400, "{v}");
+    assert_eq!(v["error"]["code"], "weak_password", "{v}");
+    // Add: a username that trims to empty fails on commit.
+    let (s, _) = post_json(
+        &proxy,
+        &root,
+        "/api/settings/users",
+        serde_json::json!({"add": {"username": "   ", "password": "long-enough-pw", "role": "user"}}),
+    )
+    .await;
+    assert_eq!(s, 400, "blank username rejected");
+    // Add: valid -> the new user can log in (exercises the hashing path).
+    // login_as always uses TEST_PASSWORD, so create eve with it.
+    let (s, v) = post_json(
+        &proxy,
+        &root,
+        "/api/settings/users",
+        serde_json::json!({"add": {"username": "eve", "password": support::TEST_PASSWORD, "role": "user"}}),
+    )
+    .await;
+    assert_eq!(s, 200, "{v}");
+    let _ = support::login_as(&proxy, "eve").await;
+
+    // Reset: weak password and unknown user both rejected.
+    let (s, v) = post_json(
+        &proxy,
+        &root,
+        "/api/settings/users",
+        serde_json::json!({"reset_password": {"username": "adm", "new_password": "short"}}),
+    )
+    .await;
+    assert_eq!(s, 400, "{v}");
+    assert_eq!(v["error"]["code"], "weak_password", "{v}");
+    let (s, v) = post_json(
+        &proxy,
+        &root,
+        "/api/settings/users",
+        serde_json::json!({"reset_password": {"username": "ghost", "new_password": "long-enough-pw"}}),
+    )
+    .await;
+    assert_eq!(s, 400, "{v}");
+    assert!(
+        v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("no such user"),
+        "{v}"
+    );
+
+    // set_role: promote bob to admin (verified functionally), then confirm the
+    // superuser's role can't be changed.
+    let (s, v) = post_json(
+        &proxy,
+        &root,
+        "/api/settings/users",
+        serde_json::json!({"set_role": {"username": "bob", "role": "admin"}}),
+    )
+    .await;
+    assert_eq!(s, 200, "{v}");
+    let bob = support::login_as(&proxy, "bob").await;
+    let (s, _) = post_json(
+        &proxy,
+        &bob,
+        "/api/settings/governor",
+        serde_json::json!({"enabled": true}),
+    )
+    .await;
+    assert_eq!(s, 200, "bob now has admin rights");
+    let (s, v) = post_json(
+        &proxy,
+        &root,
+        "/api/settings/users",
+        serde_json::json!({"set_role": {"username": support::TEST_USER, "role": "user"}}),
+    )
+    .await;
+    assert_eq!(s, 403, "{v}");
+    assert!(
+        v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("immutable"),
+        "{v}"
+    );
+}
+
+/// User-management input validation: invalid role and unknown-target legs on
+/// add / set_role / remove, plus the exactly-one-action rule.
+#[tokio::test]
+async fn users_reject_invalid_role_unknown_target_and_bad_action() {
+    let mock = start_mock().await;
+    let proxy = start_proxy_with(&mock.url, support::StoreOpts::default(), &[]).await;
+    let root = support::login(&proxy).await;
+    for body in [
+        serde_json::json!({"add": {"username": "x", "password": "long-enough-pw", "role": "wizard"}}),
+        serde_json::json!({"remove": "ghost"}),
+        serde_json::json!({"set_role": {"username": "x", "role": "wizard"}}),
+        serde_json::json!({"set_role": {"username": "ghost", "role": "user"}}),
+        serde_json::json!({}),
+    ] {
+        let (s, v) = post_json(&proxy, &root, "/api/settings/users", body).await;
+        assert_eq!(s, 400, "{v}");
+    }
+}
+
+/// Scraper header auth: HTTP Basic works (and repeats hit the credential memo),
+/// while an unknown scheme, a wrong password, and a foreign cookie all 401.
+#[tokio::test]
+async fn scraper_header_auth_variants() {
+    let mock = start_mock().await;
+    let proxy = start_proxy(&mock.url, &[]).await;
+
+    for _ in 0..2 {
+        let r = client()
+            .get(proxy.url("/api/config"))
+            .basic_auth(support::TEST_USER, Some(support::TEST_PASSWORD))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(r.status(), 200, "HTTP Basic scrape credential");
+    }
+    let r = client()
+        .get(proxy.url("/api/config"))
+        .header("authorization", "Digest x")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 401, "unknown auth scheme");
+    let r = client()
+        .get(proxy.url("/api/config"))
+        .bearer_auth(format!("{}:wrong", support::TEST_USER))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 401, "wrong password");
+    let r = client()
+        .get(proxy.url("/api/config"))
+        .header("cookie", "foo=bar")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 401, "a foreign cookie is ignored");
+}
+
+/// Pre-setup, a non-HTML request to the operator surface answers 503
+/// setup_required rather than redirecting.
+#[tokio::test]
+async fn require_session_pre_setup_answers_setup_required_json() {
+    let proxy = start_proxy_fresh().await;
+    let r = client()
+        .get(proxy.url("/api/config"))
+        .header("accept", "application/json")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 503);
+    let v: serde_json::Value = r.json().await.unwrap();
+    assert_eq!(v["error"]["code"], "setup_required", "{v}");
+}
+
+/// GET /login redirects an already-authenticated user to the dashboard.
+#[tokio::test]
+async fn login_page_redirects_when_already_authenticated() {
+    let mock = start_mock().await;
+    let proxy = start_proxy(&mock.url, &[]).await;
+    let root = support::login(&proxy).await;
+    let r = no_redirect_client()
+        .get(proxy.url("/login"))
+        .header("cookie", &root)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 302);
+    assert_eq!(r.headers()["location"], "/");
+}
+
+/// POST /login before setup bounces to the wizard.
+#[tokio::test]
+async fn login_pre_setup_redirects_to_wizard() {
+    let proxy = start_proxy_fresh().await;
+    let r = no_redirect_client()
+        .post(proxy.url("/login"))
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body("username=x&password=yyyyyyyyyy")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 302);
+    assert_eq!(r.headers()["location"], "/setup");
+}
+
+/// An empty login body (both form fields absent) falls to the burner-hash path
+/// and still fails closed.
+#[tokio::test]
+async fn login_with_empty_body_fails_closed() {
+    let mock = start_mock().await;
+    let proxy = start_proxy(&mock.url, &[]).await;
+    let r = no_redirect_client()
+        .post(proxy.url("/login"))
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body("")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 401);
+}
+
+/// POST /logout clears the session cookie and redirects to the login page.
+#[tokio::test]
+async fn logout_clears_the_session_cookie() {
+    let mock = start_mock().await;
+    let proxy = start_proxy(&mock.url, &[]).await;
+    let root = support::login(&proxy).await;
+    let r = no_redirect_client()
+        .post(proxy.url("/logout"))
+        .header("cookie", &root)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 303);
+    assert_eq!(r.headers()["location"], "/login");
+    let set = r.headers()["set-cookie"].to_str().unwrap();
+    assert!(set.contains("nimproxy_session="), "{set}");
+    assert!(set.contains("Max-Age=0"), "{set}");
+}


### PR DESCRIPTION
## Summary

Maintenance release **v0.6.3** — supply-chain hardening, static-analysis cleanup, a test-coverage expansion, and a documentation/records refresh. No proxy behavior changes.

## Type of change

- [x] Security / hardening
- [x] Docs / knowledge base
- [x] CI / build / release infrastructure
- [x] Release (version bump)

## What & why

**1. Sign the downloadable release assets.** The container manifest was already cosign-signed, but the tarballs and SBOM on the GitHub Release were not. The `release` job now `cosign sign-blob`s each per-arch tarball and the SBOM (keyless, `id-token: write`), attaching a `.sig` + `.pem` per asset, with the `verify-blob` command in the release notes. Scorecard **Signed-Releases** lever.

**2. CodeQL `rust/hardcoded-cryptographic-value` triage.** All 5 Critical alerts are false positives (test fixtures + a `getrandom`-overwritten scratch buffer). Added `.github/codeql/codeql-config.yml` (`paths-ignore: [tests/**, fuzz/**]`, honored for Rust under `build-mode: none`); the rule stays active on `src/`. In-`src` `#[cfg(test)]` fixture alerts get dismissed in the UI.

**3. Test-coverage expansion — 91.4% → 96.1% lines / 97.5% functions (gate raised 80 → 90).** Evidence-driven from `cargo llvm-cov`, scoped by a strict YAGNI pass (a planned clock/injection seam was eliminated — the target branches were reachable without any production change), then hardened by two blind-review rounds:
- **Unit tests**: auth primitives (→ `auth.rs` **100%**), `config::validate` branches + serde-defaults + unreadable-store, `parse_role` (superuser never assignable), the SSE 1 MiB guard, history load/compaction + filesystem-failure fallbacks (→ `history.rs` 96.7%).
- **e2e tests** (existing harness): setup double-claim / orphan-adoption / invalid-config / throttled+failed key probes, nim-key/client/user validation + ownership legs, the auth handler surface (Basic scrape creds, login redirects, logout), plus boot refusal on empty `DATA_DIR` and the `--health` probe.
- **Documented residual** (deliberately uncovered, verified honest by audit): the handler stale-session/account arms — a genuine TOCTOU race across each handler's second, independent store-lock, not deterministically triggerable without a test-only sync hook (the underlying `apply_password_change` logic *is* unit-tested); `lib.rs` banner/logging and dead `GovernorSettings::default`; and the proxy request-flow branches (a future Wave 3).

**4. PR template** enriched into a standard, agent-legible form (typed sections + a checklist whose conditional groups name their trigger).

**5. Documentation-consistency pass**: recorded the full CI gate set + applied `main`/`v*` rulesets, added the fuzz test layer and signed-asset notes, fixed a stale `cargo audit` reference (→ `cargo-deny`) and an old version placeholder; cron-comment nits.

## How it was tested

```sh
cargo fmt --all --check                       # clean
cargo clippy --all-targets -- -D warnings     # clean
cargo test                                    # 84 lib + 72 e2e, all pass
cargo llvm-cov --fail-under-lines 90          # 96.09% lines, 97.47% functions — passes
```

Two blind Sonnet reviewers audited the additions: one for quality/flakiness (ran the setup double-claim race 15× — zero flakes; hand-verified base64 bit-math and throttle arithmetic → *ship*), one auditing exclusion-honesty (confirmed the residual is genuine, surfaced 6 cheap deterministic misses which were then added, and corrected the stale-session justification).

## Breaking changes & migration

None.

## Checklist

### Code quality
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo test` passes (84 lib + 72 e2e).
- [x] New behavior ships with tests — this PR *is* tests + CI/docs; no product-behavior change.

### Docs & knowledge base
- [x] README updated (Supply chain section; four testing layers).
- [x] `knowledge/` updated (test-strategy incl. coverage gate, release runbook, testing index).
- [x] Dated `knowledge/log.md` entries (incl. the two review rounds).
- [x] `CHANGELOG.md` promoted to `[0.6.3]`.

### Security
- [x] Extends artifact verifiability; CodeQL scope keeps queries on shipped source; new tests lock in fail-closed/ownership/label invariants.

### Workflows & supply chain
- [x] New/changed Actions SHA-pinned; new signing step shellcheck-clean; coverage gate raised to 90.
- [x] Version/release changes follow `knowledge/ops/release.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNL3aKt4QV8i1jTvAWZ1Av