### PR TITLE
Add absolute request deadlines for issue #50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the opt-in `X-Nim-Proxy-Deadline-Ms` request header: an absolute
+  wall-clock deadline enforced across queueing, worker admission, retries, and
+  generation. Buffered expiry returns `504 deadline_exceeded`; streaming
+  expiry emits the same error inside the committed SSE response. Expiry drops
+  upstream work and all request-owned permits, and is exposed as request status
+  `deadline` plus `nimproxy_deadline_exceeded_total`.
+
 ### Security
 
 - Bumped `crossbeam-epoch` to 0.9.20 in `Cargo.lock` to resolve

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ curl http://localhost:8000/v1/chat/completions \
        "messages":[{"role":"user","content":"hello"}]}'
 ```
 
+For benchmarks or bounded jobs, add
+`X-Nim-Proxy-Deadline-Ms: <milliseconds>`. This is an absolute wall-clock
+deadline across proxy queueing, retries, and generation; heartbeats and output
+chunks do not reset it. Buffered requests expire with HTTP 504 and error code
+`deadline_exceeded`. Streaming requests have already committed HTTP 200, so
+they receive the same code in a terminal SSE error event. Requests without the
+header retain the proxy's normal patient behavior.
+
 ## The dashboard
 
 Served at `GET /` — a single embedded HTML file, no Grafana, no config. Because the proxy sits in the request path for every harness and model, it doubles as a **benchmarking and agent-observability tool**: it sees how tool-heavy each harness is, how deep its conversations run, how it tunes sampling, where models truncate, and how much "thinking" a reasoning model burns — all from counts and sizes, never message content.
@@ -150,6 +158,7 @@ Every line chart has a hover crosshair with a per-series tooltip; every table is
 - **One queue for all clients.** Any number of harnesses share the lane pool through a global FIFO dispatcher: slots are granted strictly in arrival order, no client can starve another, and a client that disconnects while queued returns its slot.
 - **Sticky conversations, spread bursts.** Each conversation prefers the same lane every turn, keeping any server-side [prefix cache](https://docs.nvidia.com/nim/large-language-models/latest/kv-cache-reuse.html) warm on one key. When that lane is full the request spills to the least-loaded ready lane — the API is stateless, so crossing keys is always safe, just potentially a cold cache.
 - **Heartbeats instead of failures.** For streaming requests the proxy commits to `200 text/event-stream` immediately and emits SSE comment lines (`: heartbeat` — ignored by every OpenAI client) while it waits for a slot or rides out upstream 429/500/502/503/504 with `Retry-After` honored and instant failover between keys. Streams that stall mid-generation are cut after the `stream_idle` limit.
+- **Optional absolute deadlines.** `X-Nim-Proxy-Deadline-Ms` bounds the whole request independently of heartbeats or socket activity. Expiry cancels queue/retry/upstream work and releases its lane, model, and in-flight ownership.
 - **Model-pressure aware.** NIM caps per-model worker concurrency independently of the 40 RPM key limit; the proxy detects that specific exhaustion, backs off the affected *model* adaptively (never wasting healthy key capacity on failover), and surfaces it on the dashboard — see [architecture: governor](knowledge/architecture/governor.md).
 - **Pass-through with one exception.** Bodies are forwarded untouched, except: streaming chat requests get `stream_options: {"include_usage": true}` injected so token accounting is exact rather than estimated. If a model rejects the field, the proxy retries untouched and never injects for that model again. `strict_passthrough` in Settings disables injection entirely.
 - **Local answers where possible.** `GET /v1/models` is cached (10 min default, single-flight refresh), so harness catalog polls don't burn rate budget.
@@ -230,7 +239,8 @@ The build and release path is hardened to the OpenSSF baseline (scored weekly by
 
 | Metric | Labels | Meaning |
 |---|---|---|
-| `nimproxy_requests_total` | client, model, path, status | Every request (`status` includes `disconnect`, `stall`, `stream_error`) |
+| `nimproxy_requests_total` | client, model, path, status | Every request (`status` includes `disconnect`, `stall`, `stream_error`, `deadline`) |
+| `nimproxy_deadline_exceeded_total` | client, model, path | Requests stopped by `X-Nim-Proxy-Deadline-Ms` |
 | `nimproxy_prompt_tokens_total` | client, model | Prompt tokens, from upstream `usage` |
 | `nimproxy_completion_tokens_total` | client, model, source | Completion tokens; `usage` = exact, `estimate` = per-SSE-event fallback |
 | `nimproxy_ttft_seconds` | model | Upstream send → first streamed byte |

--- a/docs/superpowers/plans/2026-07-16-request-deadline.md
+++ b/docs/superpowers/plans/2026-07-16-request-deadline.md
@@ -1,0 +1,50 @@
+# Explicit Request Deadline Implementation Plan
+
+> **For agentic workers:** Implement inline with test-driven development; no subagents are needed for this maintenance change.
+
+**Goal:** Add an opt-in `X-Nim-Proxy-Deadline-Ms` absolute deadline that cancels buffered and streaming work and reports a distinct outcome.
+
+**Architecture:** Parse one checked absolute deadline in `proxy::handle`. Race the whole buffered request future and the spawned streaming workflow against that deadline so dropping the losing future releases existing RAII-owned resources. Keep all current behavior when the header is absent.
+
+**Tech Stack:** Rust, Axum, Tokio, reqwest, existing real-binary e2e harness.
+
+## Global Constraints
+
+- Build from integration commit `28ed638`, which contains the `crossbeam-epoch` security fix.
+- Do not change default patient behavior without the header.
+- Do not add dependencies or change lane/governor policy.
+- Invalid header details are returned only after normal client authentication.
+- Update the OKF knowledge graph and log with the behavior change.
+
+### Task 1: Deadline contract and lifecycle enforcement
+
+**Files:**
+- Modify: `tests/support/mod.rs`
+- Modify: `tests/e2e.rs`
+- Modify: `src/proxy.rs`
+
+**Interfaces:**
+- Consume request header `X-Nim-Proxy-Deadline-Ms` as canonical unsigned milliseconds.
+- Produce buffered `400 invalid_deadline` or `504 deadline_exceeded` responses.
+- Produce streaming SSE `deadline_exceeded` errors after the committed 200.
+- Produce request status `deadline` and `nimproxy_deadline_exceeded_total`.
+
+- [ ] Add deterministic mock behaviors for delayed headers and periodically active response bodies.
+- [ ] Add focused e2e tests for invalid/duplicate input, buffered expiry and resource release, active-stream expiry, metrics, and header-free compatibility.
+- [ ] Run each focused test and confirm it fails because deadline support is absent.
+- [ ] Implement canonical parsing plus buffered and streaming deadline races in `src/proxy.rs`.
+- [ ] Re-run focused tests until green, then run `cargo test`.
+
+### Task 2: Operator contract and repository memory
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+- Create: `knowledge/decisions/explicit-request-deadline.md`
+- Modify: `knowledge/architecture/streaming-pipeline.md`
+- Modify: `knowledge/index.md`
+- Modify: `knowledge/log.md`
+
+- [x] Document the header, buffered/streaming outcomes, metric, cancellation semantics, and alternatives.
+- [x] Run `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, `git diff --check`, and the repository's knowledge-link checks if present.
+- [x] Review the final diff for secret exposure, unrelated changes, and divergence from the approved design.

--- a/docs/superpowers/specs/2026-07-16-request-deadline-design.md
+++ b/docs/superpowers/specs/2026-07-16-request-deadline-design.md
@@ -59,9 +59,10 @@ shorten that caller's own request.
 - The deadline begins when `proxy::handle` accepts the request, before auth
   delay, parsing, queueing, or upstream work.
 - `0` is valid and means immediate expiry.
