### PR TITLE
fix: publish releases with gh cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,37 +290,42 @@ jobs:
               "$f"
           done
       - name: Publish release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          # Explicit: on the dispatch path the triggering ref is a branch, so
-          # the action must not derive the release tag from it.
-          tag_name: ${{ needs.prepare.outputs.tag }}
-          generate_release_notes: true
-          files: |
-            nim-proxy-*.tar.gz
-            nim-proxy-*.tar.gz.sigstore.json
-            nim-proxy-sbom.spdx.json
-            nim-proxy-sbom.spdx.json.sigstore.json
-          body: |
-            Container image (multi-arch, signed, with SBOM + provenance):
+        # GitHub-hosted runners include gh. Keeping publication in a script
+        # removes a third-party action while preserving the release contract.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          {
+            printf '%s\n\n' 'Container image (multi-arch, signed, with SBOM + provenance):'
+            printf '%s\n' '```sh'
+            printf 'docker pull ghcr.io/%s:%s\n' "$REPOSITORY" "$RELEASE_VERSION"
+            printf '%s\n\n' '```'
+            printf '%s\n\n' 'Verify the image signature:'
+            printf '%s\n' '```sh'
+            printf 'cosign verify ghcr.io/%s:%s \\\n' "$REPOSITORY" "$RELEASE_VERSION"
+            printf "  --certificate-identity-regexp 'https://github.com/%s/.github/workflows/release.yml@.*' \\\\\n" "$REPOSITORY"
+            printf '%s\n' '  --certificate-oidc-issuer https://token.actions.githubusercontent.com'
+            printf '%s\n\n' '```'
+            printf '%s\n\n' 'Verify a downloaded asset (tarball or SBOM) against its Sigstore bundle:'
+            printf '%s\n' '```sh'
+            printf 'cosign verify-blob nim-proxy-%s-linux-amd64.tar.gz \\\n' "$RELEASE_VERSION"
+            printf '  --bundle nim-proxy-%s-linux-amd64.tar.gz.sigstore.json \\\n' "$RELEASE_VERSION"
+            printf "  --certificate-identity-regexp 'https://github.com/%s/.github/workflows/release.yml@.*' \\\\\n" "$REPOSITORY"
+            printf '%s\n' '  --certificate-oidc-issuer https://token.actions.githubusercontent.com'
+            printf '%s\n' '```'
+          } > release-notes.md
 
-            ```sh
-            docker pull ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.version }}
-            ```
-
-            Verify the image signature:
-
-            ```sh
-            cosign verify ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.version }} \
-              --certificate-identity-regexp 'https://github.com/${{ github.repository }}/.github/workflows/release.yml@.*' \
-              --certificate-oidc-issuer https://token.actions.githubusercontent.com
-            ```
-
-            Verify a downloaded asset (tarball or SBOM) against its Sigstore bundle:
-
-            ```sh
-            cosign verify-blob nim-proxy-${{ needs.prepare.outputs.version }}-linux-amd64.tar.gz \
-              --bundle nim-proxy-${{ needs.prepare.outputs.version }}-linux-amd64.tar.gz.sigstore.json \
-              --certificate-identity-regexp 'https://github.com/${{ github.repository }}/.github/workflows/release.yml@.*' \
-              --certificate-oidc-issuer https://token.actions.githubusercontent.com
-            ```
+          # Explicit tag: dispatch runs start from a branch ref. --notes is a
+          # preamble when combined with --generate-notes.
+          gh release create "$RELEASE_TAG" \
+            nim-proxy-*.tar.gz \
+            nim-proxy-*.tar.gz.sigstore.json \
+            nim-proxy-sbom.spdx.json \
+            nim-proxy-sbom.spdx.json.sigstore.json \
+            --repo "$REPOSITORY" \
+            --generate-notes \
+            --notes "$(<release-notes.md)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   expansions into step-scoped environment variables, and added a seven-day
   observation window for routine Cargo, GitHub Actions, and Docker dependency
   updates. Dependabot security updates remain immediate.
