### PR TITLE
chore: prepare v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-07-17
+
 ### Added
 
 - Added the opt-in `X-Nim-Proxy-Deadline-Ms` request header: an absolute
@@ -28,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refreshed runtime and supply-chain dependencies: Tokio 1.53.0, bytes 1.12.1,
+  the pinned Rust builder image, eight pinned GitHub Actions, and
+  `sigstore/cosign-installer` 4.1.2.
 - Internal cleanup (no behavior change): dropped a redundant `async` on the
   streaming handler (all `.await`s live inside its spawned task, so the
   function itself never awaited — this avoids wrapping it in a needless
@@ -453,7 +458,9 @@ Initial rate-limit-aware proxy.
 - **Distroless image**: a static musl binary shipped `FROM scratch` (~3.5 MB,
   TLS roots compiled in), running non-root with hardened compose defaults.
 
-[Unreleased]: https://github.com/miztertea/nim-proxy/compare/v0.6.2...HEAD
+[Unreleased]: https://github.com/miztertea/nim-proxy/compare/v0.6.4...HEAD
+[0.6.4]: https://github.com/miztertea/nim-proxy/compare/v0.6.3...v0.6.4
+[0.6.3]: https://github.com/miztertea/nim-proxy/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/miztertea/nim-proxy/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/miztertea/nim-proxy/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/miztertea/nim-proxy/compare/v0.5.0...v0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "nim-proxy"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nim-proxy"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "Rate-limit-aware OpenAI-compatible proxy for NVIDIA NIM with multi-key load balancing"
 license = "MIT"

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,13 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-17] ingest — prepare v0.6.4 release metadata
+
+Promoted the accumulated deadline, security, cleanup, and dependency entries
+from Unreleased into v0.6.4; bumped the crate and lockfile package version; and
+repaired the stale changelog comparison links so v0.6.3 and v0.6.4 each have a
+complete release range.
+
 ## [2026-07-16] lint — low-risk cleanup batch (dead async, redundant clones)
 
 Staged a tight, YAGNI-scoped cleanup batch on a sub-branch off the


### PR DESCRIPTION
## Summary

- bump the crate and lockfile package version to 0.6.4
- promote the accumulated deadline, security, cleanup, and dependency notes into the 2026-07-17 release section
- repair the stale changelog comparison links for v0.6.3 and v0.6.4
- record the release-metadata ingest in the knowledge log

## How it was tested

- `cargo test` (84 unit + 78 end-to-end tests)
- `cargo fmt --all --check` with Rust 1.97.1
- `cargo clippy --all-targets -- -D warnings` with Rust 1.97.1
- `git diff --check`

## Release note

This PR prepares release metadata only. The Release workflow is intentionally left for manual dispatch from `main` after merge.