### PR TITLE
fix: restore release signing with Cosign v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,30 @@ jobs:
           tar xzf actionlint_1.7.12_linux_amd64.tar.gz actionlint
       - name: actionlint
         run: ./actionlint -color
+      - name: Release workflow contract
+        run: python3 scripts/test_release_contract.py
+      - name: Install release Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.2
+      - name: Cosign bundle smoke test
+        run: |
+          set -euo pipefail
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          printf 'nim-proxy release signing contract\n' > "$tmp/blob"
+          COSIGN_PASSWORD="" cosign generate-key-pair --output-key-prefix "$tmp/test"
+          COSIGN_PASSWORD="" cosign sign-blob --yes \
+            --key "$tmp/test.key" \
+            --use-signing-config=false \
+            --tlog-upload=false \
+            --bundle "$tmp/blob.sigstore.json" \
+            "$tmp/blob"
+          cosign verify-blob \
+            --key "$tmp/test.pub" \
+            --bundle "$tmp/blob.sigstore.json" \
+            --insecure-ignore-tlog \
+            "$tmp/blob"
       # zizmor: GitHub-Actions security lint (template injection, cache
       # poisoning, unpinned actions, …). The action uploads SARIF so every
       # severity is triageable in code scanning but never fails the build;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,10 @@ jobs:
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin the CLI independently: installer majors may change their
+          # default Cosign major and therefore its command-line contract.
+          cosign-release: v3.1.2
       - name: Sign image (keyless)
         run: cosign sign --yes "${IMAGE}@${{ steps.manifest.outputs.digest }}"
       - name: Attest build provenance
@@ -257,19 +261,20 @@ jobs:
           merge-multiple: true
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.2
       # The container manifest is already signed in the merge job; this signs
       # the *downloadable* assets (the per-arch tarballs and the SBOM) so a
       # binary pulled from the Releases page is verifiable too, not just the
       # image. Keyless: the OIDC identity is this workflow, verified below.
-      # Each blob gets a detached signature (.sig) + the signing certificate
-      # (.pem); both are attached to the release next to the artifact.
+      # Each blob gets one Sigstore bundle containing its signature,
+      # certificate, and transparency-log proof.
       - name: Sign release assets (keyless)
         run: |
           set -euo pipefail
           for f in nim-proxy-*.tar.gz nim-proxy-sbom.spdx.json; do
             cosign sign-blob --yes \
-              --output-signature "$f.sig" \
-              --output-certificate "$f.pem" \
+              --bundle "$f.sigstore.json" \
               "$f"
           done
       - name: Publish release
@@ -281,11 +286,9 @@ jobs:
           generate_release_notes: true
           files: |
             nim-proxy-*.tar.gz
-            nim-proxy-*.tar.gz.sig
-            nim-proxy-*.tar.gz.pem
+            nim-proxy-*.tar.gz.sigstore.json
             nim-proxy-sbom.spdx.json
-            nim-proxy-sbom.spdx.json.sig
-            nim-proxy-sbom.spdx.json.pem
+            nim-proxy-sbom.spdx.json.sigstore.json
           body: |
             Container image (multi-arch, signed, with SBOM + provenance):
 
@@ -301,12 +304,11 @@ jobs:
               --certificate-oidc-issuer https://token.actions.githubusercontent.com
             ```
 
-            Verify a downloaded asset (tarball or SBOM) against its `.sig` + `.pem`:
+            Verify a downloaded asset (tarball or SBOM) against its Sigstore bundle:
 
             ```sh
             cosign verify-blob nim-proxy-${{ needs.prepare.outputs.version }}-linux-amd64.tar.gz \
-              --signature nim-proxy-${{ needs.prepare.outputs.version }}-linux-amd64.tar.gz.sig \
-              --certificate nim-proxy-${{ needs.prepare.outputs.version }}-linux-amd64.tar.gz.pem \
+              --bundle nim-proxy-${{ needs.prepare.outputs.version }}-linux-amd64.tar.gz.sigstore.json \
               --certificate-identity-regexp 'https://github.com/${{ github.repository }}/.github/workflows/release.yml@.*' \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com
             ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Refreshed runtime and supply-chain dependencies: Tokio 1.53.0, bytes 1.12.1,
