### PR TITLE
fix: harden workflow inputs and dependency updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,14 @@
-# nim-proxy container-level config. Everything else — NIM keys, client API
+# nim-proxy deployment-level config. Everything else — NIM keys, client API
 # keys, the open/keyed API mode, users, limits, pricing, history retention, the
 # model-pressure governor — is configured in the dashboard on first run (a
 # setup wizard) and stored in DATA_DIR/config.json. Legacy app-level env vars
 # (NIM_API_KEYS, PROXY_API_KEYS, ADMIN_PASSWORD, INSECURE_NO_AUTH, …) are
 # ignored, with a one-line boot warning if any are still set.
+
+# Host interface where Docker Compose publishes port 8000. This is consumed by
+# Compose, not the proxy process; keep the loopback default unless the setup is
+# protected for LAN/public access as described in the deployment guide.
+#PUBLISH_HOST=127.0.0.1
 
 # Bind address / port the proxy listens on.
 #HOST=0.0.0.0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      # Version updates wait through the recommended observation window;
+      # Dependabot security updates bypass cooldowns.
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       cargo-minor-patch:
@@ -27,6 +31,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       actions:
         update-types: ["minor", "patch"]
@@ -36,3 +42,5 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,9 +147,11 @@ jobs:
       # The documented multi-runner pattern: matrix job outputs clobber each
       # other, so each leg exports its digest as an artifact file instead.
       - name: Export digest
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p "$RUNNER_TEMP/digests"
-          digest="${{ steps.build.outputs.digest }}"
+          digest="$BUILD_DIGEST"
           touch "$RUNNER_TEMP/digests/${digest#sha256:}"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -160,12 +162,17 @@ jobs:
       # Extract the exact static binary we just shipped — natively on this
       # runner: create (not run) a container and copy /nim-proxy out.
       - name: Extract release binary
