### PR TITLE
Low-risk cleanup: drop dead async on streaming, remove redundant clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reused the destination buffer via `clone_from` when re-owning keys during
   superuser claim. `cargo clippy --all-targets -- -D warnings`, `cargo fmt`,
   and the full test suite (lib + e2e) stay green.
+- Rewrote the `Basic`-auth credential branch in `auth::identify` with the `?`
+  operator (behavior identical). Rust stable rolled to 1.97 on 2026-07-14 and
+  its improved `clippy::question_mark` lint flagged the old
+  `else if let … else { return None }` shape, breaking the `-D warnings` CI
+  job on code untouched by any open PR. Covered by the existing auth tests.
 
 ## [0.6.3] - 2026-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in `Cargo.toml` changed. Clears the `cargo-deny` advisories failure that was
   red on `main` and every open Dependabot PR.
 
+### Changed
+
+- Internal cleanup (no behavior change): dropped a redundant `async` on the
+  streaming handler (all `.await`s live inside its spawned task, so the
+  function itself never awaited — this avoids wrapping it in a needless
+  future), removed two redundant `String` clones on the key-add paths, and
+  reused the destination buffer via `clone_from` when re-owning keys during
+  superuser claim. `cargo clippy --all-targets -- -D warnings`, `cargo fmt`,
+  and the full test suite (lib + e2e) stay green.
+
 ## [0.6.3] - 2026-07-05
 
 Supply-chain and static-analysis release — no proxy behavior changes.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -25,6 +25,18 @@ superuser claim. Deliberately excluded as churn/net-negative: the 13
 false-positives). Verified: fmt clean, `clippy --all-targets -D warnings`
 clean, lib 84 + e2e 72 tests green.
 
+Follow-up (same PR): CI's `fmt, clippy, tests` job went red — not on the
+cleanup, but on pre-existing code. Rust stable rolled 1.94 → 1.97 on
+2026-07-14, and 1.97's improved `clippy::question_mark` now flags the
+`else if let Some(basic) = … else { return None }` shape in `auth::identify`
+under `-D warnings`. The Dependabot PRs (#47–49) had passed this job because
+they ran on 2026-07-09, before the toolchain bump; this PR was the first to
+run CI afterward, so it surfaced here. Applied clippy's own `?`-operator
+rewrite (behavior identical, auth tests cover it). Reproduced locally by
+`rustup update stable` to 1.97.1 before and after the fix. Because #52's head
+is the integration branch, merging this PR into it also clears the same
+failure for #52.
+
 ## [2026-07-16] lint — crossbeam-epoch advisory fix (RUSTSEC-2026-0204)
 
 `cargo-deny`'s advisories check went red on `main` — and therefore on every

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,25 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-16] lint — low-risk cleanup batch (dead async, redundant clones)
+
+Staged a tight, YAGNI-scoped cleanup batch on a sub-branch off the
+`claude/dependabot-pull-requests-2z8240` integration branch (PR into it, not
+into `main`). Scope was chosen for highest signal / least risk: (1) removed a
+redundant `async` on `proxy::streaming` — every `.await` lives inside its
+`tokio::spawn`ed task, so the function body only spawns and returns a
+`Response`; dropping `async` avoids a pointless future wrapper and the single
+caller drops its `.await`; (2) removed two redundant `String` clones on the
+nim-key / client-key add paths (the value was moved into the struct, not
+reused); (3) `clone_from` buffer reuse when re-owning orphan keys during
+superuser claim. Deliberately excluded as churn/net-negative: the 13
+`redundant_closure_for_method_calls` rewrites (`|x| x.as_u64()` →
+`serde_json::Value::as_u64`) which are longer and less readable, the
+`clone_into` inversions on cold config-write paths, and adding a new
+`[lints.clippy]` gate (not requested; nursery lints risk future CI
+false-positives). Verified: fmt clean, `clippy --all-targets -D warnings`
+clean, lib 84 + e2e 72 tests green.
+
 ## [2026-07-16] lint — crossbeam-epoch advisory fix (RUSTSEC-2026-0204)
 
 `cargo-deny`'s advisories check went red on `main` — and therefore on every

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -295,10 +295,9 @@ pub async fn identify(state: &Arc<AppState>, headers: &HeaderMap) -> Option<Stri
     let auth = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
     let cred = if let Some(bearer) = auth.strip_prefix("Bearer ") {
         bearer.trim().to_owned()
-    } else if let Some(basic) = auth.strip_prefix("Basic ") {
-        String::from_utf8(base64_decode(basic.trim())?).ok()?
     } else {
-        return None;
+        let basic = auth.strip_prefix("Basic ")?;
+        String::from_utf8(base64_decode(basic.trim())?).ok()?
     };
     if let Some(user) = state.admin.memo_hit(&cred) {
         return Some(user);

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -578,7 +578,6 @@ pub async fn handle(
             fallback,
             inflight_guard,
         )
-        .await
     } else {
         buffered(state, cfg, ctx, method, path_query, headers, body, prefer).await
     }