-  the pinned Rust builder image, eight pinned GitHub Actions, and
-  `sigstore/cosign-installer` 4.1.2.
+- Refreshed runtime and supply-chain dependencies: Tokio 1.53.1, bytes 1.12.1,
+  serde 1.0.229, serde_json 1.0.151, futures-util 0.3.33, tokio-stream 0.1.19,
+  the pinned Rust builder image and toolchain action, pinned GitHub Actions,
+  and `sigstore/cosign-installer` 4.1.2.
+- Migrated downloadable-asset signing to Cosign v3 Sigstore bundles, pinned
+  the Cosign CLI independently of its installer action, and added a real
+  sign/verify contract smoke test to CI.
 - Internal cleanup (no behavior change): dropped a redundant `async` on the
   streaming handler (all `.await`s live inside its spawned task, so the
   function itself never awaited — this avoids wrapping it in a needless

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ scrape_configs:
 
 ### Supply chain
 
-The build and release path is hardened to the OpenSSF baseline (scored weekly by the [Scorecard badge](https://scorecard.dev/viewer/?uri=github.com/miztertea/nim-proxy) above): every GitHub Actions step is SHA-pinned, CI runs **CodeQL** static analysis, workflow linting (`actionlint` + `zizmor`), dependency review, and `cargo-deny` (advisories on every PR plus a weekly audit), and the untrusted-byte parsers are **fuzzed** weekly. Releases are signed with keyless [cosign](https://docs.sigstore.dev/): the multi-arch image carries a signature, SLSA build provenance, and an SPDX SBOM, and the downloadable tarballs + SBOM each ship a `.sig` + `.pem` you can check with `cosign verify-blob` (the exact command is in every release's notes). Published `v*` tags are protected against retagging.
+The build and release path is hardened to the OpenSSF baseline (scored weekly by the [Scorecard badge](https://scorecard.dev/viewer/?uri=github.com/miztertea/nim-proxy) above): every GitHub Actions step is SHA-pinned, CI runs **CodeQL** static analysis, workflow linting (`actionlint` + `zizmor`), dependency review, and `cargo-deny` (advisories on every PR plus a weekly audit), and the untrusted-byte parsers are **fuzzed** weekly. Releases are signed with keyless [cosign](https://docs.sigstore.dev/): the multi-arch image carries a signature, SLSA build provenance, and an SPDX SBOM, and the downloadable tarballs + SBOM each ship a `.sigstore.json` bundle you can check with `cosign verify-blob` (the exact command is in every release's notes). Published `v*` tags are protected against retagging.
 
 ## Operations
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,16 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-28] ingest — repair Cosign v3 release asset signing
+
+The first v0.6.4 release attempt built and signed the multi-arch image but
+failed before publishing the GitHub Release. `cosign-installer` 4.1.2 had
+changed its default CLI from Cosign v2 to v3 while the release job retained
+the legacy `.sig` + `.pem` `sign-blob` flags. Migrated release assets and
+verification instructions to `.sigstore.json` bundles, explicitly pinned the
+Cosign CLI separately from the installer, and added a real offline
+sign/verify contract smoke test to the workflow-lint gate.
+
 ## [2026-07-17] ingest — prepare v0.6.4 release metadata
 
 Promoted the accumulated deadline, security, cleanup, and dependency entries

--- a/knowledge/ops/release.md
+++ b/knowledge/ops/release.md
@@ -13,7 +13,9 @@ pushes it to `ghcr.io/miztertea/nim-proxy`, signs it with keyless cosign,
 attests SLSA build provenance, generates an SPDX SBOM, and publishes a GitHub
 Release with the static binaries and the SBOM attached. The downloadable
 assets (tarballs + SBOM) are themselves signed with `cosign sign-blob`, each
-getting a `.sig` + `.pem` alongside it. SemVer + Keep a Changelog throughout.
+getting a `.sigstore.json` bundle alongside it. The bundle contains the
+signature, signing certificate, and transparency-log proof. SemVer + Keep a
+Changelog throughout.
 
 It has two entry points: **Run workflow** in the Actions UI (the normal path
 since v0.6.1 — the workflow's `prepare` job resolves the version from
@@ -72,17 +74,16 @@ cosign verify ghcr.io/miztertea/nim-proxy:X.Y.Z \
   --certificate-identity-regexp 'https://github.com/miztertea/nim-proxy/.github/workflows/release.yml@.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
-# and a downloaded asset against its detached .sig + .pem:
+# and a downloaded asset against its Sigstore bundle:
 cosign verify-blob nim-proxy-X.Y.Z-linux-amd64.tar.gz \
-  --signature nim-proxy-X.Y.Z-linux-amd64.tar.gz.sig \
-  --certificate nim-proxy-X.Y.Z-linux-amd64.tar.gz.pem \
+  --bundle nim-proxy-X.Y.Z-linux-amd64.tar.gz.sigstore.json \
   --certificate-identity-regexp 'https://github.com/miztertea/nim-proxy/.github/workflows/release.yml@.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 
 Also check the GitHub Release page: two `nim-proxy-X.Y.Z-linux-*.tar.gz` assets
-plus `nim-proxy-sbom.spdx.json`, each with its `.sig` + `.pem`, and generated
-release notes. The notes are
+plus `nim-proxy-sbom.spdx.json`, each with its `.sigstore.json` bundle, and
+generated release notes. The notes are
 grouped by PR label via `.github/release.yml` (Security / Breaking changes /
 Features=`enhancement` / Fixes=`bug` / Documentation / Dependencies —
 Dependabot's default label / Other; `skip-changelog` excludes a PR) — so

--- a/scripts/test_release_contract.py
+++ b/scripts/test_release_contract.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Guard the release workflow's Cosign CLI and artifact contract."""
+
+from pathlib import Path
+import unittest
+
+
+WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "release.yml"
+
+
+class ReleaseContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text()
+
+    def test_cosign_cli_is_explicitly_pinned(self) -> None:
+        self.assertEqual(self.workflow.count("cosign-release: v3.1.2"), 2)
+
+    def test_blob_signing_uses_sigstore_bundles(self) -> None:
+        self.assertIn('--bundle "$f.sigstore.json"', self.workflow)
+        self.assertNotIn("--output-signature", self.workflow)
+        self.assertNotIn("--output-certificate", self.workflow)
+
+    def test_release_publishes_and_verifies_bundles(self) -> None:
+        self.assertIn("nim-proxy-*.tar.gz.sigstore.json", self.workflow)
+        self.assertIn("nim-proxy-sbom.spdx.json.sigstore.json", self.workflow)
+        self.assertIn(
+            "--bundle "
+            "nim-proxy-${{ needs.prepare.outputs.version }}"
+            "-linux-amd64.tar.gz.sigstore.json",
+            self.workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- migrate downloadable release assets from legacy detached `.sig`/`.pem` output to Cosign v3 `.sigstore.json` bundles
- pin the Cosign CLI independently from the installer action
- add a workflow contract test and a real offline Cosign v3 sign/verify smoke test to CI
- update current release documentation and v0.6.4 notes

## Root cause

The first v0.6.4 run reached `Sign release assets (keyless)` after the image, provenance, SBOM, and binary builds succeeded. Dependabot PR #49 upgraded `sigstore/cosign-installer` and its default CLI from Cosign v2 to v3, but the workflow retained the v2 `--output-signature` / `--output-certificate` contract. Cosign v3 consequently attempted to create a bundle at an empty path and the GitHub Release was never published.

## Verification

- `python3 scripts/test_release_contract.py`
- `actionlint -color`
- real Cosign v3.1.2 bundle sign/verify smoke test
- `cargo test` (84 unit + 78 end-to-end)
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

After this merges and main is green, the aborted protected `v0.6.4` tag and exact partial GHCR package version will be removed before dispatching a fresh v0.6.4 run.