-- Leading or trailing whitespace, signs, decimal points, non-ASCII digits,
-  duplicate header values, values that do not fit `u64`, and durations that
-  cannot be added to the request start instant are invalid.
+- Signs, decimal points, non-ASCII digits, duplicate header values, values that
+  do not fit `u64`, and durations that cannot be added to the request start
+  instant are invalid. HTTP's ordinary optional-whitespace normalization
+  happens before application parsing.
 - Invalid values return HTTP 400 with OpenAI-style error code
   `invalid_deadline` before acquiring a model permit or RPM slot.
 - Normal authentication still runs before the invalid-header response, so the
@@ -102,11 +103,9 @@ absolute `std::time::Instant`. Parse the header once in `handle`, using
 instant with `checked_add` from the request start captured at the beginning of
 the handler.
 
-The value provides:
-
-- its absolute instant for Tokio timeout conversion;
-- an effective wait deadline equal to the earlier of the request deadline and
-  `Instant::now() + cfg.max_wait`.
+The value provides its absolute instant for Tokio timeout conversion. Existing
+admission code retains its `max_wait` deadline; the outer absolute timer owns
+explicit-deadline classification and cancels that admission future if it wins.
 
 No new dependency is required.
 
@@ -124,8 +123,8 @@ If the timeout wins:
 3. the proxy records `deadline` and increments the dedicated counter;
 4. the caller receives the 504 error contract above.
 
-The buffered loop also receives the effective wait deadline so queue/retry
-logic cannot outlive a shorter explicit deadline.
+The buffered loop retains its existing `max_wait` deadline. It cannot outlive a
+shorter explicit deadline because the outer timer drops the whole loop.
 
 ### Streaming path
 
@@ -150,11 +149,13 @@ queue heartbeats and body relay.
 - The explicit deadline is absolute and never resets on heartbeats, response
   bytes, retries, or worker-governor activity.
 - `max_wait` continues to classify ordinary admission/retry exhaustion as
-  status `504`; if the explicit deadline is earlier, expiry is classified as
-  `deadline`.
+  status `504`. A shorter explicit deadline is enforced by the outer timer and
+  classified as `deadline`, without triggering the dispatcher's predictive
+  fast-fail path.
 - `request_timeout` and `stream_idle` may fire first and retain their existing
   `502`/`stall` classifications.
-- A retry cannot start after the effective wait deadline.
+- A retry cannot start after the absolute deadline because the enclosing
+  workflow has been dropped.
 - The header cannot extend any existing limit.
 
 ## Security and Input Handling
@@ -224,4 +225,3 @@ the same secondary scan used in diagnosis:
 Secondary findings remain separately tracked unless evidence connects them to
 the deadline defect. In particular, the July 5 three-lane 429 retry storm is
 not part of this change.
-

--- a/docs/superpowers/specs/2026-07-16-request-deadline-design.md
+++ b/docs/superpowers/specs/2026-07-16-request-deadline-design.md
@@ -1,0 +1,227 @@
+# Explicit Request Deadline Design
+
+## Problem
+
+nim-proxy deliberately keeps requests patient while they wait for RPM capacity,
+model-worker capacity, or retryable upstream failures. Its existing timeouts are
+phase-specific:
+
+- `max_wait` bounds queueing and retries, but not a successful generation;
+- `request_timeout` bounds one buffered upstream attempt;
+- `stream_idle` bounds inactivity between streamed chunks, but active traffic
+  can continue indefinitely.
+
+Production logs from the Rambler model tournament show the consequence. A
+buffered Minimax request outlived its client and continued inside the proxy for
+825 seconds before being logged as `200`. Buffered HTTP handlers do not receive
+a reliable downstream-close notification while they are still waiting to
+produce a response, so client cancellation alone cannot bound orphaned work.
+Streaming requests observe downstream closure while relaying body chunks, but
+not in every phase before that relay begins.
+
+The proxy needs an opt-in, absolute wall-clock deadline that it owns and can
+enforce across the request's entire lifetime.
+
+## Goals
+
+- Let any `/v1` caller request a shorter absolute lifetime with
+  `X-Nim-Proxy-Deadline-Ms`.
+- Enforce the deadline through model admission, RPM queueing, upstream sends,
+  retry/error-body reads, buffered body reads, and active streaming.
+- Cancel in-progress upstream work as far as dropping the Rust future and HTTP
+  response permits.
+- Release queue reservations, model permits, active-request gauges, and the
+  global in-flight guard on expiry.
+- Classify deadline expiry separately in responses, access logs, Prometheus,
+  and history snapshots.
+- Preserve current behavior exactly when the header is absent.
+
+## Non-goals
+
+- Detect every buffered client disconnect immediately. Hyper does not expose a
+  general downstream-close signal before a buffered handler starts its
+  response; the explicit deadline bounds this unavoidable blind spot.
+- Add a server-wide generation timeout or change the defaults for existing
+  clients.
+- Persist per-request deadline state or expose it in the dashboard in this
+  change.
+- Change NIM lane pacing, retry policy, model-governor adaptation, or existing
+  phase-specific timeout settings.
+
+## Public Contract
+
+### Request header
+
+`X-Nim-Proxy-Deadline-Ms` is an unsigned decimal number of milliseconds. It is
+accepted for every authenticated or open-mode `/v1` caller because it can only
+shorten that caller's own request.
+
+- The deadline begins when `proxy::handle` accepts the request, before auth
+  delay, parsing, queueing, or upstream work.
+- `0` is valid and means immediate expiry.
+- Leading or trailing whitespace, signs, decimal points, non-ASCII digits,
+  duplicate header values, values that do not fit `u64`, and durations that
+  cannot be added to the request start instant are invalid.
+- Invalid values return HTTP 400 with OpenAI-style error code
+  `invalid_deadline` before acquiring a model permit or RPM slot.
+- Normal authentication still runs before the invalid-header response, so the
+  header does not become an authentication oracle.
+
+### Expiry response
+
+For buffered requests, expiry returns HTTP 504:
+
+```json
+{
+  "error": {
+    "message": "proxy request deadline exceeded",
+    "type": "proxy_error",
+    "code": "deadline_exceeded"
+  }
+}
+```
+
+For streaming requests, HTTP 200 has already been committed. Expiry emits one
+SSE `error` event containing the same message and code when the downstream is
+still connected, then closes the stream. If the downstream has already gone,
+the send may fail, but cleanup and accounting still occur.
+
+Expiry is recorded as `nimproxy_requests_total{status="deadline"}` and in the
+access log with status `deadline`. A dedicated counter,
+`nimproxy_deadline_exceeded_total{client,model,path}`, makes the outcome easy to
+query without changing the bounded label sets already used by request metrics.
+The existing history sampler automatically persists both counters.
+
+## Internal Design
+
+### Deadline representation and parsing
+
+Add a small private `RequestDeadline` value in `src/proxy.rs` containing the
+absolute `std::time::Instant`. Parse the header once in `handle`, using
+`HeaderMap::get_all` to reject duplicates explicitly. Derive the absolute
+instant with `checked_add` from the request start captured at the beginning of
+the handler.
+
+The value provides:
+
+- its absolute instant for Tokio timeout conversion;
+- an effective wait deadline equal to the earlier of the request deadline and
+  `Instant::now() + cfg.max_wait`.
+
+No new dependency is required.
+
+### Buffered path
+
+Keep the existing buffered retry loop and phase-specific timeout behavior.
+When an explicit deadline exists, run the whole buffered future under
+`tokio::time::timeout_at`.
+
+If the timeout wins:
+
+1. dropping the buffered future drops any pending dispatcher receiver,
+   `ModelPermit`, reqwest send/body future, and active-request guard;
+2. the handler's in-flight guard drops when the 504 response returns;
+3. the proxy records `deadline` and increments the dedicated counter;
+4. the caller receives the 504 error contract above.
+
+The buffered loop also receives the effective wait deadline so queue/retry
+logic cannot outlive a shorter explicit deadline.
+
+### Streaming path
+
+The streaming handler continues to return an SSE response immediately. Inside
+its spawned request-lifetime task, construct the existing streaming workflow as
+one future and race it against `tokio::time::sleep_until` for the explicit
+deadline. Without a header, use a pending future so the existing workflow is
+unchanged.
+
+If the deadline wins, dropping the workflow future drops any dispatcher
+receiver, model permit, pending reqwest send/error-body read, or active upstream
+body stream. The outer task then records `deadline`, increments the counter,
+attempts the terminal SSE error, and exits. Existing in-flight and active
+guards remain owned by the outer task and drop on exit.
+
+This outer race closes the gaps where the current streaming path does not watch
+`tx.closed()`, while retaining the faster existing disconnect detection during
+queue heartbeats and body relay.
+
+### Interaction with existing limits
+
+- The explicit deadline is absolute and never resets on heartbeats, response
+  bytes, retries, or worker-governor activity.
+- `max_wait` continues to classify ordinary admission/retry exhaustion as
+  status `504`; if the explicit deadline is earlier, expiry is classified as
+  `deadline`.
+- `request_timeout` and `stream_idle` may fire first and retain their existing
+  `502`/`stall` classifications.
+- A retry cannot start after the effective wait deadline.
+- The header cannot extend any existing limit.
+
+## Security and Input Handling
+
+The header is untrusted input. Parsing accepts only one canonical decimal
+value and uses checked time arithmetic. It is never copied into logs or metric
+labels. Existing client/model/path label sanitization remains the only source
+of deadline metric labels.
+
+Allowing the header in open mode does not grant additional capacity or access:
+it only causes earlier cancellation of the request carrying it. Authentication
+continues to precede detailed validation errors.
+
+## Tests
+
+Use the real-binary end-to-end harness and its scriptable upstream. Extend the
+mock only with deterministic behaviors needed to hold specific phases open.
+
+Required cases:
+
+1. malformed and duplicate headers return `400 invalid_deadline` with zero
+   upstream hits;
+2. `0` expires immediately as `504 deadline_exceeded`;
+3. a buffered request expires while awaiting response headers, and the next
+   request proves the in-flight slot was released;
+4. a buffered response body expires despite periodic upstream body activity;
+5. a streaming request expires while queued or retrying and emits the terminal
+   SSE error;
+6. an actively producing stream expires despite chunks arriving more often
+   than `stream_idle`;
+7. model and in-flight permits are available immediately after expiry;
+8. metrics contain request status `deadline` and the dedicated counter;
+9. a request without the header retains the current patient behavior;
+10. an explicit deadline cannot extend a shorter existing phase timeout.
+
+Each behavior is implemented test-first: add one failing test, verify the
+expected failure, add only enough production code to pass it, and run the
+focused test again before proceeding.
+
+## Documentation and Knowledge Ingest
+
+Implementation updates:
+
+- `README.md` with the opt-in header, buffered 504, streaming SSE outcome, and
+  the new metric;
+- `knowledge/architecture/streaming-pipeline.md` with the absolute deadline and
+  cancellation ownership;
+- a new decision page
+  `knowledge/decisions/explicit-request-deadline.md` covering client-only,
+  server-wide, and opt-in alternatives;
+- `knowledge/index.md` and `knowledge/log.md` per repository maintenance rules;
+- `CHANGELOG.md` under Unreleased.
+
+## Investigation Discipline
+
+During implementation and verification, every selected log or test slice gets
+the same secondary scan used in diagnosis:
+
+1. Why is this evidence relevant to the deadline hypothesis?
+2. Does anything adjacent look anomalous even if unrelated?
+3. Has the same client, model, lane, status, or duration pattern appeared
+   elsewhere?
+4. Which resource owner should release at this boundary, and is there evidence
+   it did?
+5. Is missing observability preventing a firm conclusion?
+
+Secondary findings remain separately tracked unless evidence connects them to
+the deadline defect. In particular, the July 5 three-lane 429 retry storm is
+not part of this change.
+

