### PR TITLE
Bump bytes from 1.12.0 to 1.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"


### PR DESCRIPTION
## Summary

Updates the direct `bytes` dependency from 1.12.0 to 1.12.1 in `Cargo.lock`.

Dependabot automatically closed #47 after the integration branch reached `main`, although that merge did not include the bytes update and `main` remained on 1.12.0. This replacement preserves the approved dependency update on the corrected base.

## Validation

- `cargo test`: 84 unit and 78 end-to-end tests passed
- `git diff --check`
- lockfile diff contains only the bytes version and checksum

Replaces #47.