@@ -681,7 +680,7 @@ async fn buffered(
 /// comment lines (ignored by every OpenAI SSE client) while we wait for a
 /// slot or ride out 429/5xx, then pipe the upstream stream through.
 #[allow(clippy::too_many_arguments)]
-async fn streaming(
+fn streaming(
     state: Arc<AppState>,
     cfg: Arc<Config>,
     ctx: Ctx,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -129,12 +129,12 @@ pub async fn setup_submit(
         // ownership rule and the pool-floor invariant.
         for k in &mut cand.upstream.nim_keys {
             if k.owner != req.username {
-                k.owner = req.username.clone();
+                k.owner.clone_from(&req.username);
             }
         }
         for c in &mut cand.client_auth.keys {
             if c.owner != req.username {
-                c.owner = req.username.clone();
+                c.owner.clone_from(&req.username);
             }
         }
         if let Some(b) = &req.base_url {
@@ -436,7 +436,7 @@ pub async fn nim_keys(
         (Some(add), None, None) => {
             cand.upstream.nim_keys.push(NimKey {
                 key: add.key.trim().to_owned(),
-                owner: username.clone(),
+                owner: username,
                 enabled: true,
                 rpm: add.rpm.unwrap_or(40),
             });
@@ -515,7 +515,7 @@ pub async fn clients(
                 name: add.name.trim().to_owned(),
                 secret_sha256: auth::sha256_hex(&secret),
                 last4: last4(&secret),
-                owner: username.clone(),
+                owner: username,
             });
             minted = Some(secret);
         }


### PR DESCRIPTION
## Summary

A tight, YAGNI-scoped cleanup batch staged **into the integration branch** (`claude/dependabot-pull-requests-2z8240`, not `main`), so it sits alongside the crossbeam-epoch advisory fix while we decide merge vs. release. Every change either deletes code/allocations or reuses a buffer; none changes behavior. The scope was chosen for highest signal / least risk on an already-clean codebase (default `clippy -D warnings` was already green).

## Type of change

- [x] Refactor (no behavior change)
- [x] Performance / rate-limiting — minor: avoids a needless future wrapper on the stream path + a couple of allocations
- [ ] ~~Bug fix~~ — no defect being fixed
- [ ] ~~New feature / behavior change~~
- [ ] ~~Security / hardening~~
- [ ] ~~Docs / knowledge base only~~ — docs updated in lockstep, but the substance is code
- [ ] ~~Release (version bump)~~ — none

## Related issues

None.

## What & why

Three changes, each independently verifiable:

1. **`proxy::streaming` — drop redundant `async`.** Every `.await` in this handler lives inside its `tokio::spawn(async move { … })` task; the function body itself only creates the channel, spawns the task, and returns a `Response`. So the `async` on the fn signature just wrapped a synchronous body in a pointless future. Made it `fn` and dropped the single caller's `.await` (both `if`/`else` arms still yield `Response`, so it type-checks). This is compiler-guaranteed and exercised end-to-end by the e2e streaming tests.
2. **Remove two redundant `String` clones** (`settings::nim_keys`, `settings::clients`): `owner: username.clone()` where `username` is moved into the pushed struct and not used afterward → `owner: username`. A genuinely-needed clone here would fail to compile, so this is a safe, compiler-checked simplification.
3. **`clone_from` buffer reuse** when re-owning orphan keys during superuser claim (`settings::setup_submit`): `k.owner = req.username.clone()` → `k.owner.clone_from(&req.username)`, reusing the existing allocation instead of dropping it and allocating anew.

### Deliberately excluded (YAGNI / net-negative)

- The 13 `redundant_closure_for_method_calls` rewrites clippy suggests (`|x| x.as_u64()` → `serde_json::Value::as_u64`): they make the code **longer and less readable**. Churn, not cleanup.
- The `clone_into` inversions on cold config-write paths (`x.clone_into(&mut dest)` reads backwards for negligible gain).
- Adding a new `[lints.clippy]` gate: not requested, and nursery-tier lints risk future CI false-positives. Noted here as an *optional* follow-up if you later want these enforced rather than one-off.

## How it was tested

```sh
$ cargo fmt --check           # clean
$ cargo clippy --all-targets -- -D warnings   # clean
$ cargo test --lib            # test result: ok. 84 passed; 0 failed
$ cargo test --test e2e       # test result: ok. 72 passed; 0 failed
```

The e2e suite includes the streaming paths touched here (`stalled_upstream_stream_errors_out_within_idle_timeout`, `non_retryable_error_is_relayed_buffered_and_surfaced_in_stream`, etc.), so change (1) is validated behaviorally, not just by types.

## Breaking changes & migration

None. No public surface, config, on-disk format, or `/v1` behavior changed.

## Checklist

### Code quality
- [x] `cargo fmt --check` is clean.
- [x] `cargo clippy --all-targets -- -D warnings` is clean.
- [x] `cargo test` passes locally (lib 84 + e2e 72).
- [ ] ~~New behavior ships with tests~~ — no new behavior; existing e2e streaming tests cover the touched path.
- [x] Scope is tight; commit message explains the *why*.

### Docs & knowledge base
- [x] `CHANGELOG.md` `[Unreleased]` updated (`### Changed`).
- [x] Dated entry appended to `knowledge/log.md`.
- [ ] ~~README / `examples/` updated~~ — no user-facing behavior/setup change.
- [ ] ~~New decision page~~ — routine internal cleanup, not an architectural decision.

### Security — touches `src/settings.rs`
- [x] No change to the auth posture, API-key gate, or fail-closed behavior: the edits are an allocation reuse and two moved (rather than cloned) `owner` strings on already-authorized config-write handlers. Ownership/validation logic is untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DbTPXYSQ3iPSrpqJPgkTKw)_