+        env:
+          RELEASE_ARCH: ${{ matrix.arch }}
+          RELEASE_PLATFORM: ${{ matrix.platform }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           set -euo pipefail
-          cid=$(docker create --platform "${{ matrix.platform }}" "${IMAGE}@${{ steps.build.outputs.digest }}")
-          docker cp "$cid:/nim-proxy" "nim-proxy-${{ matrix.arch }}"
+          cid=$(docker create --platform "$RELEASE_PLATFORM" "${IMAGE}@${BUILD_DIGEST}")
+          docker cp "$cid:/nim-proxy" "nim-proxy-${RELEASE_ARCH}"
           docker rm "$cid" >/dev/null
-          tar -czf "nim-proxy-${{ needs.prepare.outputs.version }}-linux-${{ matrix.arch }}.tar.gz" "nim-proxy-${{ matrix.arch }}"
+          tar -czf "nim-proxy-${RELEASE_VERSION}-linux-${RELEASE_ARCH}.tar.gz" "nim-proxy-${RELEASE_ARCH}"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-${{ matrix.arch }}
@@ -203,18 +210,21 @@ jobs:
       - id: manifest
         name: Stitch the multi-arch manifest and tag it
         working-directory: ${{ runner.temp }}/digests
+        env:
+          RELEASE_MINOR: ${{ needs.prepare.outputs.minor }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           set -euo pipefail
           # Each downloaded artifact file is named by its image digest hex.
           refs=()
           for d in *; do refs+=("${IMAGE}@sha256:${d}"); done
           docker buildx imagetools create \
-            -t "${IMAGE}:${{ needs.prepare.outputs.version }}" \
-            -t "${IMAGE}:${{ needs.prepare.outputs.minor }}" \
+            -t "${IMAGE}:${RELEASE_VERSION}" \
+            -t "${IMAGE}:${RELEASE_MINOR}" \
             -t "${IMAGE}:latest" \
             "${refs[@]}"
           digest=$(docker buildx imagetools inspect \
-            "${IMAGE}:${{ needs.prepare.outputs.version }}" \
+            "${IMAGE}:${RELEASE_VERSION}" \
             --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
       - name: Install cosign
@@ -224,7 +234,9 @@ jobs:
           # default Cosign major and therefore its command-line contract.
           cosign-release: v3.1.2
       - name: Sign image (keyless)
-        run: cosign sign --yes "${IMAGE}@${{ steps.manifest.outputs.digest }}"
+        env:
+          MANIFEST_DIGEST: ${{ steps.manifest.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${MANIFEST_DIGEST}"
       - name: Attest build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Moved release metadata and image digests from inline shell-template
+  expansions into step-scoped environment variables, and added a seven-day
+  observation window for routine Cargo, GitHub Actions, and Docker dependency
+  updates. Dependabot security updates remain immediate.
+
+### Changed
+
+- Docker Compose's host-side publish address is now configurable with
+  `PUBLISH_HOST` in `.env` while retaining `127.0.0.1` as the safe default.
+
 ## [0.6.4] - 2026-07-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ App-level configuration lives in the dashboard (Settings) and persists to `DATA_
 | `TRUST_PROXY` | `false` | Trust `X-Forwarded-Proto` and mark the session cookie `Secure` (set behind a TLS-terminating reverse proxy) |
 | `RUST_LOG` | `nim_proxy=info` | Log filter |
 
+Docker Compose also reads `PUBLISH_HOST` from `.env` for the host-side port
+publish. It defaults to `127.0.0.1`; set `PUBLISH_HOST=0.0.0.0` only when the
+deployment is ready for LAN/public reachability. This is a Compose setting,
+not an environment variable consumed by nim-proxy.
+
 Everything else is a Settings control: NIM keys (per-key rpm, enable/disable, ownership), the upstream base URL, client API keys and the open/keyed API mode, limits (`max_wait`, `heartbeat`, `stream_idle`, `request_timeout`, `models_ttl`, `max_inflight`, `strict_passthrough`), reference pricing, history retention, the model-pressure governor, and users & roles.
 
 ## Security & deployment
@@ -197,7 +202,9 @@ Login is username + password → a signed, HttpOnly, SameSite=Strict session coo
 - **`keyed`** (default) — clients send `Authorization: Bearer <npk_…>`. Each user mints their own client keys; a key's 128-bit secret is shown **exactly once** (only its SHA-256 digest + last-4 are stored). Keyed with zero keys rejects everything (fail closed). Unknown keys get an OpenAI-style 401; comparison is constant-time.
 - **`open`** — `/v1` is unauthenticated. Only for loopback or a fully private network. This toggle affects **only `/v1`** — the dashboard is never open.
 
-The compose file publishes `127.0.0.1:8000:8000` by default so a bare bring-up can't leak.
+The compose file publishes `127.0.0.1:8000:8000` by default so a bare
+bring-up can't leak. Set `PUBLISH_HOST=0.0.0.0` in `.env` when intentional
+LAN/public exposure is protected appropriately.
 
 ### Scrapers
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       # Bound to loopback by default — reachable only from this host. To expose
       # it, complete the first-run setup wizard (creates the superuser; keep the
       # /v1 API in keyed mode), put TLS in front (nginx/Caddy or your platform's
-      # edge) with TRUST_PROXY=true, then change this to "8000:8000".
-      - "127.0.0.1:8000:8000"
+      # edge) with TRUST_PROXY=true, then set PUBLISH_HOST=0.0.0.0 in .env.
+      - "${PUBLISH_HOST:-127.0.0.1}:8000:8000"
     env_file: .env
     read_only: true
     cap_drop: [ALL]

--- a/knowledge/decisions/dependency-update-cooldown.md
+++ b/knowledge/decisions/dependency-update-cooldown.md
@@ -1,0 +1,46 @@
+---
+type: Decision
+title: Seven-day cooldown for routine dependency updates
+description: Delay non-security Dependabot updates long enough for regressions and compromised releases to surface.
+tags: [dependencies, supply-chain, dependabot]
+timestamp: 2026-07-28T00:00:00Z
+resource: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
+---
+
+# Seven-day cooldown for routine dependency updates
+
+## Context
+
+Dependabot checks the Cargo, GitHub Actions, and Docker ecosystems weekly.
+Without an explicit policy, GitHub applies a three-day cooldown to routine
+version updates. That window is shorter than zizmor's recommended seven days
+and can admit a fresh regression or opportunistically compromised release
+before the ecosystem has had much time to react.
+
+Security updates are not subject to Dependabot cooldowns, so delaying routine
+updates does not delay vulnerability remediation.
+
+## Options
+
+1. Keep GitHub's implicit three-day default.
+2. Apply one seven-day default to every updater.
+3. Maintain ecosystem- and SemVer-specific windows.
+
+## Choice
+
+Set `cooldown.default-days: 7` on the Cargo, GitHub Actions, and Docker
+updaters. Use the same window everywhere until observed maintenance or
+security outcomes justify a more complex policy.
+
+## Consequences
+
+- Routine releases receive a seven-day observation period before Dependabot
+  proposes them.
+- Security updates continue immediately.
+- A uniform value is easy to audit and avoids policy drift between ecosystems.
+- The repository intentionally accepts receiving routine fixes several days
+  later in exchange for lower regression and supply-chain risk.
+
+This policy complements the pinned-action, dependency-review, cargo-deny, and
+workflow-lint controls described in the
+[test strategy](../testing/test-strategy.md).

--- a/knowledge/decisions/index.md
+++ b/knowledge/decisions/index.md
@@ -19,3 +19,4 @@ description: Lightweight ADRs — context, options, choice, consequences.
 - [dashboard-operator-console-redesign](dashboard-operator-console-redesign.md)
 - [ui-managed-config-store](ui-managed-config-store.md)
 - [explicit-request-deadline](explicit-request-deadline.md)
+- [dependency-update-cooldown](dependency-update-cooldown.md)

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -30,6 +30,7 @@ the chronology in [log.md](log.md).
 | [dashboard-operator-console-redesign](decisions/dashboard-operator-console-redesign.md) | 6→5 tabs (Compare merged in), dark-only palette, webfonts via Google Fonts CDN under CSP, window-halves delta chips |
 | [ui-managed-config-store](decisions/ui-managed-config-store.md) | App config moves from env into a JSON store edited from the dashboard; first-run wizard, multi-user + per-key ownership, no encryption at rest |
 | [explicit-request-deadline](decisions/explicit-request-deadline.md) | Opt-in wall-clock bound cancels queue/retry/generation work without weakening patient defaults |
+| [dependency-update-cooldown](decisions/dependency-update-cooldown.md) | Routine dependency updates wait seven days; security updates remain immediate |
 
 ## Research — validated external facts
 
@@ -56,7 +57,7 @@ the chronology in [log.md](log.md).
 | Page | One-liner |
 |---|---|
 | [deploy-docker](ops/deploy-docker.md) | Compose, volume, healthcheck, hardening flags |
-| [configure-env](ops/configure-env.md) | The 5 container env vars; everything else lives in the Settings UI; lockout recovery |
+| [configure-env](ops/configure-env.md) | Compose publishing, the 5 container env vars, Settings, and lockout recovery |
 | [sharing-with-friends](ops/sharing-with-friends.md) | Create-a-user multi-user setup, key etiquette, ToS positioning |
 | [capacity-math](ops/capacity-math.md) | What N clients on K keys actually does (the 50-clients/3-lanes analysis) |
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,22 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-28] ingest — harden workflow inputs and parameterize Compose publishing
+
+Moved release metadata and digest values out of shell-script template
+expansions and into step-scoped environment variables, preserving the release
+pipeline while removing seven template-injection findings. Added a
+`PUBLISH_HOST` Compose interpolation with a loopback default so intentional
+LAN exposure lives in ignored `.env` deployment state rather than a tracked
+`docker-compose.yml` edit.
+
+## [2026-07-28] decision — delay routine dependency updates for seven days
+
+Applied one seven-day Dependabot cooldown to Cargo, GitHub Actions, and Docker
+version updates. The explicit observation window follows zizmor's
+supply-chain recommendation without delaying security updates, which
+Dependabot exempts from cooldowns.
+
 ## [2026-07-28] ingest — repair Cosign v3 release asset signing
 
 The first v0.6.4 release attempt built and signed the multi-arch image but

--- a/knowledge/ops/configure-env.md
+++ b/knowledge/ops/configure-env.md
@@ -1,7 +1,7 @@
 ---
 type: Runbook
 title: Configuration reference
-description: The 5 container-level env vars; everything else lives in the Settings UI; lockout recovery.
+description: Compose publishing, the 5 container-level env vars, Settings, and lockout recovery.
 tags: [configuration]
 timestamp: 2026-07-04T00:00:00Z
 ---
@@ -13,7 +13,16 @@ A first-run wizard claims a fresh install (create the superuser → add ≥1 NIM
 key, validated against the upstream → land on the dashboard, logged in); after
 that, Settings edits everything and persists it to `DATA_DIR/config.json`
 (atomic, 0600 — see [ui-managed-config-store](../decisions/ui-managed-config-store.md)).
-Env now covers **container-level concerns only**.
+Env now covers **deployment-level concerns only**.
+
+## Compose-only publish setting
+
+`PUBLISH_HOST` controls the host interface where Docker Compose publishes
+container port 8000. It defaults to `127.0.0.1`, keeping a bare deployment
+loopback-only. Set `PUBLISH_HOST=0.0.0.0` in `.env` only for intentional
+LAN/public exposure after the authentication and TLS posture is ready.
+Compose consumes this value while interpolating `docker-compose.yml`;
+nim-proxy itself does not read it.
 
 ## The 5 env vars
 

--- a/knowledge/ops/deploy-docker.md
+++ b/knowledge/ops/deploy-docker.md
@@ -9,7 +9,7 @@ timestamp: 2026-07-02T00:00:00Z
 # Deploy with Docker
 
 ```sh
-cp .env.example .env     # only container vars now (HOST/PORT/DATA_DIR/RUST_LOG/TRUST_PROXY)
+cp .env.example .env     # deployment vars; PUBLISH_HOST is Compose-only
 docker compose up -d     # pulls ghcr.io/miztertea/nim-proxy:latest (signed, multi-arch)
 docker ps                # STATUS shows (healthy) via the built-in probe
 docker logs nim-proxy-nim-proxy-1
@@ -40,16 +40,17 @@ Deployment patterns:
 - **Local**: keep the default loopback publish (`127.0.0.1:8000:8000`) so it
   can't leak; set the API mode to `open` in Settings if you don't want client
   keys. Reach it at `http://localhost:8000`.
-- **VPS / bare metal**: behind nginx/Caddy doing TLS; change the publish to
-  `8000:8000` (or bind the reverse proxy to the loopback port) and set
-  `TRUST_PROXY=true`. Keep the API `keyed`.
+- **VPS / bare metal**: behind nginx/Caddy doing TLS; set
+  `PUBLISH_HOST=0.0.0.0` in `.env` (or leave the reverse proxy on the
+  loopback port) and set `TRUST_PROXY=true`. Keep the API `keyed`.
 - **PaaS (ECS/Railway/Fly)**: platform edge terminates TLS; set
   `TRUST_PROXY=true`. Complete the wizard as soon as the instance is reachable.
 
 What the compose file gives you (see
 [distroless-scratch-image](../decisions/distroless-scratch-image.md) for why):
 
-- `FROM scratch` image (~3.5 MB), non-root UID 10001, loopback publish default.
+- `FROM scratch` image (~3.5 MB), non-root UID 10001, loopback publish default
+  with an ignored `.env` override (`PUBLISH_HOST`) for intentional exposure.
 - `read_only: true`, `cap_drop: [ALL]`, `no-new-privileges` — writes go only
   to the named `history` volume mounted at `/data`, which now holds both
   `history.jsonl` **and `config.json` (credentials, 0600)**. A volume backup


### PR DESCRIPTION
## Summary

Clears seven zizmor template-injection findings by passing release metadata
through step-scoped environment variables, and clears three Dependabot
cooldown findings with a uniform seven-day observation window. It also makes
Docker Compose's host publish address configurable through ignored `.env`
state while preserving the loopback default.

## Type of change

- [ ] Bug fix (no behavior change beyond the fix)
- [x] New feature / behavior change
- [ ] Performance / rate-limiting
- [x] Security / hardening
- [ ] Refactor (no behavior change)
- [ ] Docs / knowledge base only
- [x] CI / build / release infrastructure
- [ ] Release (version bump)

## Related issues

Addresses ten open code-scanning alerts: seven `zizmor/template-injection`
findings and three `zizmor/dependabot-cooldown` findings. The
`zizmor/superfluous-actions` release-action recommendation and three
solo-maintainer Scorecard findings remain intentionally out of scope.

## What & why

Inline GitHub expression expansion inside shell bodies is a code-injection
smell even when today's values are controlled; step-scoped environment
variables preserve normal shell quoting and the release workflow's behavior.
Routine dependency updates now wait seven days so regressions or
opportunistically compromised releases have time to surface, while Dependabot
security updates remain immediate.

The Compose publish-address change moves the intentional LAN binding from a
tracked `docker-compose.yml` edit into `PUBLISH_HOST=0.0.0.0` in ignored
`.env` deployment state. The default remains `127.0.0.1`.

The policy rationale is recorded in
`knowledge/decisions/dependency-update-cooldown.md`; deployment runbooks,
README, CHANGELOG, and the knowledge chronology are updated in lockstep.

## How it was tested

```sh
cargo test
# 84 unit + 78 end-to-end tests passed; 0 failed

cargo fmt --check
cargo clippy --all-targets -- -D warnings
# clean (run with the official Rust toolchain container because the host
# package omits these components)

actionlint .github/workflows/*.yml
python3 scripts/test_release_contract.py
# clean; 3/3 release contract tests passed

zizmor --offline --min-severity high .github/workflows/
# no findings

zizmor --offline --format json \
  .github/dependabot.yml .github/workflows/release.yml
# only the intentionally deferred superfluous-actions recommendation remains

docker compose config
# PUBLISH_HOST=0.0.0.0 -> host_ip 0.0.0.0
# unset/empty PUBLISH_HOST -> host_ip 127.0.0.1
```

## Screenshots / output

N/A — no dashboard or visual changes.

## Breaking changes & migration

None. Existing Compose users retain loopback publishing by default. Operators
who intentionally expose the service can set `PUBLISH_HOST=0.0.0.0` in `.env`
instead of editing the tracked Compose file.

## Checklist

### Code quality

- [x] `cargo fmt --check` is clean.
- [x] `cargo clippy --all-targets -- -D warnings` is clean (zero warnings).
- [x] `cargo test` passes locally (unit + end-to-end).
- [x] New behavior is exercised by zizmor, the existing release contract,
      and rendered Compose configuration checks.
- [x] Scope is tight; commit messages explain the *why*.

### Docs & knowledge base — lockstep is a hard rule (see AGENTS.md)

- [x] README updated for the Compose override.
- [x] Affected `knowledge/` pages updated in this PR.
- [x] New decision recorded in `knowledge/decisions/` and both indexes.
- [x] Dated entries appended to `knowledge/log.md`.
- [x] `CHANGELOG.md` `[Unreleased]` updated.

### Security — application auth/input triggers

- [x] N/A — no application auth, config-store, label-sanitizing, or dashboard
      rendering code changed.

### Rate-limiting

- [x] N/A — pacing, pool, dispatcher, and affinity behavior are unchanged.

### Workflows & supply chain

- [x] No Actions were added or repinned; `actionlint` passes and the zizmor
      high-severity gate is clean.
- [x] N/A — no release or version change.