--- a/knowledge/architecture/streaming-pipeline.md
+++ b/knowledge/architecture/streaming-pipeline.md
@@ -1,9 +1,9 @@
 ---
 type: Component
 title: Streaming pipeline (src/proxy.rs)
-description: SSE commitment, heartbeats, retry/failover, usage injection, idle cutoff, and token scanning.
-tags: [streaming, sse, retries, metrics]
-timestamp: 2026-07-02T00:00:00Z
+description: SSE commitment, heartbeats, retry/failover, absolute deadlines, idle cutoff, and token scanning.
+tags: [streaming, sse, retries, deadlines, metrics]
+timestamp: 2026-07-16T00:00:00Z
 ---
 
 # Streaming pipeline — `src/proxy.rs`
@@ -23,7 +23,13 @@ For a `stream: true` chat request:
    model; 429/500/502/503/504 → bench the lane, `: retrying` comment, loop
    (instant failover to other lanes); other non-2xx → relay as an in-stream
    `error` event; success → pipe.
-5. **Pipe with watchdog**: chunks forward verbatim while `SseScan` (a
+5. **Race the absolute deadline**: when the caller supplies
+   `X-Nim-Proxy-Deadline-Ms`, the spawned workflow races one absolute timer
+   that never resets on heartbeats, retries, or data. Expiry drops the whole
+   workflow (reqwest work + model/queue ownership), records status `deadline`,
+   and best-effort sends a terminal `deadline_exceeded` SSE error. See the
+   [deadline decision](../decisions/explicit-request-deadline.md).
+6. **Pipe with watchdog**: chunks forward verbatim while `SseScan` (a
    line-reassembling observer) counts data events and extracts the `usage`
    object. Each upstream read races two exits in a `select!`: the
    `stream_idle` timeout cuts stalled upstreams with an in-stream error
@@ -32,10 +38,12 @@ For a `stream: true` chat request:
    time rather than at the stall cutoff (with `stream_idle` 0 there is no
    cutoff, so this is what prevents hung upstreams from pinning slots until
    restart).
-6. **Account**: TTFT histogram at first chunk; tokens/sec and prompt/
+7. **Account**: TTFT histogram at first chunk; tokens/sec and prompt/
    completion counters at end (`source="usage"` exact, `"estimate"` =
    one-per-event fallback); one access-log line per request.
 
-Non-streaming requests use the same wait/retry loop minus heartbeats, and
-harvest `usage` from the buffered JSON. `/v1/models` GETs short-circuit to a
-TTL cache with single-flight refresh.
+Non-streaming requests use the same wait/retry loop minus heartbeats and
+harvest `usage` from the buffered JSON. An explicit deadline races the whole
+buffered future, which is also how the proxy bounds upstream work after an
+otherwise-unobservable buffered client disconnect. `/v1/models` GETs
+short-circuit to a TTL cache with single-flight refresh.

--- a/knowledge/decisions/explicit-request-deadline.md
+++ b/knowledge/decisions/explicit-request-deadline.md
@@ -1,0 +1,63 @@
+---
+type: Decision
+title: Opt-in absolute request deadlines
+description: A caller-supplied deadline bounds the whole proxy lifecycle independently of heartbeats and phase-specific timeouts.
+tags: [timeouts, cancellation, streaming, benchmarking]
+timestamp: 2026-07-16T00:00:00Z
+---
+
+# Opt-in absolute request deadlines
+
+## Context
+
+The proxy is deliberately patient: it waits through RPM saturation, model
+worker pressure, and retryable upstream failures. Its existing limits are
+phase-specific. `max_wait` bounds admission and retries, `request_timeout`
+bounds one buffered upstream attempt, and `stream_idle` bounds gaps between
+stream chunks. None bounds an actively producing request end to end.
+
+Rambler's NIM model tournament exposed the operational consequence: a buffered
+request continued upstream for 825 seconds after its client had timed out.
+Buffered handlers cannot reliably observe a downstream disconnect before they
+have a response to write. Streaming handlers can observe many disconnects, but
+heartbeats and regular chunks also keep ordinary socket read timeouts alive.
+
+## Options
+
+1. Rely on client timeouts. Rejected: activity resets read timeouts, and a
+   disconnected buffered client does not cancel the proxy's upstream future.
+2. Add one server-wide maximum. Rejected: it would weaken the patient default
+   for agent harnesses and make one duration serve unrelated workloads.
+3. Accept an opt-in absolute request deadline. It lets bounded workloads state
+   their policy without changing other clients.
+
+## Choice
+
+Option 3. Any `/v1` caller may send `X-Nim-Proxy-Deadline-Ms` with one unsigned
+decimal millisecond value. The clock starts when the handler accepts the
+request and never resets. The buffered request future or spawned streaming
+workflow races that absolute instant; when the timer wins, dropping the work
+future cancels reqwest work and releases dispatcher, governor, active-request,
+and in-flight ownership through existing RAII guards.
+
+Buffered expiry returns HTTP 504 with `deadline_exceeded`. A stream has already
+committed HTTP 200, so it gets a terminal SSE error with that code when channel
+capacity permits; delivery is best-effort so a slow downstream cannot delay
+cleanup. Invalid headers fail with `invalid_deadline` after normal client auth
+and before upstream admission.
+
+## Consequences
+
+- Benchmarks get a true wall-clock bound through queueing, retries, and active
+  generation.
+- Buffered work that cannot notice client disconnect is bounded by a deadline
+  the proxy can enforce itself.
+- Requests without the header behave exactly as before.
+- Deadline expiry has request status `deadline` and a dedicated
+  `nimproxy_deadline_exceeded_total{client,model,path}` counter.
+- A caller can only shorten its own work, so the header is safe in open mode.
+- The feature does not provide immediate buffered-disconnect detection; that
+  remains a transport limitation.
+
+See the [streaming pipeline](../architecture/streaming-pipeline.md) for task
+ownership and cancellation flow.

--- a/knowledge/decisions/index.md
+++ b/knowledge/decisions/index.md
@@ -18,3 +18,4 @@ description: Lightweight ADRs — context, options, choice, consequences.
 - [input-sanitizing-and-xss](input-sanitizing-and-xss.md)
 - [dashboard-operator-console-redesign](dashboard-operator-console-redesign.md)
 - [ui-managed-config-store](ui-managed-config-store.md)
+- [explicit-request-deadline](explicit-request-deadline.md)

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -29,6 +29,7 @@ the chronology in [log.md](log.md).
 | [request-shape-metrics](decisions/request-shape-metrics.md) | Capture agent-behavior & quality signal as bounded metrics — counts, never content — for benchmarking |
 | [dashboard-operator-console-redesign](decisions/dashboard-operator-console-redesign.md) | 6→5 tabs (Compare merged in), dark-only palette, webfonts via Google Fonts CDN under CSP, window-halves delta chips |
 | [ui-managed-config-store](decisions/ui-managed-config-store.md) | App config moves from env into a JSON store edited from the dashboard; first-run wizard, multi-user + per-key ownership, no encryption at rest |
+| [explicit-request-deadline](decisions/explicit-request-deadline.md) | Opt-in wall-clock bound cancels queue/retry/generation work without weakening patient defaults |
 
 ## Research — validated external facts
 
@@ -45,7 +46,7 @@ the chronology in [log.md](log.md).
 | [key-pool](architecture/key-pool.md) | Per-key sliding-window lanes; least-loaded selection; cooldown benching |
 | [dispatcher](architecture/dispatcher.md) | Global FIFO slot queue; abandoned-waiter slot return; affinity accounting |
 | [governor](architecture/governor.md) | Per-model concurrency gate; classifies worker exhaustion apart from 429s and backs off the model, adaptively |
-| [streaming-pipeline](architecture/streaming-pipeline.md) | Heartbeats, retry/failover, idle timeout, SSE usage scanning |
+| [streaming-pipeline](architecture/streaming-pipeline.md) | Heartbeats, retry/failover, absolute deadlines, idle timeout, SSE usage scanning |
 | [metrics-history](architecture/metrics-history.md) | Prometheus registry + 5-min snapshot history replayed by the dashboard |
 | [dashboard](architecture/dashboard.md) | Single embedded HTML; dark operator console; 5 tabs; hover charts & sortable tables |
 | [client-auth](architecture/client-auth.md) | `/v1` client keys (open/keyed) + store-backed multi-user dashboard sessions; fail-closed posture |

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -37,6 +37,18 @@ rewrite (behavior identical, auth tests cover it). Reproduced locally by
 is the integration branch, merging this PR into it also clears the same
 failure for #52.
 
+## [2026-07-16] decision — opt-in absolute request deadlines
+
+Rambler's model tournament showed a buffered request continuing inside the
+proxy for 825 seconds after its client timed out. Root cause: `max_wait`,
+`request_timeout`, and `stream_idle` bound individual phases, while buffered
+handlers cannot reliably observe a downstream disconnect before producing a
+response. Added `X-Nim-Proxy-Deadline-Ms` as an opt-in absolute clock across
+admission, retries, and generation. Expiry drops the request workflow and its
+RAII-owned resources; buffered callers receive `504 deadline_exceeded`, while
+streams receive a best-effort terminal SSE error. Status `deadline` and
+`nimproxy_deadline_exceeded_total` make the outcome independently visible.
+
 ## [2026-07-16] lint — crossbeam-epoch advisory fix (RUSTSEC-2026-0204)
 
 `cargo-deny`'s advisories check went red on `main` — and therefore on every

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -34,6 +34,37 @@ struct Ctx {
 /// Cap on distinct `model` label values tracked, past which new models are
 /// bucketed to "other" so an attacker can't explode metric cardinality.
 const MODEL_LABEL_CAP: usize = 256;
+const DEADLINE_HEADER: &str = "x-nim-proxy-deadline-ms";
+
+#[derive(Clone, Copy)]
+struct RequestDeadline(Instant);
+
+fn parse_request_deadline(
+    headers: &HeaderMap,
+    accepted: Instant,
+) -> Result<Option<RequestDeadline>, ()> {
+    let mut values = headers.get_all(DEADLINE_HEADER).iter();
+    let Some(value) = values.next() else {
+        return Ok(None);
+    };
+    if values.next().is_some() {
+        return Err(());
+    }
+    let raw = value.to_str().map_err(|_| ())?;
+    if raw.is_empty() || !raw.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(());
+    }
+    let millis = raw.parse::<u64>().map_err(|_| ())?;
+    accepted
+        .checked_add(Duration::from_millis(millis))
+        .map(RequestDeadline)
+        .map(Some)
+        .ok_or(())
+}
+
+fn wait_deadline(cfg: &Config) -> Instant {
+    Instant::now() + cfg.max_wait
+}
 
 /// Reduce an arbitrary client-supplied string to a safe metric-label / log
 /// value: keep a conservative charset (which model ids use), drop everything
@@ -199,6 +230,17 @@ fn record_request(ctx: &Ctx, status: &str) {
         ctx.path,
         ctx.started.elapsed().as_millis()
     );
+}
+
+fn record_deadline(ctx: &Ctx) {
+    counter!(
+        "nimproxy_deadline_exceeded_total",
+        "client" => ctx.client.clone(),
+        "model" => ctx.model.clone(),
+        "path" => ctx.path.clone(),
+    )
+    .increment(1);
+    record_request(ctx, "deadline");
 }
 
 fn record_tokens(ctx: &Ctx, prompt: Option<u64>, completion: Option<u64>, source: &str) {
@@ -441,6 +483,7 @@ pub async fn handle(
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {
+    let accepted = Instant::now();
     // Fail closed until first-time setup completes: nothing proxies, and the
     // error tells the operator exactly why.
     if state
@@ -504,6 +547,11 @@ pub async fn handle(
         }
     };
 
+    let request_deadline = match parse_request_deadline(&headers, accepted) {
+        Ok(deadline) => deadline,
+        Err(()) => return invalid_deadline(),
+    };
+
     let path_query = uri
         .path_and_query()
         .map(|pq| pq.as_str().to_owned())
@@ -524,6 +572,18 @@ pub async fn handle(
     // Answer the model-catalog probe from cache: harnesses poll it and it
     // shouldn't burn rate-limit budget on every poll.
     if method == Method::GET && uri.path() == "/v1/models" {
+        if let Some(deadline) = request_deadline {
+            return match tokio::time::timeout_at(deadline.0.into(), models(state, cfg)).await {
+                Ok(resp) => {
+                    record_request(&ctx, resp.status().as_str());
+                    resp
+                }
+                Err(_) => {
+                    record_deadline(&ctx);
+                    deadline_exceeded()
+                }
+            };
+        }
         let resp = models(state, cfg).await;
         record_request(&ctx, resp.status().as_str());
         return resp;
@@ -566,6 +626,7 @@ pub async fn handle(
     }
 
     if wants_stream {
+        let wait_deadline = wait_deadline(&cfg);
         streaming(
             state,
             cfg,
@@ -577,9 +638,34 @@ pub async fn handle(
             prefer,
             fallback,
             inflight_guard,
+            request_deadline,
+            wait_deadline,
         )
     } else {
-        buffered(state, cfg, ctx, method, path_query, headers, body, prefer).await
+        let wait_deadline = wait_deadline(&cfg);
+        let deadline_ctx = ctx.clone();
+        let work = buffered(
+            state,
+            cfg,
+            ctx,
+            method,
+            path_query,
+            headers,
+            body,
+            prefer,
+            wait_deadline,
+        );
+        if let Some(deadline) = request_deadline {
+            match tokio::time::timeout_at(deadline.0.into(), work).await {
+                Ok(response) => response,
+                Err(_) => {
+                    record_deadline(&deadline_ctx);
+                    deadline_exceeded()
+                }
+            }
+        } else {
+            work.await
+        }
     }
 }
 
@@ -612,10 +698,10 @@ async fn buffered(
     headers: HeaderMap,
     body: Bytes,
     prefer: Option<usize>,
+    deadline: Instant,
 ) -> Response {
     let _active = crate::dispatch::scopeguard(|| gauge!("nimproxy_active_requests").decrement(1.0));
     gauge!("nimproxy_active_requests").increment(1.0);
-    let deadline = Instant::now() + cfg.max_wait;
     loop {
         // Two admission gates: a model-pressure permit (worker concurrency,
         // held through the whole upstream exchange — dropped on every exit
@@ -691,6 +777,8 @@ fn streaming(
     prefer: Option<usize>,
     mut fallback: Option<Bytes>,
     inflight_guard: impl Send + 'static,
+    request_deadline: Option<RequestDeadline>,
+    deadline: Instant,
 ) -> Response {
     let (tx, rx) = mpsc::channel::<Result<Bytes, std::io::Error>>(16);
 
@@ -701,208 +789,226 @@ fn streaming(
         let _active =
             crate::dispatch::scopeguard(|| gauge!("nimproxy_active_requests").decrement(1.0));
         gauge!("nimproxy_active_requests").increment(1.0);
-        let send = |b: &'static str| {
-            let tx = tx.clone();
-            // Static control frames — no per-send alloc/copy.
-            async move { tx.send(Ok(Bytes::from_static(b.as_bytes()))).await.is_ok() }
-        };
-        if !send(": connected\n\n").await {
-            record_request(&ctx, "disconnect");
-            return;
-        }
-        let deadline = Instant::now() + cfg.max_wait;
-        loop {
-            // Model-pressure permit first (worker concurrency), then an RPM
-            // slot — both heartbeating so the harness doesn't hang up. The
-            // permit spans the whole upstream exchange and drops on every
-            // exit from this iteration.
-            let Ok(_permit) = acquire_model_permit(&state, &cfg, &ctx, deadline, || {
-                tx.try_send(Ok(Bytes::from_static(b": heartbeat\n\n")))
-                    .is_ok()
-            })
-            .await
-            else {
-                record_request(&ctx, "504");
-                let _ = tx
-                    .send(Ok(sse_error(
-                        "proxy timed out waiting for an upstream slot",
-                    )))
-                    .await;
+        let deadline_tx = tx.clone();
+        let deadline_ctx = ctx.clone();
+        let work = async move {
+            let send = |b: &'static str| {
+                let tx = tx.clone();
+                // Static control frames — no per-send alloc/copy.
+                async move { tx.send(Ok(Bytes::from_static(b.as_bytes()))).await.is_ok() }
+            };
+            if !send(": connected\n\n").await {
+                record_request(&ctx, "disconnect");
                 return;
-            };
-            let slot = reserve_slot(&state, cfg.heartbeat, deadline, prefer, || {
-                tx.try_send(Ok(Bytes::from_static(b": heartbeat\n\n")))
-                    .is_ok()
-            })
-            .await;
-            let Some(slot) = slot else {
-                record_request(&ctx, "504");
-                let _ = tx
-                    .send(Ok(sse_error(
-                        "proxy timed out waiting for an upstream slot",
-                    )))
-                    .await;
-                return;
-            };
-
-            let sent_at = Instant::now();
-            let resp = match upstream_request(
-                &state.http,
-                &cfg.base_url,
-                &method,
-                &path_query,
-                &headers,
-                &slot.key,
-                &body,
-            )
-            .send()
-            .await
-            {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::warn!(lane = slot.lane, error = %e, "upstream connection error, retrying");
-                    bench(&slot, "connect", Duration::from_secs(5));
-                    continue;
-                }
-            };
-
-            // A 400 right after we injected stream_options usually means this
-            // model rejects the field: remember that and retry untouched.
-            if resp.status() == reqwest::StatusCode::BAD_REQUEST && fallback.is_some() {
-                tracing::info!(model = %ctx.model, "model rejected stream_options; retrying without injection");
-                state.no_inject.lock().unwrap().insert(ctx.model.clone());
-                body = fallback.take().unwrap();
-                continue;
             }
-
-            if retryable(resp.status()) {
-                if Instant::now() >= deadline {
+            loop {
+                // Model-pressure permit first (worker concurrency), then an RPM
+                // slot — both heartbeating so the harness doesn't hang up. The
+                // permit spans the whole upstream exchange and drops on every
+                // exit from this iteration.
+                let Ok(_permit) = acquire_model_permit(&state, &cfg, &ctx, deadline, || {
+                    tx.try_send(Ok(Bytes::from_static(b": heartbeat\n\n")))
+                        .is_ok()
+                })
+                .await
+                else {
                     record_request(&ctx, "504");
                     let _ = tx
-                        .send(Ok(sse_error("upstream unavailable, retries exhausted")))
+                        .send(Ok(sse_error(
+                            "proxy timed out waiting for an upstream slot",
+                        )))
                         .await;
                     return;
-                }
-                let status = resp.status();
-                let backoff = backoff_for(&resp);
-                // Worker exhaustion is model-scoped: back off the model via
-                // the governor, never the lane (see `buffered`).
-                let detail = resp.text().await.unwrap_or_default();
-                if governor::is_worker_exhausted(&detail) {
-                    state.governor.note_exhausted(
-                        &ctx.model,
-                        cfg.governor.overrides.get(&ctx.model).copied(),
-                    );
-                } else {
-                    tracing::info!(lane = slot.lane, %status, ?backoff, "lane benched, retrying");
-                    bench(&slot, status.as_str(), backoff);
-                }
-                if !send(": retrying\n\n").await {
-                    record_request(&ctx, "disconnect");
+                };
+                let slot = reserve_slot(&state, cfg.heartbeat, deadline, prefer, || {
+                    tx.try_send(Ok(Bytes::from_static(b": heartbeat\n\n")))
+                        .is_ok()
+                })
+                .await;
+                let Some(slot) = slot else {
+                    record_request(&ctx, "504");
+                    let _ = tx
+                        .send(Ok(sse_error(
+                            "proxy timed out waiting for an upstream slot",
+                        )))
+                        .await;
                     return;
-                }
-                continue;
-            }
+                };
 
-            if !resp.status().is_success() {
-                // Non-retryable upstream error after we already committed to
-                // SSE: surface it as an in-stream error event.
-                let status = resp.status();
-                let detail = resp.text().await.unwrap_or_default();
-                tracing::warn!(%status, "upstream rejected request");
-                record_request(&ctx, status.as_str());
-                let _ = tx
-                    .send(Ok(sse_error(&format!("upstream error {status}: {detail}"))))
-                    .await;
-                return;
-            }
-
-            let mut scan = SseScan::default();
-            let mut first_chunk: Option<Instant> = None;
-            let mut chunks = resp.bytes_stream();
-            loop {
-                // Two ways out of a blocked upstream read: the stall cutoff
-                // (a stalled upstream would otherwise hold the client
-                // forever), and the client hanging up (`tx.closed()`) — which
-                // must free the in-flight slot promptly, not at the cutoff
-                // (and with stream_idle 0 there is no cutoff: a hung upstream
-                // would pin the slot until restart).
-                let upstream_read = async {
-                    if cfg.stream_idle.is_zero() {
-                        Ok(chunks.next().await)
-                    } else {
-                        tokio::time::timeout(cfg.stream_idle, chunks.next()).await
+                let sent_at = Instant::now();
+                let resp = match upstream_request(
+                    &state.http,
+                    &cfg.base_url,
+                    &method,
+                    &path_query,
+                    &headers,
+                    &slot.key,
+                    &body,
+                )
+                .send()
+                .await
+                {
+                    Ok(r) => r,
+                    Err(e) => {
+                        tracing::warn!(lane = slot.lane, error = %e, "upstream connection error, retrying");
+                        bench(&slot, "connect", Duration::from_secs(5));
+                        continue;
                     }
                 };
-                let next = tokio::select! {
-                    _ = tx.closed() => {
+
+                // A 400 right after we injected stream_options usually means this
+                // model rejects the field: remember that and retry untouched.
+                if resp.status() == reqwest::StatusCode::BAD_REQUEST && fallback.is_some() {
+                    tracing::info!(model = %ctx.model, "model rejected stream_options; retrying without injection");
+                    state.no_inject.lock().unwrap().insert(ctx.model.clone());
+                    body = fallback.take().unwrap();
+                    continue;
+                }
+
+                if retryable(resp.status()) {
+                    if Instant::now() >= deadline {
+                        record_request(&ctx, "504");
+                        let _ = tx
+                            .send(Ok(sse_error("upstream unavailable, retries exhausted")))
+                            .await;
+                        return;
+                    }
+                    let status = resp.status();
+                    let backoff = backoff_for(&resp);
+                    // Worker exhaustion is model-scoped: back off the model via
+                    // the governor, never the lane (see `buffered`).
+                    let detail = resp.text().await.unwrap_or_default();
+                    if governor::is_worker_exhausted(&detail) {
+                        state.governor.note_exhausted(
+                            &ctx.model,
+                            cfg.governor.overrides.get(&ctx.model).copied(),
+                        );
+                    } else {
+                        tracing::info!(lane = slot.lane, %status, ?backoff, "lane benched, retrying");
+                        bench(&slot, status.as_str(), backoff);
+                    }
+                    if !send(": retrying\n\n").await {
                         record_request(&ctx, "disconnect");
                         return;
                     }
-                    read = upstream_read => match read {
-                        Ok(n) => n,
-                        Err(_) => {
-                            tracing::warn!(model = %ctx.model, idle = ?cfg.stream_idle, "upstream stream stalled");
-                            record_request(&ctx, "stall");
-                            let _ = tx.send(Ok(sse_error("upstream stream stalled"))).await;
+                    continue;
+                }
+
+                if !resp.status().is_success() {
+                    // Non-retryable upstream error after we already committed to
+                    // SSE: surface it as an in-stream error event.
+                    let status = resp.status();
+                    let detail = resp.text().await.unwrap_or_default();
+                    tracing::warn!(%status, "upstream rejected request");
+                    record_request(&ctx, status.as_str());
+                    let _ = tx
+                        .send(Ok(sse_error(&format!("upstream error {status}: {detail}"))))
+                        .await;
+                    return;
+                }
+
+                let mut scan = SseScan::default();
+                let mut first_chunk: Option<Instant> = None;
+                let mut chunks = resp.bytes_stream();
+                loop {
+                    // Two ways out of a blocked upstream read: the stall cutoff
+                    // (a stalled upstream would otherwise hold the client
+                    // forever), and the client hanging up (`tx.closed()`) — which
+                    // must free the in-flight slot promptly, not at the cutoff
+                    // (and with stream_idle 0 there is no cutoff: a hung upstream
+                    // would pin the slot until restart).
+                    let upstream_read = async {
+                        if cfg.stream_idle.is_zero() {
+                            Ok(chunks.next().await)
+                        } else {
+                            tokio::time::timeout(cfg.stream_idle, chunks.next()).await
+                        }
+                    };
+                    let next = tokio::select! {
+                        _ = tx.closed() => {
+                            record_request(&ctx, "disconnect");
+                            return;
+                        }
+                        read = upstream_read => match read {
+                            Ok(n) => n,
+                            Err(_) => {
+                                tracing::warn!(model = %ctx.model, idle = ?cfg.stream_idle, "upstream stream stalled");
+                                record_request(&ctx, "stall");
+                                let _ = tx.send(Ok(sse_error("upstream stream stalled"))).await;
+                                return;
+                            }
+                        }
+                    };
+                    let Some(chunk) = next else { break };
+                    match chunk {
+                        Ok(b) => {
+                            if first_chunk.is_none() {
+                                first_chunk = Some(Instant::now());
+                                histogram!("nimproxy_ttft_seconds", "model" => ctx.model.clone())
+                                    .record(sent_at.elapsed().as_secs_f64());
+                            }
+                            scan.feed(&b);
+                            if tx.send(Ok(b)).await.is_err() {
+                                record_request(&ctx, "disconnect");
+                                return; // client hung up
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "upstream stream broke mid-response");
+                            record_request(&ctx, "stream_error");
+                            let _ = tx.send(Ok(sse_error("upstream stream interrupted"))).await;
                             return;
                         }
                     }
-                };
-                let Some(chunk) = next else { break };
-                match chunk {
-                    Ok(b) => {
-                        if first_chunk.is_none() {
-                            first_chunk = Some(Instant::now());
-                            histogram!("nimproxy_ttft_seconds", "model" => ctx.model.clone())
-                                .record(sent_at.elapsed().as_secs_f64());
-                        }
-                        scan.feed(&b);
-                        if tx.send(Ok(b)).await.is_err() {
-                            record_request(&ctx, "disconnect");
-                            return; // client hung up
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!(error = %e, "upstream stream broke mid-response");
-                        record_request(&ctx, "stream_error");
-                        let _ = tx.send(Ok(sse_error("upstream stream interrupted"))).await;
-                        return;
-                    }
                 }
-            }
 
-            // Token accounting: exact when the upstream reported usage,
-            // otherwise estimate ~1 token per SSE event.
-            let source = if scan.completion.is_some() {
-                "usage"
-            } else {
-                "estimate"
-            };
-            let completion = scan.completion.or(Some(scan.events));
-            record_tokens(&ctx, scan.prompt, completion, source);
-            record_quality(
-                &ctx,
-                scan.finish_reason.as_deref(),
-                scan.reasoning,
-                scan.tool_call_max.map(|m| m + 1),
-            );
-            if let (Some(first), Some(c)) = (first_chunk, completion) {
-                let gen_secs = first.elapsed().as_secs_f64();
-                if gen_secs > 0.1 && c > 0 {
-                    histogram!("nimproxy_tokens_per_second", "model" => ctx.model.clone(), "source" => source.to_owned())
+                // Token accounting: exact when the upstream reported usage,
+                // otherwise estimate ~1 token per SSE event.
+                let source = if scan.completion.is_some() {
+                    "usage"
+                } else {
+                    "estimate"
+                };
+                let completion = scan.completion.or(Some(scan.events));
+                record_tokens(&ctx, scan.prompt, completion, source);
+                record_quality(
+                    &ctx,
+                    scan.finish_reason.as_deref(),
+                    scan.reasoning,
+                    scan.tool_call_max.map(|m| m + 1),
+                );
+                if let (Some(first), Some(c)) = (first_chunk, completion) {
+                    let gen_secs = first.elapsed().as_secs_f64();
+                    if gen_secs > 0.1 && c > 0 {
+                        histogram!("nimproxy_tokens_per_second", "model" => ctx.model.clone(), "source" => source.to_owned())
                         .record(c as f64 / gen_secs);
-                    // Mean inter-token latency (time-per-output-token).
-                    histogram!("nimproxy_tpot_seconds", "model" => ctx.model.clone())
-                        .record(gen_secs / c as f64);
+                        // Mean inter-token latency (time-per-output-token).
+                        histogram!("nimproxy_tpot_seconds", "model" => ctx.model.clone())
+                            .record(gen_secs / c as f64);
+                    }
                 }
+                // Total upstream time for streaming, for parity with the buffered
+                // path (which records upstream_seconds directly).
+                histogram!("nimproxy_upstream_seconds", "model" => ctx.model.clone())
+                    .record(sent_at.elapsed().as_secs_f64());
+                record_request(&ctx, "200");
+                return;
             }
-            // Total upstream time for streaming, for parity with the buffered
-            // path (which records upstream_seconds directly).
-            histogram!("nimproxy_upstream_seconds", "model" => ctx.model.clone())
-                .record(sent_at.elapsed().as_secs_f64());
-            record_request(&ctx, "200");
-            return;
+        };
+        if let Some(request_deadline) = request_deadline {
+            tokio::select! {
+                _ = tokio::time::sleep_until(request_deadline.0.into()) => {
+                    record_deadline(&deadline_ctx);
+                    let _ = deadline_tx
+                        .try_send(Ok(sse_error_with_code(
+                            "deadline_exceeded",
+                            "proxy request deadline exceeded",
+                        )));
+                }
+                _ = work => {}
+            }
+        } else {
+            work.await;
         }
     });
 
@@ -1031,9 +1137,13 @@ fn proxy_error_json(code: &str, message: impl Into<String>) -> serde_json::Value
     })
 }
 
-fn sse_error(message: &str) -> Bytes {
-    let event = proxy_error_json("upstream_unavailable", message);
+fn sse_error_with_code(code: &str, message: &str) -> Bytes {
+    let event = proxy_error_json(code, message);
     Bytes::from(format!("data: {event}\n\ndata: [DONE]\n\n"))
+}
+
+fn sse_error(message: &str) -> Bytes {
+    sse_error_with_code("upstream_unavailable", message)
 }
 
 fn json_response(status: StatusCode, body: Bytes) -> Response {
@@ -1055,6 +1165,19 @@ fn unauthorized() -> Response {
         axum::Json(body),
     )
         .into_response()
+}
+
+fn invalid_deadline() -> Response {
+    let body = proxy_error_json(
+        "invalid_deadline",
+        "X-Nim-Proxy-Deadline-Ms must be one unsigned decimal millisecond value",
+    );
+    (StatusCode::BAD_REQUEST, axum::Json(body)).into_response()
+}
+
+fn deadline_exceeded() -> Response {
+    let body = proxy_error_json("deadline_exceeded", "proxy request deadline exceeded");
+    (StatusCode::GATEWAY_TIMEOUT, axum::Json(body)).into_response()
 }
 
 fn overloaded(max_inflight: usize) -> Response {

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -91,6 +91,217 @@ async fn keyed_mode_rejects_bad_tokens_and_accepts_good_ones() {
 }
 
 #[tokio::test]
+async fn deadline_header_validation_runs_after_auth_and_before_upstream() {
+    let mock = start_mock().await;
+    let proxy = start_proxy_with(&mock.url, keyed("alice", "sekrit"), &[]).await;
+
+    let unauthorized = client()
+        .post(proxy.url("/v1/chat/completions"))
+        .header("x-nim-proxy-deadline-ms", "not-a-number")
+        .json(&chat_body("unauthorized", false))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unauthorized.status(), 401, "auth fails before validation");
+
+    let malformed = client()
+        .post(proxy.url("/v1/chat/completions"))
+        .bearer_auth("sekrit")
+        .header("x-nim-proxy-deadline-ms", "10.0")
+        .json(&chat_body("malformed", false))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(malformed.status(), 400);
+    let body: serde_json::Value = malformed.json().await.unwrap();
+    assert_eq!(body["error"]["code"], "invalid_deadline");
+
+    let duplicate = client()
+        .post(proxy.url("/v1/chat/completions"))
+        .bearer_auth("sekrit")
+        .header("x-nim-proxy-deadline-ms", "100")
+        .header("x-nim-proxy-deadline-ms", "200")
+        .json(&chat_body("duplicate", false))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(duplicate.status(), 400);
+    let body: serde_json::Value = duplicate.json().await.unwrap();
+    assert_eq!(body["error"]["code"], "invalid_deadline");
+    assert_eq!(mock.state.hit_count(), 0, "invalid input never reaches NIM");
+}
+
+#[tokio::test]
+async fn deadline_applies_to_models_cache_refresh() {
+    use std::sync::atomic::Ordering;
+
+    let mock = start_mock().await;
+    mock.state.models_delay_ms.store(10_000, Ordering::SeqCst);
+    let proxy = start_proxy(&mock.url, &[]).await;
+
+    let started = Instant::now();
+    let resp = client()
+        .get(proxy.url("/v1/models"))
+        .header("x-nim-proxy-deadline-ms", "100")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 504);
+    assert!(started.elapsed() < Duration::from_secs(2));
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["error"]["code"], "deadline_exceeded");
+}
+
+#[tokio::test]
+async fn buffered_deadline_cancels_header_wait_and_releases_inflight_slot() {
+    let mock = start_mock().await;
+    mock.state.push(Behavior::DelayHeaders(10_000));
+    let proxy = start_proxy_with(
+        &mock.url,
+        StoreOpts {
+            max_inflight: 1,
+            request_timeout_secs: 30,
+            ..Default::default()
+        },
+        &[],
+    )
+    .await;
+
+    let started = Instant::now();
+    let expired = client()
+        .post(proxy.url("/v1/chat/completions"))
+        .header("x-nim-proxy-deadline-ms", "150")
+        .json(&chat_body("deadline", false))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(expired.status(), 504);
+    assert!(started.elapsed() < Duration::from_secs(2));
+    let body: serde_json::Value = expired.json().await.unwrap();
+    assert_eq!(body["error"]["code"], "deadline_exceeded");
+
+    let after = client()
+        .post(proxy.url("/v1/chat/completions"))
+        .json(&chat_body("after-deadline", false))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(after.status(), 200, "deadline released max_inflight slot");
+
+    let metrics = metrics(&proxy).await;
+    assert!(metrics.contains(
+        r#"nimproxy_requests_total{client="local",model="mock/model-a",path="/v1/chat/completions",status="deadline"} 1"#
+    ));
+    assert!(metrics.contains(
+        r#"nimproxy_deadline_exceeded_total{client="local",model="mock/model-a",path="/v1/chat/completions"} 1"#
+    ));
+}
+
+#[tokio::test]
+async fn streaming_deadline_stops_retry_wait() {
+    let mock = start_mock().await;
+    mock.state.push(Behavior::RateLimited(2));
+    let proxy = start_proxy_with(
+        &mock.url,
+        StoreOpts {
+            nim_keys: vec![("only-key".into(), 40)],
+            ..Default::default()
+        },
+        &[],
+    )
+    .await;
+
+    let started = Instant::now();
+    let resp = client()
+        .post(proxy.url("/v1/chat/completions"))
+        .header("x-nim-proxy-deadline-ms", "150")
+        .json(&chat_body("retry-deadline", true))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "stream was already committed");
+    let body = read_sse(resp).await;
+    assert!(body.contains(": retrying"), "retry was observed: {body}");
+    assert!(
+        body.contains("deadline_exceeded"),
+        "deadline surfaced: {body}"
+    );
+    assert!(started.elapsed() < Duration::from_secs(2));
+}
+
+#[tokio::test]
+async fn streaming_deadline_stops_an_active_non_idle_stream() {
+    let mock = start_mock().await;
+    mock.state.push(Behavior::ActiveStream(25));
+    let proxy = start_proxy_with(
+        &mock.url,
+        StoreOpts {
+            stream_idle_secs: 5,
+            ..Default::default()
+        },
+        &[],
+    )
+    .await;
+
+    let started = Instant::now();
+    let resp = client()
+        .post(proxy.url("/v1/chat/completions"))
+        .header("x-nim-proxy-deadline-ms", "175")
+        .json(&chat_body("active-deadline", true))
+        .send()
+        .await
+        .unwrap();
+    let body = read_sse(resp).await;
+    assert!(
+        body.matches("delta").count() >= 2,
+        "stream stayed active: {body}"
+    );
+    assert!(
+        body.contains("deadline_exceeded"),
+        "deadline surfaced: {body}"
+    );
+    assert!(started.elapsed() < Duration::from_secs(2));
+}
+
+#[tokio::test]
+async fn streaming_deadline_releases_inflight_when_downstream_is_not_reading() {
+    let mock = start_mock().await;
+    mock.state.push(Behavior::FloodStream);
+    let proxy = start_proxy_with(
+        &mock.url,
+        StoreOpts {
+            max_inflight: 1,
+            stream_idle_secs: 5,
+            ..Default::default()
+        },
+        &[],
+    )
+    .await;
+
+    let unread = client()
+        .post(proxy.url("/v1/chat/completions"))
+        .header("x-nim-proxy-deadline-ms", "75")
+        .json(&chat_body("unread-deadline", true))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unread.status(), 200);
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let after = client()
+        .post(proxy.url("/v1/chat/completions"))
+        .json(&chat_body("after-unread-deadline", false))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        after.status(),
+        200,
+        "deadline cleanup cannot block on SSE send"
+    );
+}
+
+#[tokio::test]
 async fn streaming_rides_out_429s_with_lane_failover() {
     let mock = start_mock().await;
     mock.state.push(Behavior::RateLimited(1));

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -2,7 +2,7 @@
 //! and a launcher that runs the real proxy binary against it.
 
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -33,6 +33,15 @@ pub enum Behavior {
     BadRequestIfInjected,
     /// Send headers + one chunk, then stall forever.
     Hang,
+    /// Wait before sending response headers, simulating an upstream that has
+    /// accepted work but has not started its response.
+    DelayHeaders(u64),
+    /// Stream a data event at this interval forever. Unlike `Hang`, this stays
+    /// active often enough that an idle timeout must not be what stops it.
+    ActiveStream(u64),
+    /// Write large chunks without pause until downstream backpressure fills
+    /// the proxy's response channel.
+    FloodStream,
     /// Buffered response with an unknown `finish_reason` — exercises the
     /// server-side clamp that collapses odd values to `other`.
     OddFinish,
@@ -49,6 +58,7 @@ pub struct MockState {
     pub hits: Mutex<Vec<Hit>>,
     pub script: Mutex<VecDeque<Behavior>>,
     pub models_hits: AtomicUsize,
+    pub models_delay_ms: AtomicU64,
 }
 
 impl MockState {
@@ -93,6 +103,10 @@ pub async fn start_mock() -> MockNim {
 
 async fn mock_models(State(state): State<Arc<MockState>>) -> Response {
     state.models_hits.fetch_add(1, Ordering::SeqCst);
+    let delay = state.models_delay_ms.load(Ordering::SeqCst);
+    if delay > 0 {
+        tokio::time::sleep(Duration::from_millis(delay)).await;
+    }
     axum::Json(serde_json::json!({
         "object": "list",
         "data": [{"id": "mock/model-a", "object": "model", "created": 0, "owned_by": "mock"}]
@@ -155,6 +169,34 @@ async fn mock_chat(
                 Ok::<_, std::io::Error>(Bytes::from("data: {\"choices\":[]}\n\n"))
             })
             .chain(futures_util::stream::pending());
+            sse(Body::from_stream(stream))
+        }
+        Behavior::DelayHeaders(ms) => {
+            tokio::time::sleep(Duration::from_millis(ms)).await;
+            axum::Json(serde_json::json!({
+                "id": "mock-delayed", "object": "chat.completion",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "delayed"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1}
+            }))
+            .into_response()
+        }
+        Behavior::ActiveStream(ms) => {
+            let stream = futures_util::stream::unfold((), move |()| async move {
+                tokio::time::sleep(Duration::from_millis(ms)).await;
+                Some((
+                    Ok::<_, std::io::Error>(Bytes::from(
+                        "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"x\"}}]}\n\n",
+                    )),
+                    (),
+                ))
+            });
+            sse(Body::from_stream(stream))
+        }
+        Behavior::FloodStream => {
+            let chunk = Bytes::from(vec![b'x'; 1024 * 1024]);
+            let stream = futures_util::stream::unfold(chunk, |chunk| async move {
+                Some((Ok::<_, std::io::Error>(chunk.clone()), chunk))
+            });
             sse(Body::from_stream(stream))
         }
         Behavior::Ok | Behavior::BadRequestIfInjected => {


### PR DESCRIPTION
## Summary

- add opt-in `X-Nim-Proxy-Deadline-Ms` absolute wall-clock deadlines for `/v1` requests
- enforce the deadline across admission, queueing, retries, model-cache refresh, and generation
- cancel expired upstream work and release request-owned permits promptly
- report buffered expiry as HTTP 504 `deadline_exceeded` and streaming expiry as a terminal SSE error
- expose deadline outcomes through request status `deadline` and `nimproxy_deadline_exceeded_total`

## Root cause

Production workload logs showed a buffered request continuing inside the proxy for roughly 825 seconds after its caller timed out. Existing `max_wait`, `request_timeout`, and `stream_idle` settings bound individual phases, but there was no end-to-end wall-clock deadline. Buffered Hyper handlers also cannot reliably observe a downstream disconnect before producing their response.

## Validation

- `cargo test`: 84 unit tests and 78 end-to-end tests passed
- six new end-to-end deadline regressions cover validation/auth ordering, model-cache refresh, buffered header waits, streaming retries, continuously active streams, and unread downstream backpressure
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings` on Rust 1.97.1
- final diff, secret, scope, and knowledge-link checks

Addresses #50.