+- Replaced the third-party GitHub Release publishing action with the
+  GitHub-hosted runner's preinstalled `gh` CLI, preserving generated notes,
+  verification instructions, and signed asset uploads while reducing the
+  workflow's external action surface.
 
 ### Changed
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,14 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-28] ingest — publish GitHub Releases with the runner CLI
+
+Replaced `softprops/action-gh-release` with the GitHub-hosted runner's
+preinstalled `gh release create`. The release job still uses the prepared tag,
+prepends the container and Sigstore verification instructions to generated
+notes, and uploads the same signed tarballs and SBOM assets, while removing
+one third-party action from the release trust surface.
+
 ## [2026-07-28] ingest — harden workflow inputs and parameterize Compose publishing
 
 Moved release metadata and digest values out of shell-script template

--- a/knowledge/ops/release.md
+++ b/knowledge/ops/release.md
@@ -14,8 +14,9 @@ attests SLSA build provenance, generates an SPDX SBOM, and publishes a GitHub
 Release with the static binaries and the SBOM attached. The downloadable
 assets (tarballs + SBOM) are themselves signed with `cosign sign-blob`, each
 getting a `.sigstore.json` bundle alongside it. The bundle contains the
-signature, signing certificate, and transparency-log proof. SemVer + Keep a
-Changelog throughout.
+signature, signing certificate, and transparency-log proof. The final release
+is published by the GitHub-hosted runner's preinstalled `gh` CLI rather than a
+third-party publishing action. SemVer + Keep a Changelog throughout.
 
 It has two entry points: **Run workflow** in the Actions UI (the normal path
 since v0.6.1 — the workflow's `prepare` job resolves the version from

--- a/scripts/test_release_contract.py
+++ b/scripts/test_release_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Guard the release workflow's Cosign CLI and artifact contract."""
+"""Guard the release workflow's publication, Cosign, and artifact contract."""
 
 from pathlib import Path
 import unittest
@@ -25,11 +25,20 @@ class ReleaseContractTests(unittest.TestCase):
         self.assertIn("nim-proxy-*.tar.gz.sigstore.json", self.workflow)
         self.assertIn("nim-proxy-sbom.spdx.json.sigstore.json", self.workflow)
         self.assertIn(
-            "--bundle "
-            "nim-proxy-${{ needs.prepare.outputs.version }}"
-            "-linux-amd64.tar.gz.sigstore.json",
+            "printf '  --bundle "
+            "nim-proxy-%s-linux-amd64.tar.gz.sigstore.json",
             self.workflow,
         )
+
+    def test_release_uses_runner_gh_cli(self) -> None:
+        self.assertNotIn("softprops/action-gh-release", self.workflow)
+        self.assertIn("GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}", self.workflow)
+        self.assertIn("RELEASE_TAG: ${{ needs.prepare.outputs.tag }}", self.workflow)
+        self.assertIn("REPOSITORY: ${{ github.repository }}", self.workflow)
+        self.assertIn('gh release create "$RELEASE_TAG"', self.workflow)
+        self.assertIn('--repo "$REPOSITORY"', self.workflow)
+        self.assertIn("--generate-notes", self.workflow)
+        self.assertIn('--notes "$(<release-notes.md)"', self.workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- replace `softprops/action-gh-release` with the GitHub-hosted runner's preinstalled `gh release create`
- preserve the prepared tag, generated release notes, verification preamble, and all six signed assets
- pass GitHub context values through step-scoped environment variables and explicitly select the repository
- extend the release contract and update the changelog and release runbook

## Why

Code-scanning alert #28 (`zizmor/superfluous-actions`) reports that GitHub Release publication is already available through the runner CLI. The third-party action added supply-chain surface without adding required behavior.

## Impact

No application or artifact-format change. Release publication keeps the same tag, notes, and downloadable assets; the implementation moves into a shell step authenticated with the job's least-privilege `GITHUB_TOKEN`.

## Verification

- `python3 scripts/test_release_contract.py` — 4/4 passed, including RED→GREEN coverage for the CLI path
- actionlint 1.7.12 — clean
- `uvx zizmor --offline .github/workflows/release.yml` — no findings
- mocked execution of the exact YAML script — explicit tag/repo, six assets, generated notes, and rendered verification commands confirmed
- Rust 1.97 container: `cargo fmt --check`
- Rust 1.97 container: `cargo clippy --all-targets -- -D warnings`
- Rust 1.97 container: `cargo test` — 162 passed
