### PR TITLE
Cleanup: rename lane bench to cooldown, remove pricing and estimated savings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Reliability tables, the Pricing settings card, the `pricing` config block
   (`ref_price_in` / `ref_price_out`), and the `POST /api/settings/pricing`
   route are gone; `/api/config` no longer returns `server.pricing` and
-  `/api/dashboard` no longer returns `price_in` / `price_out`.
+  `/api/dashboard/now` no longer returns `price_in` / `price_out`.
 
   An honest figure needs a published per-model rate for each model in the pool;
   applying one reference rate to every model measured nothing. Existing config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** the lane state entered after an upstream 429/5xx is now called
+  **cooldown** rather than "bench", and the Prometheus series
+  `nimproxy_lane_benched_total` is renamed to `nimproxy_lane_cooldown_total`.
+  Every other `nimproxy_*` series is unchanged. Update any dashboards, alerts,
+  or recording rules that referenced the old name.
+
+  Retained history stores the metric name verbatim, so lane-cooldown charts
+  show a gap for points recorded before the upgrade and return to full fidelity
+  one retention window (`history_days`) later. This is a deliberate clean break
+  — no compatibility alias is carried.
+
+### Removed
+
+- **Breaking:** pricing configuration and the estimated-savings metric. The
+  `Dollars saved` KPI, the `Saved` columns in the Models, Clients, and
+  Reliability tables, the Pricing settings card, the `pricing` config block
+  (`ref_price_in` / `ref_price_out`), and the `POST /api/settings/pricing`
+  route are gone; `/api/config` no longer returns `server.pricing` and
+  `/api/dashboard` no longer returns `price_in` / `price_out`.
+
+  An honest figure needs a published per-model rate for each model in the pool;
+  applying one reference rate to every model measured nothing. Existing config
+  stores containing a `pricing` block still load — the orphan key is ignored,
+  and no migration runs. `REF_PRICE_IN` / `REF_PRICE_OUT` remain in the
+  legacy-env warning list so an upgrader who still sets them is told they do
+  nothing.
+
 ## [0.6.5] - 2026-07-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ burns — all from counts and sizes, never message content.
 
 Five persona-aligned tabs, each ordered at-a-glance → trends → detail:
 
-- **Overview** — the one-screen landing: dollars saved, capacity and success-rate ring gauges, request/token/savings sparklines, a health strip, and top models & harnesses.
+- **Overview** — the one-screen landing: capacity and success-rate ring gauges, request and token sparklines, a health strip, and top models & harnesses.
 - **Models** — ranked model cards, TTFT / generation-speed / inter-token-latency / upstream-latency charts, tokens-per-minute, tool-call volume, truncation and reasoning-share breakdowns, and a head-to-head scorecard.
 - **Clients** — what each agent is *doing*: tool intensity, conversation depth, sampling fingerprint, requested output budget, streaming-vs-buffered mix, and a per-harness leaderboard.
 - **Reliability** — availability against the configured SLO (99.9% by default) with an error budget, requests-by-outcome over time, where time goes (queue / first token / generation), an error taxonomy, an hour-of-day heatmap, and a model-pressure card when the governor engages.
@@ -169,8 +169,8 @@ your workload.
 
 **Settings.** Everything app-level is managed here: NIM keys (per-key rpm,
 enable/disable), client API keys, the open/keyed API mode, upstream URL,
-limits, pricing, default dashboard window, history retention, availability
-SLO, the model-pressure governor, and users. Saves validate, persist, and apply
+limits, default dashboard window, history retention, availability SLO, the
+model-pressure governor, and users. Saves validate, persist, and apply
 live. The config file itself is read at boot; an out-of-band edit to
 `DATA_DIR/config.json` requires a restart.
 
@@ -209,9 +209,9 @@ not an environment variable consumed by nim-proxy.
 Everything else is a Settings control: NIM keys (per-key rpm, enable/disable,
 ownership), the upstream base URL, client API keys and the open/keyed API
 mode, limits (`max_wait`, `heartbeat`, `stream_idle`, `request_timeout`,
-`models_ttl`, `max_inflight`, `strict_passthrough`), reference pricing,
-default dashboard window, history retention, availability SLO, the
-model-pressure governor, and users & roles.
+`models_ttl`, `max_inflight`, `strict_passthrough`), default dashboard
+window, history retention, availability SLO, the model-pressure governor, and
+users & roles.
 
 ## Security & deployment
 

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ The build and release path is hardened to the OpenSSF baseline (scored weekly by
 | `nimproxy_queue_wait_seconds` | — | Time waiting for a rate-limit slot |
 | `nimproxy_queue_depth` / `nimproxy_active_requests` | — | Live load gauges |
 | `nimproxy_lane_requests_total` | lane | Requests per key lane |
-| `nimproxy_lane_benched_total` | lane, status | Upstream 429/5xx/connect per lane |
+| `nimproxy_lane_cooldown_total` | lane, status | Upstream 429/5xx/connect per lane |
 | `nimproxy_affinity_total` | result | Conversation routing: `sticky` / `spill` / `none` |
 | `nimproxy_unauthorized_total` | — | Rejected API requests |
 | `nimproxy_login_failures_total` | — | Failed dashboard logins |

--- a/knowledge/architecture/dashboard.md
+++ b/knowledge/architecture/dashboard.md
@@ -17,7 +17,7 @@ custom date-range picker, and five persona-aligned tabs, each ordered
 **at-a-glance → trends → detail**:
 
 - **Overview** (landing, balanced) — KPI cards + threshold ring gauges,
-  request/token/savings sparklines, a health strip, a p50/p95 performance
+  request and token sparklines, a health strip, a p50/p95 performance
   band, top models & harnesses.
 - **Models** (benchmarker) — KPI cards, tokens/min-by-model chart, a
   TTFT/tok-s/TPOT/upstream quantile quad, a "how responses end" breakdown,

--- a/knowledge/architecture/dashboard.md
+++ b/knowledge/architecture/dashboard.md
@@ -149,8 +149,8 @@ The browser polls `/api/dashboard/now` every three seconds. Only a
 following, unpaused window refetches history when its revision changes.
 Custom and paused totals remain fixed, while **Now** widgets—active requests,
 queue depth, current RPM/capacity, enabled lane slots, uptime, and header
-metadata—continue refreshing. A config-revision change updates pricing,
-capacity, auth state, default window, retention, and SLO without reloading
+metadata—continue refreshing. A config-revision change updates capacity,
+auth state, default window, retention, and SLO without reloading
 the page; if the active preset is the default, its following bounds are
 recomputed.
 
@@ -173,7 +173,7 @@ recomputed.
   history uses the contemporaneous value stored with each v2 sample; legacy
   intervals explicitly show capacity unavailable. Active load, lane count,
   current RPM, and utilization are labeled **Now**; selected-window lane
-  request and bench counts remain historical.
+  request and cooldown counts remain historical.
 
 Following history survives refresh and process restart because it is rebuilt
 from the server index; only the adjacent-poll rate shown in **Now** widgets

--- a/knowledge/architecture/governor.md
+++ b/knowledge/architecture/governor.md
@@ -14,7 +14,7 @@ orthogonal to the per-key 40 RPM limit
 40 RPM with 45–90s generations, steady-state in-flight is 30–60 — you saturate
 the worker pool while fully RPM-legal. Crucially the cap is **model-scoped and
 shared across all keys** (and all of NIM's tenants), so failing over to another
-key can't help; the old behavior of benching the lane just burned healthy key
+key can't help; the old behavior of cooling down the lane just burned healthy key
 capacity.
 
 ## Classify first, then govern
@@ -22,7 +22,7 @@ capacity.
 `is_worker_exhausted(body)` sniffs the signature (`"Worker local total request
 limit"`) on the pre-stream error response. In `proxy.rs`'s retry path this is
 checked **before** generic 429/5xx handling: worker exhaustion routes to
-per-model backoff and **never benches the lane**. Plain 429/5xx behavior is
+per-model backoff and **never cools down the lane**. Plain 429/5xx behavior is
 unchanged ([key-pool](key-pool.md)).
 
 ## Admission gate
@@ -44,7 +44,7 @@ error the governor:
 - engages at `max(1, inflight_at_error / 2)` (the failing request's permit is
   still held, so the observed count includes it),
 - opens a short **2s drain gap** blocking new admissions while workers free up
-  (a drain gap, not a lane-style bench),
+  (a drain gap, not a lane-style cooldown),
 - then **grows +1 per stable minute** (additive increase),
 - and **dissolves back to ungoverned after 30 clean minutes**.
 

--- a/knowledge/architecture/key-pool.md
+++ b/knowledge/architecture/key-pool.md
@@ -1,7 +1,7 @@
 ---
 type: Component
 title: Key pool (src/pool.rs)
-description: One lane per NIM key; exact sliding-window limiter, least-loaded selection, cooldown benching, releasable reservations.
+description: One lane per NIM key; exact sliding-window limiter, least-loaded selection, cooldown on upstream backoff, releasable reservations.
 tags: [pool, rate-limiting]
 timestamp: 2026-07-02T00:00:00Z
 ---
@@ -9,7 +9,7 @@ timestamp: 2026-07-02T00:00:00Z
 # Key pool — `src/pool.rs`
 
 Each API key is a **lane** holding a `VecDeque<Instant>` of send timestamps
-(the sliding window) and a `cooldown_until` instant (benching).
+(the sliding window) and a `cooldown_until` instant (cooldown).
 
 - **Reserve** (`reserve(prefer)`): the preferred lane wins if it has capacity
   ([affinity](../decisions/sticky-affinity-with-spillover.md)); otherwise the
@@ -19,8 +19,8 @@ Each API key is a **lane** holding a `VecDeque<Instant>` of send timestamps
   `Wait(duration)` until the soonest slot.
 - **Window** is 61s for a 60s upstream limit — see
   [window-jitter-margin](../decisions/window-jitter-margin.md).
-- **Penalize**: an upstream 429/5xx benches the lane (`Retry-After` honored,
-  defaults 10s for 429, 5s for connect errors). Benched lanes are skipped;
+- **Penalize**: an upstream 429/5xx puts the lane in cooldown (`Retry-After` honored,
+  defaults 10s for 429, 5s for connect errors). Lanes in cooldown are skipped;
   other lanes absorb traffic.
 - **Release**: a reservation granted to a client that vanished while queued
   is removed from the window by its stamp, returning the slot.
@@ -37,7 +37,7 @@ only**. Rebuild **carries over per-lane rate state** (`sent` window,
 (can't be double-spent across a swap), a lowered rpm is honored immediately
 (`try_take` checks `sent.len() < rpm` live), and a disabled key keeps its stored
 state so it re-enables **warm**. Grants carry their originating `Arc<Pool>`
-(`Slot { pool, lane, key }`) so late bench/release after a swap route to the
+(`Slot { pool, lane, key }`) so late cooldown/release after a swap route to the
 pool that granted them — no index-out-of-bounds, late ops on a retired pool are
 benign. **Invariant**: the superuser always owns ≥1 enabled key, pinning the
 pool floor (removing/disabling the last one is a 400), so the pool can never

--- a/knowledge/architecture/streaming-pipeline.md
+++ b/knowledge/architecture/streaming-pipeline.md
@@ -20,7 +20,7 @@ For a `stream: true` chat request:
    interval a `: heartbeat` comment goes out (send failure = client gone →
    the granted slot is never wasted on a dead request).
 4. **Send + triage**: 400-after-injection → retry untouched and remember the
-   model; 429/500/502/503/504 → bench the lane, `: retrying` comment, loop
+   model; 429/500/502/503/504 → cool down the lane, `: retrying` comment, loop
    (instant failover to other lanes); other non-2xx → relay as an in-stream
    `error` event; success → pipe.
 5. **Race the absolute deadline**: when the caller supplies

--- a/knowledge/decisions/lane-cooldown-naming.md
+++ b/knowledge/decisions/lane-cooldown-naming.md
@@ -36,8 +36,8 @@ was already load-bearing.
 
 ## Choice
 
-**Option 5.** `bench` → `cooldown` across `src/`, `tests/`, `knowledge/`, and
-`README.md`. The Prometheus series `nimproxy_lane_benched_total` becomes
+**Option 5.** `bench` → `cooldown` across `src/`, `tests/`, `scripts/`,
+`knowledge/`, and `README.md`. The Prometheus series `nimproxy_lane_benched_total` becomes
 `nimproxy_lane_cooldown_total`; every other `nimproxy_*` series is unchanged.
 The internal helper `proxy::bench` becomes `proxy::enter_cooldown`.
 

--- a/knowledge/decisions/lane-cooldown-naming.md
+++ b/knowledge/decisions/lane-cooldown-naming.md
@@ -1,0 +1,67 @@
+---
+type: Decision
+title: Name the post-backoff lane state "cooldown", not "bench"
+description: The sports idiom "bench" had no standard translation that wasn't already load-balancing vocabulary. Renamed to cooldown across code, metrics, and prose, accepting a history discontinuity on the renamed series.
+tags: [terminology, metrics, pool, breaking-change]
+timestamp: 2026-07-29T00:00:00Z
+---
+
+# Name the post-backoff lane state "cooldown", not "bench"
+
+## Context
+
+When the upstream returns 429/5xx/connect-error, the granting lane is taken out
+of rotation until a deadline. The design-phase name for that state was
+**bench** — a sports idiom, borrowed before the vocabulary settled.
+
+It was never a good fit. "Bench" has no standard equivalent in load-balancing
+vocabulary, so it had to be explained rather than recognized, and every
+translation of the dashboard would have had to invent a term. The field holding
+the deadline was already called `cooldown_until`, so the codebase was
+internally inconsistent with itself: one concept, two names, and the better name
+was already load-bearing.
+
+## Options
+
+1. **Keep `bench`.** Zero work, but the term stays unexplainable and the
+   internal inconsistency with `cooldown_until` persists.
+2. **`ejection`** — Envoy's word for the same idea (outlier detection ejects a
+   host). Accurate, but implies removal from the pool rather than a timed
+   pause, and the lane always comes back.
+3. **`circuit break`** — widely understood, but carries half-open/closed state
+   machinery this does not have. Claiming it would overstate the behavior.
+4. **`quarantine`** — accurate but alarming for a routine 429.
+5. **`cooldown`** — a timed pause before reuse. Already the field name, already
+   standard, and it is exactly what the code does.
+
+## Choice
+
+**Option 5.** `bench` → `cooldown` across `src/`, `tests/`, `knowledge/`, and
+`README.md`. The Prometheus series `nimproxy_lane_benched_total` becomes
+`nimproxy_lane_cooldown_total`; every other `nimproxy_*` series is unchanged.
+The internal helper `proxy::bench` becomes `proxy::enter_cooldown`.
+
+Prose says **lane cooldown** where ambiguity with
+[dependency-update-cooldown](dependency-update-cooldown.md) is possible. The two
+are different domains and do not conflict.
+
+Historical CHANGELOG entries keep the old word — they describe what shipped at
+the time, and rewriting them would be dishonest.
+
+## Consequences
+
+- **Breaking for anything scraping the old series.** Dashboards, alerts, or
+  recording rules referencing `nimproxy_lane_benched_total` must be updated.
+- **Retained history shows a gap.** `history.jsonl` persists the metric name
+  verbatim, so points recorded before the upgrade stay under the old key while
+  the dashboard queries the new one. Lane-cooldown charts are blank for
+  pre-upgrade points and return to full fidelity one retention window
+  (`history_days`) after upgrading.
+
+  This was a deliberate choice over a read-time alias in `history.rs`. The
+  alias would work, but it is a permanent compatibility shim carried forever to
+  smooth a one-time bounded gap in a homelab tool — precisely the kind of
+  prototype-phase residue this release exists to remove. The gap is visible,
+  self-healing, and documented.
+- The vocabulary is now recognizable without explanation, which is what makes
+  the labels machine-translatable in the same release.

--- a/knowledge/decisions/no-estimated-savings-metric.md
+++ b/knowledge/decisions/no-estimated-savings-metric.md
@@ -1,0 +1,66 @@
+---
+type: Decision
+title: Remove the estimated-savings metric and pricing configuration
+description: "Dollars saved" needed a published per-model rate to be honest; one reference rate for all tokens is not a measurement. Deleted the metric, the config, and the route rather than fixing an unfixable number.
+tags: [dashboard, metrics, settings, breaking-change]
+timestamp: 2026-07-29T00:00:00Z
+---
+
+# Remove the estimated-savings metric and pricing configuration
+
+## Context
+
+The dashboard showed a **Dollars saved** KPI on Overview, plus a `Saved` column
+in the Models, Clients, and Reliability tables. It multiplied prompt and
+completion tokens by two operator-configured reference rates
+(`ref_price_in`, `ref_price_out`) stored in a `Pricing` config block and edited
+through `/api/settings/pricing`.
+
+The number was never trustworthy. A meaningful "saved" figure is the difference
+between what you paid and what *the same model* would have cost elsewhere, which
+requires a published per-model rate for every model in the pool. Instead a
+single pair of rates was applied to every model, so a run against a small model
+and a run against a large one contributed identically. The figure moved with
+traffic volume and looked precise — two decimal places and a currency symbol —
+while measuring nothing in particular.
+
+It also anchored the only currency in the product, which would have forced a
+`Intl.NumberFormat` currency decision (which currency? whose locale? the
+operator's or the viewer's?) during the localization work in this same release.
+
+## Options
+
+1. **Keep it, document the caveat.** The tooltip already said "vs reference
+   pricing." Nobody reads a caveat on a number rendered in dollars.
+2. **Fix it with per-model rates.** Correct, but requires a maintained rate
+   table for every NIM model, kept current against someone else's pricing page.
+   That is a product, and nobody asked for it.
+3. **Make it token-denominated** — "tokens served" rather than dollars. But
+   that is just `Tokens out`, which the dashboard already shows.
+4. **Remove it.**
+
+## Choice
+
+**Option 4.** Deleted the KPI tile, the three `Saved` table columns, the
+`money()` helper and its `$` prefix, the `Pricing` settings card, the
+`Pricing` config struct with `ref_price_in` / `ref_price_out`, the
+`/api/settings/pricing` route and handler, and the pricing validation branch.
+
+`REF_PRICE_IN` and `REF_PRICE_OUT` stay in the legacy-env warning list in
+`lib.rs`. An operator upgrading with them still set should be told they are
+ignored — that list exists for exactly this.
+
+## Consequences
+
+- **`/api/settings/pricing` is gone** (404 after upgrade), and `/api/config` no
+  longer carries a `server.pricing` object. `/api/dashboard` no longer emits
+  `price_in` / `price_out`.
+- **Existing config stores load unchanged.** `StoredConfig` has no
+  `deny_unknown_fields`, so a `pricing` block written by 0.6.5 or earlier is
+  ignored rather than rejected. No migration runs, and nothing rewrites the
+  store until the next settings save. Covered by
+  `config_with_a_legacy_pricing_block_still_loads`.
+- The API surface shrinks from 13 `/api/*` routes to 12 before the OpenAPI spec
+  is generated in the same release, so the spec never documents this route.
+- The currency-formatting question disappears rather than being answered, which
+  removes it from the `Intl` migration entirely.

--- a/knowledge/decisions/no-estimated-savings-metric.md
+++ b/knowledge/decisions/no-estimated-savings-metric.md
@@ -53,8 +53,8 @@ ignored — that list exists for exactly this.
 ## Consequences
 
 - **`/api/settings/pricing` is gone** (404 after upgrade), and `/api/config` no
-  longer carries a `server.pricing` object. `/api/dashboard` no longer emits
-  `price_in` / `price_out`.
+  longer carries a `server.pricing` object. `/api/dashboard/now` no longer
+  emits `price_in` / `price_out`.
 - **Existing config stores load unchanged.** `StoredConfig` has no
   `deny_unknown_fields`, so a `pricing` block written by 0.6.5 or earlier is
   ignored rather than rejected. No migration runs, and nothing rewrites the

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -32,6 +32,8 @@ the chronology in [log.md](log.md).
 | [ui-managed-config-store](decisions/ui-managed-config-store.md) | App config moves from env into a JSON store edited from the dashboard; first-run wizard, multi-user + per-key ownership, no encryption at rest |
 | [explicit-request-deadline](decisions/explicit-request-deadline.md) | Opt-in wall-clock bound cancels queue/retry/generation work without weakening patient defaults |
 | [dependency-update-cooldown](decisions/dependency-update-cooldown.md) | Routine dependency updates wait seven days; security updates remain immediate |
+| [lane-cooldown-naming](decisions/lane-cooldown-naming.md) | `bench` → `cooldown`; renames the metric and accepts a bounded history gap over a permanent alias |
+| [no-estimated-savings-metric](decisions/no-estimated-savings-metric.md) | "Dollars saved" needed per-model published rates to be honest; deleted rather than faked |
 
 ## Research — validated external facts
 
@@ -45,7 +47,7 @@ the chronology in [log.md](log.md).
 
 | Page | One-liner |
 |---|---|
-| [key-pool](architecture/key-pool.md) | Per-key sliding-window lanes; least-loaded selection; cooldown benching |
+| [key-pool](architecture/key-pool.md) | Per-key sliding-window lanes; least-loaded selection; cooldown on upstream backoff |
 | [dispatcher](architecture/dispatcher.md) | Global FIFO slot queue; abandoned-waiter slot return; affinity accounting |
 | [governor](architecture/governor.md) | Per-model concurrency gate; classifies worker exhaustion apart from 429s and backs off the model, adaptively |
 | [streaming-pipeline](architecture/streaming-pipeline.md) | Heartbeats, retry/failover, absolute deadlines, idle timeout, SSE usage scanning |

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,29 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-29] decision — lane cooldown naming, savings metric removed
+
+First change of the 0.6.6 presentation-layer rationalization.
+
+- Retired the `bench` idiom for the post-backoff lane state in favor of
+  **cooldown**, which the `cooldown_until` field already used. Renamed across
+  `src/`, `tests/`, `knowledge/`, and the `README.md` metrics table;
+  `nimproxy_lane_benched_total` → `nimproxy_lane_cooldown_total`;
+  `proxy::bench` → `proxy::enter_cooldown`. Recorded in
+  [lane-cooldown-naming](decisions/lane-cooldown-naming.md), including why a
+  read-time history alias was rejected in favor of a bounded, documented gap.
+- Removed the estimated-savings metric and everything feeding it: the
+  `Dollars saved` KPI, three `Saved` table columns, `money()`, the `Pricing`
+  settings card and config block, `/api/settings/pricing`, and the pricing
+  validation branch. Recorded in
+  [no-estimated-savings-metric](decisions/no-estimated-savings-metric.md).
+  `REF_PRICE_IN`/`REF_PRICE_OUT` deliberately stay in the legacy-env warning
+  list. New regression test proves a 0.6.5 store carrying a `pricing` block
+  still loads.
+- Lint: `knowledge/architecture/key-pool.md` and `governor.md` described the
+  state as "benching" while `pool.rs` already named the field `cooldown_until`
+  — the pages and the code now agree.
+
 ## [2026-07-28] ingest — prepare v0.6.5 maintenance release
 
 - Promoted the accumulated maintenance, dashboard-history corrections, and
@@ -408,7 +431,7 @@ v0.6.0 amendment.
 - **Model-pressure governor** (new component page
   [governor](architecture/governor.md)): classifies NIM's per-model
   worker-exhaustion error apart from 429s and backs off the **model** (never
-  benches the lane); adaptive AIMD (engage at half in-flight, +1/stable-min,
+  cools down the lane); adaptive AIMD (engage at half in-flight, +1/stable-min,
   dissolve after 30 clean min) with optional pinned caps. New metrics
   `nimproxy_worker_exhausted_total` / `nimproxy_model_inflight` /
   `nimproxy_model_limit`; a Reliability "Model pressure" card appears once

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -12,7 +12,7 @@ First change of the 0.6.6 presentation-layer rationalization.
 
 - Retired the `bench` idiom for the post-backoff lane state in favor of
   **cooldown**, which the `cooldown_until` field already used. Renamed across
-  `src/`, `tests/`, `knowledge/`, and the `README.md` metrics table;
+  `src/`, `tests/`, `scripts/`, `knowledge/`, and the `README.md` metrics table;
   `nimproxy_lane_benched_total` → `nimproxy_lane_cooldown_total`;
   `proxy::bench` → `proxy::enter_cooldown`. Recorded in
   [lane-cooldown-naming](decisions/lane-cooldown-naming.md), including why a
@@ -27,7 +27,13 @@ First change of the 0.6.6 presentation-layer rationalization.
   still loads.
 - Lint: `knowledge/architecture/key-pool.md` and `governor.md` described the
   state as "benching" while `pool.rs` already named the field `cooldown_until`
-  — the pages and the code now agree.
+  — the pages and the code now agree. Adversarial review of the change also
+  caught `README.md` and `architecture/dashboard.md` still advertising the
+  deleted savings KPI and sparklines, and both breaking-change notes naming
+  `/api/dashboard` where the removed fields were actually emitted by
+  `/api/dashboard/now`; all corrected in-PR. Removing the savings card
+  orphaned the `valColor` and `green` options on `kpiCards`/`sparkSvg` — it
+  was their only caller — so the unreachable branches went with it.
 
 ## [2026-07-28] ingest — prepare v0.6.5 maintenance release
 

--- a/knowledge/ops/configure-env.md
+++ b/knowledge/ops/configure-env.md
@@ -42,7 +42,7 @@ the contract.)
 NIM keys (per-key rpm, enable/disable, ownership), the upstream base URL,
 client API keys and the open/keyed API mode, limits (max_wait, heartbeat,
 stream_idle, request_timeout, models_ttl, max_inflight, strict_passthrough),
-pricing, the default dashboard window, history retention days, the
+the default dashboard window, history retention days, the
 availability SLO, the model-pressure governor, and users/roles all live in the
 store and are edited from the dashboard. A Settings save validates the
 complete candidate, writes `config.json` atomically, and swaps the live
@@ -64,7 +64,9 @@ schedules atomic background compaction of `history.jsonl`.
 **Legacy env vars are ignored.** `NIM_API_KEYS`, `PROXY_API_KEYS`,
 `ADMIN_PASSWORD`, `INSECURE_NO_AUTH`, `NIM_BASE_URL`, `RPM_PER_KEY`,
 `MAX_WAIT_SECS`, `HEARTBEAT_SECS`, `MODELS_TTL_SECS`, `STREAM_IDLE_SECS`,
-`REQUEST_TIMEOUT_SECS`, `STRICT_PASSTHROUGH`, `REF_PRICE_IN`/`REF_PRICE_OUT`,
+`REQUEST_TIMEOUT_SECS`, `STRICT_PASSTHROUGH`, `REF_PRICE_IN`/`REF_PRICE_OUT`
+(removed in 0.6.6 — see
+[no-estimated-savings-metric](../decisions/no-estimated-savings-metric.md)),
 `HISTORY_DAYS`, and `MAX_INFLIGHT` no longer do anything; a set-but-ignored one
 gets a single boot warning (`ignoring legacy env vars (…) — these settings live
 in the dashboard now`). There is no seed-from-env and no migration (there were

--- a/scripts/mock_nim.py
+++ b/scripts/mock_nim.py
@@ -95,7 +95,7 @@ class Handler(BaseHTTPRequestHandler):
 
         # NIM's second, orthogonal constraint: a per-model worker-concurrency
         # cap shared across ALL keys. The proxy's governor must absorb this
-        # without benching lanes (key failover cannot help).
+        # without putting lanes in cooldown (key failover cannot help).
         model = req.get("model", "none")
         if ARGS.worker_slots:
             with LOCK:

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,8 +33,6 @@ pub struct StoredConfig {
     #[serde(default)]
     pub limits: Limits,
     #[serde(default)]
-    pub pricing: Pricing,
-    #[serde(default)]
     pub history: HistoryCfg,
     #[serde(default)]
     pub dashboard: DashboardCfg,
@@ -130,23 +128,6 @@ pub struct Limits {
 impl Default for Limits {
     fn default() -> Self {
         serde_json::from_str("{}").expect("all Limits fields have defaults")
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct Pricing {
-    #[serde(default = "default_price_in")]
-    pub ref_price_in: f64,
-    #[serde(default = "default_price_out")]
-    pub ref_price_out: f64,
-}
-
-impl Default for Pricing {
-    fn default() -> Self {
-        Self {
-            ref_price_in: default_price_in(),
-            ref_price_out: default_price_out(),
-        }
     }
 }
 
@@ -254,12 +235,6 @@ fn default_request_timeout() -> u64 {
 fn default_max_inflight() -> usize {
     512
 }
-fn default_price_in() -> f64 {
-    0.5
-}
-fn default_price_out() -> f64 {
-    2.0
-}
 fn default_history_days() -> u64 {
     30
 }
@@ -303,8 +278,6 @@ impl StoredConfig {
             stream_idle: Duration::from_secs(self.limits.stream_idle_secs),
             request_timeout: Duration::from_secs(self.limits.request_timeout_secs),
             strict_passthrough: self.limits.strict_passthrough,
-            price_in: self.pricing.ref_price_in,
-            price_out: self.pricing.ref_price_out,
             clients: match self.client_auth.mode {
                 Mode::Open => None,
                 Mode::Keyed => Some(
@@ -442,13 +415,6 @@ pub fn validate(sc: &StoredConfig) -> Result<(), String> {
     }
     if l.max_inflight == 0 {
         return Err("max_inflight must be >= 1".into());
-    }
-    if !sc.pricing.ref_price_in.is_finite()
-        || !sc.pricing.ref_price_out.is_finite()
-        || sc.pricing.ref_price_in < 0.0
-        || sc.pricing.ref_price_out < 0.0
-    {
-        return Err("reference prices must be non-negative numbers".into());
     }
     if sc.dashboard.default_window_days == 0 {
         return Err("default_window_days must be >= 1".into());
@@ -742,6 +708,23 @@ mod tests {
         }
     }
 
+    /// 0.6.6 removed the `pricing` block. Stores written by 0.6.5 and earlier
+    /// still carry it; `StoredConfig` has no `deny_unknown_fields`, so the
+    /// orphan key must load and be ignored rather than fail the boot.
+    #[test]
+    fn config_with_a_legacy_pricing_block_still_loads() {
+        let dir = TestDir::new();
+        let mut raw = serde_json::to_value(claimed()).unwrap();
+        raw.as_object_mut().unwrap().insert(
+            "pricing".into(),
+            serde_json::json!({"ref_price_in": 0.5, "ref_price_out": 2.0}),
+        );
+        fs::write(store_path(&dir.0), serde_json::to_string(&raw).unwrap()).unwrap();
+
+        let sc = load(&dir.0).unwrap().expect("legacy store must load");
+        validate(&sc).expect("a legacy pricing block must not fail validation");
+    }
+
     #[test]
     fn future_version_refuses_to_load() {
         let dir = TestDir::new();
@@ -811,10 +794,6 @@ mod tests {
             (
                 "bad base_url",
                 Box::new(|sc| sc.upstream.base_url = "ftp://x".into()),
-            ),
-            (
-                "negative price",
-                Box::new(|sc| sc.pricing.ref_price_in = -1.0),
             ),
             (
                 "bad governor cap",

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -159,7 +159,7 @@ td {
 td.l { text-align: left; color: var(--ink-1); }
 td.best { color: var(--green-lt); font-weight: 600; }
 td .sw { margin-right: 8px; vertical-align: baseline; }
-.dim { color: var(--ink-4); } .warnc { color: var(--amber-lt); } .critc { color: var(--red); } .savec { color: var(--green-lt); }
+.dim { color: var(--ink-4); } .warnc { color: var(--amber-lt); } .critc { color: var(--red); }
 
 /* ---------- key-value lists, bars, leaderboards ---------- */
 .kv { display: flex; justify-content: space-between; align-items: center; padding: 6px 0; border-bottom: 1px solid var(--hairline); font-size: 12.5px; }
@@ -556,8 +556,8 @@ body.on-settings .tright, body.on-settings #custom { display: none; }
       </div>
       <div class="card">
         <h2>Rate-limit hits per minute</h2>
-        <div id="chart-benches"></div>
-        <div class="legend" id="legend-benches"></div>
+        <div id="chart-cooldowns"></div>
+        <div class="legend" id="legend-cooldowns"></div>
       </div>
     </div>
     <div class="card">
@@ -598,7 +598,6 @@ const fmt = n => !isFinite(n) ? '–'
   : Math.abs(n) >= 100 ? Math.round(n).toLocaleString()
   : Math.abs(n) >= 10 ? n.toFixed(1).replace(/\.0$/,'')
   : n.toFixed(2).replace(/\.?0+$/, '');
-const money = n => '$' + (n >= 1000 ? fmt(n) : n.toFixed(2));
 const secs = s => !isFinite(s) ? '–' : s < 1 ? Math.round(s*1000)+' ms' : s < 90 ? s.toFixed(1)+' s' : Math.round(s/60)+' min';
 const ago = s => { s = Math.max(0, Math.round(s));
   const d = Math.floor(s/86400), h = Math.floor(s%86400/3600), m = Math.floor(s%3600/60);
@@ -650,7 +649,7 @@ let nowData = null;
 let nowRows = [];
 let mode = { kind: 'following', preset: 'default', paused: false, from: 0, to: 0 };
 let cfg = {
-  lanes: 0, rpm: 40, rpms: [], capacity_rpm: 0, price_in: 0.5, price_out: 2.0,
+  lanes: 0, rpm: 40, rpms: [], capacity_rpm: 0,
   started: Date.now()/1000, version: '', auth: false, default_window_days: 30,
   retention_days: 30, slo_target_percent: 99.9,
 };
@@ -1004,7 +1003,6 @@ function ringGauge(el, ratio, text, color, label, sub) {
 const ICONS = {
   pulse: '<path d="M1 8h3l2-5 3 11 2-6h4"/>',
   stack: '<path d="M8 1.5l6 3-6 3-6-3zM2 8l6 3 6-3M2 11.5l6 3 6-3"/>',
-  coin: '<path d="M8 1.5A6.5 6.5 0 108 14.5 6.5 6.5 0 008 1.5zM8 4.5v7M9.8 6a2 2 0 00-3.6 1.2c0 2 3.6 1 3.6 2.8A2 2 0 016.2 10.5"/>',
   check: '<path d="M2.5 8.5l3.5 3.5 7.5-8"/>',
   clock: '<path d="M8 4v4l2.5 1.5M8 1.5A6.5 6.5 0 108 14.5 6.5 6.5 0 008 1.5z"/>',
   bolt: '<path d="M9 1.5L3 9h4l-1 5.5L13 7H9z"/>',
@@ -1159,11 +1157,9 @@ function render() {
   const reqModels = wgroups('nimproxy_requests_total', 'model', l => l.path === '/v1/chat/completions');
   const models = [...new Set([...ctok.keys(), ...ptok.keys(), ...reqModels.keys()])].filter(m => m !== 'none');
   models.sort((a,b) => (ctok.get(b)||0) - (ctok.get(a)||0));
-  let saved = 0, allP = 0, allC = 0;
+  let allP = 0, allC = 0;
   for (const m of models) {
-    const p = ptok.get(m) || 0, ct = ctok.get(m) || 0;
-    allP += p; allC += ct;
-    saved += p/1e6*cfg.price_in + ct/1e6*cfg.price_out;
+    allP += ptok.get(m) || 0; allC += ctok.get(m) || 0;
   }
   const wsum = name => windowed(s => sum(s.rows, name));
   const ttftS = wsum('nimproxy_ttft_seconds_sum'), ttftN = wsum('nimproxy_ttft_seconds_count');
@@ -1184,16 +1180,6 @@ function render() {
   const truncPct = m => finTotal.get(m) ? (finLen.get(m) || 0) / finTotal.get(m) * 100 : NaN;
   const reasonPct = m => ctok.get(m) ? (reasoningByModel.get(m) || 0) / ctok.get(m) * 100 : NaN;
   const pct = v => isFinite(v) ? v.toFixed(v && v < 10 ? 1 : 0) + '%' : '–';
-  const modelSaved = m => (ptok.get(m)||0)/1e6*cfg.price_in + (ctok.get(m)||0)/1e6*cfg.price_out;
-
-  /* cumulative dollars within the view */
-  const base = samples[0];
-  const savedAt = s => {
-    let v = 0;
-    v += (sum(s.rows, 'nimproxy_prompt_tokens_total') - sum(base.rows, 'nimproxy_prompt_tokens_total')) / 1e6 * cfg.price_in;
-    v += (sum(s.rows, 'nimproxy_completion_tokens_total') - sum(base.rows, 'nimproxy_completion_tokens_total')) / 1e6 * cfg.price_out;
-    return Math.max(0, v);
-  };
 
   /* ----- shared proxy / capacity aggregates ----- */
   const reqPts = rateSeries(s => sum(s.rows, 'nimproxy_requests_total'));
@@ -1232,28 +1218,26 @@ function render() {
   const totStreamF = [...streamF.values()].reduce((a, b) => a + b, 0);
   const totGen = totStreamT + totStreamF;
   const totToolReq = [...toolReqs.values()].reduce((a, b) => a + b, 0);
-  const clientSaved = cl => (cP.get(cl)||0)/1e6*cfg.price_in + (cC.get(cl)||0)/1e6*cfg.price_out;
 
   /* ----- shared reliability / security counters ----- */
   const shed = windowed(s => sum(s.rows, 'nimproxy_shed_total'));
   const unauth = windowed(s => sum(s.rows, 'nimproxy_unauthorized_total'));
   const logins = windowed(s => sum(s.rows, 'nimproxy_login_failures_total'));
-  const bench429 = windowed(s => sum(s.rows, 'nimproxy_lane_benched_total', l => l.status === '429'));
-  const benchOther = windowed(s => sum(s.rows, 'nimproxy_lane_benched_total', l => l.status !== '429'));
+  const cooldown429 = windowed(s => sum(s.rows, 'nimproxy_lane_cooldown_total', l => l.status === '429'));
+  const cooldownOther = windowed(s => sum(s.rows, 'nimproxy_lane_cooldown_total', l => l.status !== '429'));
   const qwS = wsum('nimproxy_queue_wait_seconds_sum'), qwN = wsum('nimproxy_queue_wait_seconds_count');
   const upS = wsum('nimproxy_upstream_seconds_sum'), upN = wsum('nimproxy_upstream_seconds_count');
   const statusG = wgroups('nimproxy_requests_total', 'status');
 
   const c = {
     last, rows, windowLabel,
-    ptok, ctok, reqModels, models, saved, allP, allC,
+    ptok, ctok, reqModels, models, allP, allC,
     wsum, ttftS, ttftN, tpsS, tpsN,
     okByModel, errByModel, ttftMS, ttftMC, tpsMS, tpsMC, errRate, errPct,
-    tpotMS, tpotMC, finTotal, finLen, reasoningByModel, tpotAvg, truncPct, reasonPct, pct, modelSaved,
-    savedAt,
+    tpotMS, tpotMC, finTotal, finLen, reasoningByModel, tpotAvg, truncPct, reasonPct, pct,
     reqPts, capacityPoints, curRpm, avgRpm, peakRpm, capacity, rpmNow, capRatio, capColor, wreq, wok, okRatio, okColor,
-    cReq, cP, cC, clients, streamT, streamF, toolReqs, totStreamT, totStreamF, totGen, totToolReq, clientSaved,
-    shed, unauth, logins, bench429, benchOther, qwS, qwN, upS, upN, statusG,
+    cReq, cP, cC, clients, streamT, streamF, toolReqs, totStreamT, totStreamF, totGen, totToolReq,
+    shed, unauth, logins, cooldown429, cooldownOther, qwS, qwN, upS, upN, statusG,
   };
   (RENDERERS[activeTab] || renderOverview)(c);
 }
@@ -1264,8 +1248,8 @@ const clientChip = cl =>
 
 /* ===== overview ===== */
 function renderOverview(c) {
-  const { windowLabel, saved, capRatio, capColor, okRatio, okColor, wreq, wok, allP, allC,
-    reqPts, savedAt, rows, shed, unauth, logins, bench429, rpmNow, capacity, curRpm,
+  const { windowLabel, capRatio, capColor, okRatio, okColor, wreq, wok, allP, allC,
+    reqPts, rows, shed, unauth, logins, cooldown429, rpmNow, capacity, curRpm,
     models, ctok, clients, cC, errRate } = c;
   const ctokPts = rateSeries(s => sum(s.rows, 'nimproxy_completion_tokens_total'));
   const okPts = samples.slice(1).map((s, i) => {
@@ -1273,15 +1257,11 @@ function renderOverview(c) {
     const dok = sum(s.rows, 'nimproxy_requests_total', l => l.status === '200') - sum(samples[i].rows, 'nimproxy_requests_total', l => l.status === '200');
     return dr > 0 ? { t: s.t, v: Math.max(0, Math.min(100, dok / dr * 100)) } : null;
   }).filter(Boolean);
-  const savedPts = samples.map(s => ({ t: s.t, v: savedAt(s) }));
-  const savedDiffs = savedPts.slice(1).map((p, i) => ({ t: p.t, v: Math.max(0, p.v - savedPts[i].v) }));
   kpiCards($('o-kpis'), [
     { icon: 'pulse', label: 'Requests', value: fmt(wreq), sub: windowLabel, delta: deltaChip(reqPts), pts: reqPts },
     { icon: 'stack', label: 'Tokens out', value: fmt(allC), sub: `${fmt(allP)} in`, delta: deltaChip(ctokPts), pts: ctokPts },
     { icon: 'check', label: 'Success rate', value: wreq ? (okRatio * 100).toFixed(2).replace(/\.?0+$/, '') + '%' : '–',
       sub: `${fmt(wok)} of ${fmt(wreq)}`, delta: deltaChip(okPts), pts: okPts },
-    { icon: 'coin', label: 'Dollars saved', value: money(saved), sub: 'vs reference pricing',
-      valColor: MED, delta: deltaChip(savedDiffs), pts: savedPts, green: true },
   ], true);
 
   $('o-reqnow').textContent = fmt(curRpm) + ' now';
@@ -1292,12 +1272,12 @@ function renderOverview(c) {
     'Capacity used · Now', `${fmt(rpmNow)} / ${fmt(capacity)} rpm · ${cfg.lanes} lane${cfg.lanes === 1 ? '' : 's'}`);
   const errShare = wreq ? (wreq - wok) / wreq * 100 : 0;
   ringGauge($('o-ring-ok'), okRatio, wreq ? Math.round(okRatio * 100) + '%' : '–', okColor,
-    'Success rate', `errors ${errShare.toFixed(errShare && errShare < 10 ? 1 : 0)}% · ${fmt(bench429)} benched`);
+    'Success rate', `errors ${errShare.toFixed(errShare && errShare < 10 ? 1 : 0)}% · ${fmt(cooldown429)} cooldowns`);
   const sul = shed + unauth + logins;
   $('o-health').innerHTML =
     metricRow('Active now', fmt(sum(rows, 'nimproxy_active_requests'))) +
     metricRow('Queued', fmt(sum(rows, 'nimproxy_queue_depth'))) +
-    metricRow('Rate-limit benches', fmt(bench429), bench429 > 0 ? 'warn' : 'zero') +
+    metricRow('Rate-limit cooldowns', fmt(cooldown429), cooldown429 > 0 ? 'warn' : 'zero') +
     metricRow('Shed · 401 · failed logins', `${fmt(shed)} · ${fmt(unauth)} · ${fmt(logins)}`, sul > 0 ? 'crit' : 'zero');
 
   const perfBlock = (label, note, p50, p95, fmtV) => {
@@ -1330,7 +1310,7 @@ function renderOverview(c) {
 function renderModels(c) {
   const { models, ptok, ctok, reqModels, allP, allC, windowLabel,
     ttftS, ttftN, tpsS, tpsN, okByModel, ttftMS, ttftMC, tpsMS, tpsMC, errRate, errPct,
-    finTotal, reasoningByModel, tpotAvg, truncPct, reasonPct, pct, modelSaved } = c;
+    finTotal, reasoningByModel, tpotAvg, truncPct, reasonPct, pct } = c;
 
   const chatReqs = [...reqModels.values()].reduce((a, b) => a + b, 0);
   const qmed = (metric, f) => { const v = quantile(wbuckets(metric, f), 0.5); return isFinite(v) ? v : NaN; };
@@ -1438,7 +1418,6 @@ function renderModels(c) {
       <div class="mstats">
         ${stat('requests', fmt(reqModels.get(m) || 0))}
         ${stat('tokens out', fmt(ct))}
-        ${stat('saved', money(modelSaved(m)), 'savec')}
         ${stat('TTFT', ttftMC.get(m) ? secs(avgTtft(m)) : '–')}
         ${stat('tok/s', tpsMC.get(m) ? fmt(avgTps(m)) : '–')}
         ${stat('errors', errPct(m), isFinite(e) && e > 0 ? 'critc' : 'dim')}
@@ -1450,27 +1429,26 @@ function renderModels(c) {
   sortTable($('table-models'), 'models', [
     { label: 'Model', align: 'l', str: true }, { label: 'Requests' }, { label: 'Tokens out' },
     { label: 'Avg TTFT' }, { label: 'Avg tok/s' }, { label: 'TPOT' }, { label: 'Avg reply' },
-    { label: 'Truncated' }, { label: 'Reasoning' }, { label: 'Errors' }, { label: 'Saved' },
+    { label: 'Truncated' }, { label: 'Reasoning' }, { label: 'Errors' },
   ], models.map(m => {
     const ct = ctok.get(m) || 0, ok = okByModel.get(m) || 0, e = errRate(m);
     return {
       vals: [m, reqModels.get(m) || 0, ct, avgTtft(m), avgTps(m), tpotAvg(m), ok ? ct / ok : NaN,
-        truncPct(m), reasonPct(m), e, modelSaved(m)],
+        truncPct(m), reasonPct(m), e],
       cells: [`<i class="sw" style="background:${publisher(m).color}"></i>${esc(m)}`,
         fmt(reqModels.get(m) || 0), fmt(ct),
         ttftMC.get(m) ? secs(avgTtft(m)) : '–', tpsMC.get(m) ? fmt(avgTps(m)) : '–',
         isFinite(tpotAvg(m)) ? secs(tpotAvg(m)) : '–', ok ? fmt(ct / ok) + ' tok' : '–',
         `<span class="${truncPct(m) >= 1 ? '' : 'dim'}">${pct(truncPct(m))}</span>`,
         `<span class="${reasonPct(m) >= 1 ? '' : 'dim'}">${pct(reasonPct(m))}</span>`,
-        `<span class="${isFinite(e) && e > 0 ? 'critc' : 'dim'}">${errPct(m)}</span>`,
-        `<span class="savec">${money(modelSaved(m))}</span>`],
+        `<span class="${isFinite(e) && e > 0 ? 'critc' : 'dim'}">${errPct(m)}</span>`],
     };
   }), { defaultIdx: 2, maxH: 440, minW: 900 });
 }
 
 /* ===== clients: what each agent is doing ===== */
 function renderClients(c) {
-  const { clients, cReq, cC, wsum, streamT, streamF, totStreamT, totGen, totToolReq, clientSaved } = c;
+  const { clients, cReq, cC, wsum, streamT, streamF, totStreamT, totGen, totToolReq } = c;
   const avgByKey = (sumN, cntN) => {
     const s = wgroups(sumN, 'client'), n = wgroups(cntN, 'client');
     return cl => n.get(cl) ? s.get(cl) / n.get(cl) : NaN;
@@ -1503,21 +1481,20 @@ function renderClients(c) {
     barList($('h-maxtok'), maxTokClients.map(cl => ({ name: cl, v: maxTokAvg(cl), color: clientColor(cl) })), fmt);
   sortTable($('table-harness'), 'harness', [
     { label: 'Harness', align: 'l', str: true }, { label: 'Requests' }, { label: 'Tokens out' },
-    { label: 'Tools/req' }, { label: 'Msgs/req' }, { label: 'Streaming' }, { label: 'Saved' },
+    { label: 'Tools/req' }, { label: 'Msgs/req' }, { label: 'Streaming' },
   ], clients.map(cl => ({
-    vals: [cl, cReq.get(cl) || 0, cC.get(cl) || 0, toolsAvg(cl), msgsAvg(cl), streamPct(cl), clientSaved(cl)],
+    vals: [cl, cReq.get(cl) || 0, cC.get(cl) || 0, toolsAvg(cl), msgsAvg(cl), streamPct(cl)],
     cells: [`<i class="sw" style="background:${clientColor(cl)}"></i>${esc(cl)}`,
       fmt(cReq.get(cl) || 0), fmt(cC.get(cl) || 0),
       isFinite(toolsAvg(cl)) ? fmt(toolsAvg(cl)) : '–', isFinite(msgsAvg(cl)) ? fmt(msgsAvg(cl)) : '–',
-      isFinite(streamPct(cl)) ? Math.round(streamPct(cl)) + '%' : '–',
-      `<span class="savec">${money(clientSaved(cl))}</span>`],
+      isFinite(streamPct(cl)) ? Math.round(streamPct(cl)) + '%' : '–'],
   })), { defaultIdx: 2, maxH: 420, minW: 620 });
 }
 
 /* ===== reliability (was Proxy) ===== */
 function renderReliability(c) {
-  const { rows, windowLabel, reqPts, wreq, wok, okRatio, clients, cReq, cP, cC, clientSaved,
-    shed, unauth, logins, bench429, benchOther, qwS, qwN, upS, upN, ttftS, ttftN, statusG,
+  const { rows, windowLabel, reqPts, wreq, wok, okRatio, clients, cReq, cP, cC,
+    shed, unauth, logins, cooldown429, cooldownOther, qwS, qwN, upS, upN, ttftS, ttftN, statusG,
     totStreamT, totStreamF, totGen, totToolReq, wsum } = c;
 
   /* hero: availability vs SLO + error budget */
@@ -1675,8 +1652,8 @@ function renderReliability(c) {
     metricRow('Active now', fmt(act)) +
     metricRow('Queued', fmt(que)) +
     metricRow('Shed (overload 503)', fmt(shed), shed > 0 ? 'crit' : 'zero') +
-    metricRow('Rate-limit benches (429)', fmt(bench429), bench429 > 0 ? 'warn' : 'zero') +
-    metricRow('Other benches (5xx)', fmt(benchOther), benchOther > 0 ? 'warn' : 'zero') +
+    metricRow('Rate-limit cooldowns', fmt(cooldown429), cooldown429 > 0 ? 'warn' : 'zero') +
+    metricRow('Upstream error cooldowns', fmt(cooldownOther), cooldownOther > 0 ? 'warn' : 'zero') +
     metricRow('Unauthorized (401)', fmt(unauth), unauth > 0 ? 'crit' : 'zero') +
     metricRow('Failed logins', fmt(logins), logins > 0 ? 'crit' : 'zero');
   const jsonMode = windowed(s => sum(s.rows, 'nimproxy_json_mode_total'));
@@ -1691,19 +1668,18 @@ function renderReliability(c) {
 
   sortTable($('table-clients'), 'clients', [
     { label: 'Client', align: 'l', str: true }, { label: 'Requests' }, { label: 'Tokens in' },
-    { label: 'Tokens out' }, { label: 'Saved' },
+    { label: 'Tokens out' },
   ], clients.map(cl => ({
-    vals: [cl, cReq.get(cl) || 0, cP.get(cl) || 0, cC.get(cl) || 0, clientSaved(cl)],
+    vals: [cl, cReq.get(cl) || 0, cP.get(cl) || 0, cC.get(cl) || 0],
     cells: [`<i class="sw" style="background:${clientColor(cl)}"></i>${esc(cl)}`,
-      fmt(cReq.get(cl) || 0), fmt(cP.get(cl) || 0), fmt(cC.get(cl) || 0),
-      `<span class="savec">${money(clientSaved(cl))}</span>`],
+      fmt(cReq.get(cl) || 0), fmt(cP.get(cl) || 0), fmt(cC.get(cl) || 0)],
   })), { defaultIdx: 3, maxH: 420, minW: 560 });
 }
 
 /* ===== capacity (was Keys) ===== */
 const LANE_COLORS = ['#76B900', '#4D6BFE', '#D9A521', '#16B8C0', '#615CED', '#EE6002'];
 function renderCapacity(c) {
-  const { capacity, rpmNow, capRatio, capColor, bench429, capacityPoints } = c;
+  const { capacity, rpmNow, capRatio, capColor, cooldown429, capacityPoints } = c;
 
   /* hero: current saturation uses only the current `/now` rate and config */
   const satPct = Math.min(1, capRatio);
@@ -1757,7 +1733,7 @@ function renderCapacity(c) {
   const prow = (l, v, color) => `<div style="display:flex;justify-content:space-between;align-items:center;padding:6px 0"><span style="font-size:12.5px;color:var(--ink-2)">${l}</span><span style="font:600 15px var(--mono);color:${color || 'var(--ink-1)'}">${v}</span></div>`;
   $('k-pressure').innerHTML =
     `<div class="hlabel" style="margin-bottom:12px">Rate-limit pressure</div>` +
-    prow('429s this window', fmt(bench429), bench429 > 0 ? 'var(--amber)' : 'var(--ink-3)') +
+    prow('429s this window', fmt(cooldown429), cooldown429 > 0 ? 'var(--amber)' : 'var(--ink-3)') +
     prow('Conversation stickiness', stickyTxt) +
     prow('Lane slots · Now', cfg.lanes);
 
@@ -1765,8 +1741,8 @@ function renderCapacity(c) {
      window counts remain selected-window values; neither domain is subtracted
      from the other. Slot numbers are explicitly not durable key identities. */
   const laneWindow = wgroups('nimproxy_lane_requests_total', 'lane');
-  const lane429 = wgroups('nimproxy_lane_benched_total', 'lane', l => l.status === '429');
-  const laneOther = wgroups('nimproxy_lane_benched_total', 'lane', l => l.status !== '429');
+  const lane429 = wgroups('nimproxy_lane_cooldown_total', 'lane', l => l.status === '429');
+  const laneOther = wgroups('nimproxy_lane_cooldown_total', 'lane', l => l.status !== '429');
   const totalLane = [...laneWindow.values()].reduce((a, b) => a + b, 0) || 1;
   const laneColor = i => LANE_COLORS[i % LANE_COLORS.length];
   const lanes = Array.from({ length: cfg.lanes }, (_, i) => {
@@ -1781,16 +1757,16 @@ function renderCapacity(c) {
     name: l.name, v: l.util * 100, color: l.util >= 0.9 ? css('--amber') : laneColor(l.i),
   })), v => Math.round(v) + '%', 100);
 
-  const benchSeries = lanes.slice(0, 6).map(l => ({
+  const cooldownSeries = lanes.slice(0, 6).map(l => ({
     name: l.name, color: laneColor(l.i),
-    pts: rateSeries(s => sum(s.rows, 'nimproxy_lane_benched_total', ll => ll.lane === String(l.i) && ll.status === '429')),
+    pts: rateSeries(s => sum(s.rows, 'nimproxy_lane_cooldown_total', ll => ll.lane === String(l.i) && ll.status === '429')),
   }));
-  lineChart($('chart-benches'), benchSeries, fmt, { height: 150 });
-  legend($('legend-benches'), benchSeries);
+  lineChart($('chart-cooldowns'), cooldownSeries, fmt, { height: 150 });
+  legend($('legend-cooldowns'), cooldownSeries);
 
   sortTable($('table-lanes'), 'lanes', [
     { label: 'Lane', align: 'l', str: true }, { label: 'Requests' }, { label: 'Share' },
-    { label: 'Now rpm' }, { label: '429s' }, { label: 'Other benches' },
+    { label: 'Now rpm' }, { label: '429s' }, { label: 'Upstream error cooldowns' },
   ], lanes.map(l => ({
     vals: [l.name, l.cur, l.cur / totalLane * 100, l.currentRpm, l.b429, l.bOther],
     cells: [`<i class="sw" style="background:${laneColor(l.i)}"></i>${esc(l.name)}`,
@@ -2042,7 +2018,7 @@ function renderServer() {
       <h2>Model-pressure governor
         <span style="margin-left:auto;display:inline-flex;align-items:center;gap:8px"><span class="kmeta">adaptive</span>
         <button class="tog" role="switch" id="gov-tog" aria-checked="${!!sv.governor.enabled}"></button></span></h2>
-      <p class="shint">Absorbs NIM worker-exhaustion per model without benching keys. Each model self-tunes: engages on the first exhaustion, climbs while stable, dissolves after a long clean stretch. Set an override only if you know a model's ceiling.</p>
+      <p class="shint">Absorbs NIM worker-exhaustion per model without cooling down keys. Each model self-tunes: engages on the first exhaustion, climbs while stable, dissolves after a long clean stretch. Set an override only if you know a model's ceiling.</p>
       <div>${ovr.map(([m, cap], i) =>
         `<span class="ochip"><span title="${esc(m)}">${esc(m)}</span><b>${+cap} max</b><button data-govdel="${i}" title="Remove override">×</button></span>`).join('')
         || '<span class="kmeta">no overrides — fully adaptive</span>'}</div>
@@ -2052,14 +2028,6 @@ function renderServer() {
         <button class="gbtn" id="gov-add">+ override</button>
       </div>
       <div class="serr" id="gov-err"></div>
-    </div>
-    <div class="card mb">
-      <h2>Pricing <button class="pbtn" id="save-pricing" style="margin-left:auto">Save</button></h2>
-      <div class="limgrid" style="margin-top:6px">
-        ${num('sv-pin', 'Reference $ / 1M in', sv.pricing.ref_price_in, '', '0.01')}
-        ${num('sv-pout', 'Reference $ / 1M out', sv.pricing.ref_price_out, '', '0.01')}
-      </div>
-      <div class="serr" id="pricing-err"></div>
     </div>
     <div class="card">
       <h2>History &amp; dashboard <button class="pbtn" id="save-history" style="margin-left:auto">Save</button></h2>
@@ -2117,15 +2085,6 @@ function renderServer() {
     if (!model || !(cap >= 1)) return note('gov-err', 'Give a model id and a cap ≥ 1.');
     try { await sPost('/api/settings/governor', { set_override: { model, cap } }); await loadSettings(); }
     catch (e) { note('gov-err', e.message); }
-  });
-  $('save-pricing').addEventListener('click', async () => {
-    const pin = +$('sv-pin').value, pout = +$('sv-pout').value;
-    if (!isFinite(pin) || !isFinite(pout)) return note('pricing-err', 'Prices need numeric values.');
-    try {
-      await sPost('/api/settings/pricing', { ref_price_in: pin, ref_price_out: pout });
-      await loadSettings();
-      note('pricing-err', 'Saved.', true);
-    } catch (e) { note('pricing-err', e.message); }
   });
   $('save-history').addEventListener('click', async () => {
     const defaultDays = Math.round(+$('sv-default-days').value);
@@ -2290,7 +2249,7 @@ function applyNowConfig(next) {
     version: next.version || '', started: +next.started || Date.now()/1000,
     lanes: +next.lanes || 0, rpms: next.rpms || [], rpm: Math.max(0, ...(next.rpms || [40])),
     capacity_rpm: +next.capacity_rpm || 0,
-    price_in: +next.price_in || 0, price_out: +next.price_out || 0, auth: !!next.auth,
+    auth: !!next.auth,
     default_window_days: +next.default_window_days || 30,
     retention_days: +next.retention_days || 0,
     slo_target_percent: +next.slo_target_percent || 99.9,

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -1008,15 +1008,15 @@ const ICONS = {
   bolt: '<path d="M9 1.5L3 9h4l-1 5.5L13 7H9z"/>',
   grid: '<path d="M2 8h5M2 4h9M2 12h7"/>',
 };
-function sparkSvg(pts, green, hero) {
+function sparkSvg(pts, hero) {
   if (!pts || pts.length < 2) return '';
   const W = 300, H = hero ? 58 : 44, vs = pts.map(p => p.v);
   const vmax = Math.max(1e-9, ...vs);
   const X = i => W * i / (vs.length - 1), Y = v => 4 + (H - 8) * (1 - Math.min(v, vmax) / vmax);
   const d = vs.map((v, i) => (i ? 'L' : 'M') + X(i).toFixed(1) + ',' + Y(v).toFixed(1)).join('');
   return `<svg class="kpispark" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none">` +
-    `<path d="${d}L${W},${H}L0,${H}Z" fill="url(#${green ? 'gGreen' : 'gMuted'})"/>` +
-    `<path d="${d}" fill="none" stroke="${green ? MED : '#8E967F'}" stroke-width="1.5"/></svg>`;
+    `<path d="${d}L${W},${H}L0,${H}Z" fill="url(#gMuted)"/>` +
+    `<path d="${d}" fill="none" stroke="#8E967F" stroke-width="1.5"/></svg>`;
 }
 /* trend chip: second half of the window vs the first half */
 function deltaChip(pts, downIsGood) {
@@ -1030,14 +1030,14 @@ function deltaChip(pts, downIsGood) {
   const good = downIsGood ? d <= 0 : d >= 0;
   return `<span class="chip ${good ? 'good' : 'bad'}" title="second half of this window vs the first">${d >= 0 ? '+' : ''}${Math.abs(d) >= 10 ? d.toFixed(0) : d.toFixed(1)}%</span>`;
 }
-/* k: {icon, label, value, sub, delta?, valColor?, pts?, green?} */
+/* k: {icon, label, value, sub, delta?, pts?} */
 function kpiCards(el, defs, hero) {
   el.innerHTML = defs.map(k =>
     `<div class="kpi${hero ? ' hero' : ''}">` +
     `<div class="kpihead"><span class="kpilabel"><svg viewBox="0 0 16 16">${ICONS[k.icon] || ''}</svg>${esc(k.label)}</span>${k.delta || ''}</div>` +
-    `<div class="kpival"${k.valColor ? ` style="color:${k.valColor}"` : ''}>${k.value}</div>` +
+    `<div class="kpival">${k.value}</div>` +
     `<div class="kpisub">${k.sub || ''}</div>` +
-    sparkSvg(k.pts, k.green, hero) + `</div>`).join('');
+    sparkSvg(k.pts, hero) + `</div>`).join('');
 }
 
 /* one metric-list row: label, right-aligned mono value, optional tone */

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -6,7 +6,7 @@
 //! The dispatcher is the only `Pool::reserve` caller in the app, and it holds
 //! the [`PoolHandle`] read lock across each reserve — so a settings-driven
 //! pool swap (which takes the write lock) can never interleave with a grant.
-//! Grants carry the `Arc<Pool>` that made them (see [`Slot`]) so bench and
+//! Grants carry the `Arc<Pool>` that made them (see [`Slot`]) so cooldown and
 //! release always land on the granting pool; a late op on a retired pool is
 //! benign because nothing consults it anymore.
 
@@ -26,7 +26,7 @@ use crate::pool::{Pool, PoolHandle, Reservation};
 const GRANT_GAP: Duration = Duration::from_millis(25);
 
 /// A granted reservation: the key to send with, and the pool that granted it
-/// so follow-up bench/release ops route to the right generation.
+/// so follow-up cooldown/release ops route to the right generation.
 pub struct Slot {
     pub pool: Arc<Pool>,
     pub lane: usize,

--- a/src/governor.rs
+++ b/src/governor.rs
@@ -5,7 +5,7 @@
 //! orthogonal to the per-key RPM limit ("ResourceExhausted: Worker local
 //! total request limit reached (32/32)"). It is **model-scoped and shared
 //! across all keys**, so failing over to another key can't help — the old
-//! behavior of benching the lane just burned healthy key capacity. Instead,
+//! behavior of cooling down the lane just burned healthy key capacity. Instead,
 //! worker exhaustion backs off the *model*:
 //!
 //! - Every model starts ungoverned (no cap, zero config).
@@ -30,7 +30,7 @@ use metrics::{counter, gauge};
 /// How often a waiter re-checks for a free permit.
 pub const POLL: Duration = Duration::from_millis(250);
 /// Post-exhaustion pause on the model: workers free up as generations
-/// finish, so short — this is a drain gap, not a lane-style bench.
+/// finish, so short — this is a drain gap, not a lane-style cooldown.
 const EXHAUST_BACKOFF: Duration = Duration::from_secs(2);
 /// Additive increase: +1 concurrency per stable minute.
 const GROW_INTERVAL: Duration = Duration::from_secs(60);
@@ -39,7 +39,7 @@ const DISSOLVE_AFTER: Duration = Duration::from_secs(30 * 60);
 
 /// The worker-exhaustion signature in an upstream error body. Must be
 /// checked *before* generic retry handling: this failure is model-scoped,
-/// never a reason to bench the lane that carried it.
+/// never a reason to cool down the lane that carried it.
 pub fn is_worker_exhausted(body: &str) -> bool {
     body.contains("Worker local total request limit")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,6 @@ pub struct Config {
     pub request_timeout: Duration,
     /// Never modify request bodies (disables stream_options usage injection).
     pub strict_passthrough: bool,
-    /// Reference $/1M token prices for the dashboard's "dollars saved" figure.
-    pub price_in: f64,
-    pub price_out: f64,
     /// token -> client name. None = local mode, no client auth.
     pub clients: Option<HashMap<String, String>>,
     /// Cap on concurrent requests; bounds memory under floods.
@@ -256,8 +253,6 @@ async fn api_dashboard_now(State(state): State<Arc<AppState>>) -> axum::Json<ser
         "version": env!("CARGO_PKG_VERSION"),
         "sampled_at": now,
         "started": state.started,
-        "price_in": stored.pricing.ref_price_in,
-        "price_out": stored.pricing.ref_price_out,
         "auth": stored.client_auth.mode == config::Mode::Keyed,
         "lanes": pool.len(),
         "rpms": pool.rpms(),
@@ -524,7 +519,6 @@ pub async fn run() {
         .route("/api/settings/clients", post(settings::clients))
         .route("/api/settings/upstream", post(settings::upstream))
         .route("/api/settings/limits", post(settings::limits))
-        .route("/api/settings/pricing", post(settings::pricing))
         .route("/api/settings/history", post(settings::history))
         .route("/api/settings/governor", post(settings::governor_cfg))
         .route("/api/settings/users", post(settings::users))

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -47,7 +47,7 @@ struct Lane {
     rpm: usize,
     /// Timestamps of requests sent within the last WINDOW.
     sent: Mutex<VecDeque<Instant>>,
-    /// Lane is benched until this instant (set after an upstream 429/5xx).
+    /// Lane is in cooldown until this instant (set after an upstream 429/5xx).
     cooldown_until: Mutex<Instant>,
 }
 
@@ -244,7 +244,7 @@ impl Pool {
         }
     }
 
-    /// Bench a lane after the upstream told us to back off.
+    /// Put a lane in cooldown after the upstream told us to back off.
     pub fn penalize(&self, lane: usize, backoff: Duration) {
         let until = Instant::now() + backoff;
         let mut cd = self.lanes[lane].cooldown_until.lock().unwrap();
@@ -403,7 +403,11 @@ mod tests {
         let pool = Pool::new(keys(2, 10));
         pool.penalize(0, Duration::from_secs(30));
         let rebuilt = pool.rebuild(keys(2, 10));
-        assert_eq!(take(&rebuilt, Some(0)), 1, "benched lane stays benched");
+        assert_eq!(
+            take(&rebuilt, Some(0)),
+            1,
+            "lane in cooldown stays in cooldown"
+        );
     }
 
     #[test]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -123,7 +123,7 @@ fn retryable(status: reqwest::StatusCode) -> bool {
     matches!(status.as_u16(), 429 | 500 | 502 | 503 | 504)
 }
 
-/// Backoff for a benched lane: honor Retry-After when present.
+/// Backoff for a lane in cooldown: honor Retry-After when present.
 fn backoff_for(resp: &reqwest::Response) -> Duration {
     resp.headers()
         .get(header::RETRY_AFTER)
@@ -204,11 +204,12 @@ async fn acquire_model_permit(
     }
 }
 
-/// Bench the granting lane after the upstream told us to back off. Routes
-/// through the slot's own pool, so a bench that races a settings-driven pool
-/// swap lands on the (possibly retired) generation that made the grant.
-fn bench(slot: &Slot, status: &str, backoff: Duration) {
-    counter!("nimproxy_lane_benched_total", "lane" => slot.lane.to_string(), "status" => status.to_owned())
+/// Put the granting lane in cooldown after the upstream told us to back
+/// off. Routes through the slot's own pool, so a cooldown that races a
+/// settings-driven pool swap lands on the (possibly retired) generation that
+/// made the grant.
+fn enter_cooldown(slot: &Slot, status: &str, backoff: Duration) {
+    counter!("nimproxy_lane_cooldown_total", "lane" => slot.lane.to_string(), "status" => status.to_owned())
         .increment(1);
     slot.pool.penalize(slot.lane, backoff);
 }
@@ -734,7 +735,7 @@ async fn buffered(
             Ok(r) => r,
             Err(e) => {
                 tracing::warn!(lane = slot.lane, error = %e, "upstream connection error, retrying");
-                bench(&slot, "connect", Duration::from_secs(5));
+                enter_cooldown(&slot, "connect", Duration::from_secs(5));
                 continue;
             }
         };
@@ -742,7 +743,7 @@ async fn buffered(
             let status = resp.status();
             let backoff = backoff_for(&resp);
             // Sniff the error body: worker exhaustion is model-scoped (shared
-            // across every key), so benching the lane would just burn healthy
+            // across every key), so cooling down the lane would just burn healthy
             // key capacity on a failover that cannot help.
             let detail = resp.text().await.unwrap_or_default();
             if governor::is_worker_exhausted(&detail) {
@@ -751,8 +752,8 @@ async fn buffered(
                     .note_exhausted(&ctx.model, cfg.governor.overrides.get(&ctx.model).copied());
                 continue; // permit drops here; re-admission waits out the drain
             }
-            tracing::info!(lane = slot.lane, %status, ?backoff, "lane benched, retrying");
-            bench(&slot, status.as_str(), backoff);
+            tracing::info!(lane = slot.lane, %status, ?backoff, "lane in cooldown, retrying");
+            enter_cooldown(&slot, status.as_str(), backoff);
             continue;
         }
         histogram!("nimproxy_upstream_seconds", "model" => ctx.model.clone())
@@ -851,7 +852,7 @@ fn streaming(
                     Ok(r) => r,
                     Err(e) => {
                         tracing::warn!(lane = slot.lane, error = %e, "upstream connection error, retrying");
-                        bench(&slot, "connect", Duration::from_secs(5));
+                        enter_cooldown(&slot, "connect", Duration::from_secs(5));
                         continue;
                     }
                 };
@@ -884,8 +885,8 @@ fn streaming(
                             cfg.governor.overrides.get(&ctx.model).copied(),
                         );
                     } else {
-                        tracing::info!(lane = slot.lane, %status, ?backoff, "lane benched, retrying");
-                        bench(&slot, status.as_str(), backoff);
+                        tracing::info!(lane = slot.lane, %status, ?backoff, "lane in cooldown, retrying");
+                        enter_cooldown(&slot, status.as_str(), backoff);
                     }
                     if !send(": retrying\n\n").await {
                         record_request(&ctx, "disconnect");
@@ -1042,7 +1043,7 @@ async fn models(state: Arc<AppState>, cfg: Arc<Config>) -> Response {
         }
         Ok(resp) => {
             if retryable(resp.status()) {
-                bench(&slot, resp.status().as_str(), backoff_for(&resp));
+                enter_cooldown(&slot, resp.status().as_str(), backoff_for(&resp));
             }
             let status =
                 StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -386,7 +386,6 @@ pub async fn api_config(
         body["server"] = serde_json::json!({
             "base_url": sc.upstream.base_url,
             "limits": sc.limits,
-            "pricing": sc.pricing,
             "history": {
                 "days": sc.history.days,
                 "available_from": history.available_from,
@@ -647,21 +646,6 @@ admin_section!(
             max_inflight: req.max_inflight,
             strict_passthrough: req.strict_passthrough,
         };
-    }
-);
-
-#[derive(Deserialize)]
-pub struct PricingReq {
-    ref_price_in: f64,
-    ref_price_out: f64,
-}
-
-admin_section!(
-    pricing,
-    PricingReq,
-    |cand: &mut StoredConfig, req: PricingReq| {
-        cand.pricing.ref_price_in = req.ref_price_in;
-        cand.pricing.ref_price_out = req.ref_price_out;
     }
 );
 

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1047,9 +1047,9 @@ async fn overloaded_requests_are_shed_with_503() {
 }
 
 /// An unreachable upstream exercises the connection-error arm: the lane is
-/// benched with status "connect" and the request fails fast at the deadline.
+/// put in cooldown with status "connect" and the request fails fast at the deadline.
 #[tokio::test]
-async fn upstream_connection_error_is_benched() {
+async fn upstream_connection_error_enters_cooldown() {
     // Nothing listens on port 1 → every connect attempt fails.
     let proxy = start_proxy_with(
         "http://127.0.0.1:1",
@@ -1071,8 +1071,8 @@ async fn upstream_connection_error_is_benched() {
 
     let metrics = metrics(&proxy).await;
     assert!(
-        metrics.contains(r#"nimproxy_lane_benched_total{lane="0",status="connect"}"#),
-        "connection error benched the lane: {metrics}"
+        metrics.contains(r#"nimproxy_lane_cooldown_total{lane="0",status="connect"}"#),
+        "connection error put the lane in cooldown: {metrics}"
     );
 }
 
@@ -2181,10 +2181,10 @@ async fn worker_exhaustion_governs_the_model_and_spares_the_lane() {
     assert_eq!(v["choices"][0]["message"]["content"], "hello world");
     assert_eq!(mock.state.hit_count(), 2, "one exhausted try, one success");
     // The retry waited out the governor's ~2s drain gap, not the 10s default
-    // lane bench a plain 429-without-Retry-After would have earned.
+    // lane cooldown a plain 429-without-Retry-After would have earned.
     assert!(
         started.elapsed() < Duration::from_secs(8),
-        "retry took {:?} — looks like a lane bench, not a model drain gap",
+        "retry took {:?} — looks like a lane cooldown, not a model drain gap",
         started.elapsed()
     );
 
@@ -2194,8 +2194,8 @@ async fn worker_exhaustion_governs_the_model_and_spares_the_lane() {
         "exhaustion counted: {metrics}"
     );
     assert!(
-        !metrics.contains("nimproxy_lane_benched_total"),
-        "worker exhaustion must never bench a lane: {metrics}"
+        !metrics.contains("nimproxy_lane_cooldown_total"),
+        "worker exhaustion must never cool down a lane: {metrics}"
     );
     assert!(
         metrics.contains(r#"nimproxy_model_limit{model="mock/model-a"} 1"#),
@@ -2231,8 +2231,8 @@ async fn worker_exhaustion_streaming_retries_inside_the_stream() {
         "exhaustion counted: {metrics}"
     );
     assert!(
-        !metrics.contains("nimproxy_lane_benched_total"),
-        "worker exhaustion must never bench a lane: {metrics}"
+        !metrics.contains("nimproxy_lane_cooldown_total"),
+        "worker exhaustion must never cool down a lane: {metrics}"
     );
 }
 
@@ -2339,10 +2339,6 @@ async fn user_role_is_denied_server_settings_and_foreign_keys() {
                 "stream_idle_secs": 300, "request_timeout_secs": 300,
                 "max_inflight": 512, "strict_passthrough": false
             }),
-        ),
-        (
-            "/api/settings/pricing",
-            serde_json::json!({"ref_price_in": 1.0, "ref_price_out": 2.0}),
         ),
         (
             "/api/settings/governor",
@@ -2968,22 +2964,14 @@ async fn governor_settings_reflect_and_persist() {
     );
 }
 
-/// Pricing and dashboard history settings save through the same pipeline and
-/// reflect in /api/config; invalid candidates leave every value unchanged.
+/// Dashboard history settings save through the shared pipeline and reflect in
+/// /api/config; invalid candidates leave every value unchanged.
 #[tokio::test]
-async fn pricing_and_history_settings_reflect_in_api_config() {
+async fn history_settings_reflect_in_api_config() {
     let mock = start_mock().await;
     let proxy = start_proxy(&mock.url, &[]).await;
     let root = support::login(&proxy).await;
 
-    let (status, v) = post_json(
-        &proxy,
-        &root,
-        "/api/settings/pricing",
-        serde_json::json!({"ref_price_in": 1.25, "ref_price_out": 3.5}),
-    )
-    .await;
-    assert_eq!(status, 200, "{v}");
     let (status, v) = post_json(
         &proxy,
         &root,
@@ -2998,8 +2986,6 @@ async fn pricing_and_history_settings_reflect_in_api_config() {
     assert_eq!(status, 200, "{v}");
 
     let cfg = api_config(&proxy, &root).await;
-    assert_eq!(cfg["server"]["pricing"]["ref_price_in"], 1.25);
-    assert_eq!(cfg["server"]["pricing"]["ref_price_out"], 3.5);
     assert_eq!(cfg["server"]["history"]["days"], 45);
     assert_eq!(cfg["server"]["dashboard"]["default_window_days"], 30);
     assert_eq!(cfg["server"]["dashboard"]["slo_target_percent"], 99.5);
@@ -3020,15 +3006,6 @@ async fn pricing_and_history_settings_reflect_in_api_config() {
     assert_eq!(cfg["server"]["history"]["days"], 45);
     assert_eq!(cfg["server"]["dashboard"]["default_window_days"], 30);
     assert_eq!(cfg["server"]["dashboard"]["slo_target_percent"], 99.5);
-
-    let (status, v) = post_json(
-        &proxy,
-        &root,
-        "/api/settings/pricing",
-        serde_json::json!({"ref_price_in": -1.0, "ref_price_out": 3.5}),
-    )
-    .await;
-    assert_eq!(status, 400, "negative prices must be refused: {v}");
 }
 
 /// The limits endpoint enforces the shared rulebook (heartbeat < max_wait)

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -23,7 +23,7 @@ pub enum Behavior {
     /// 429 with this Retry-After (seconds).
     RateLimited(u64),
     /// 429 carrying NIM's worker-exhaustion signature — model-scoped, so the
-    /// proxy must back off the model (governor), never bench the lane.
+    /// proxy must back off the model (governor), never cool down the lane.
     WorkerExhausted,
     /// A retryable server error.
     ServerError(u16),


### PR DESCRIPTION
## Summary

Two removals in one pass, both shrinking the surface before the rest of 0.6.6 touches it. The post-backoff lane state is renamed from the `bench` idiom to **cooldown**, which the `cooldown_until` field already used. The estimated-savings metric and everything feeding it — pricing config, the settings card, and `/api/settings/pricing` — is deleted rather than fixed. Nothing here adds capability.

PR 1 of 7 toward 0.6.6. Targets `release/v0.6.6`, not `main`.

## Type of change

- [x] New feature / behavior change — two deliberate breaking removals
- [x] Refactor (no behavior change) — the rename half
- [x] Docs / knowledge base only — two new decision pages
- [ ] ~~Bug fix~~ — nothing was broken; this is vocabulary and honesty
- [ ] ~~Performance / rate-limiting~~ — untouched, see below
- [ ] ~~Security / hardening~~ — no auth, sanitizing, or CSP change
- [ ] ~~CI / build / release infrastructure~~
- [ ] ~~Release (version bump)~~ — the version bumps in the release commit

## Related issues

Relates to #69. Does not close it — that closes with the release.

## What & why

**`bench` → `cooldown`.** A sports idiom with no standard equivalent in load-balancing vocabulary. It had to be explained rather than recognized, and it would have forced every translation later in this release to invent a term. The codebase already disagreed with itself: the field holding the deadline was `cooldown_until` while the prose, the metric, and the helper all said "bench". Alternatives weighed and rejected — `ejection` (Envoy's, but implies removal from the pool rather than a timed pause), `circuit break` (implies half-open/closed machinery this doesn't have), `quarantine` (alarming for a routine 429). Recorded in [`lane-cooldown-naming`](knowledge/decisions/lane-cooldown-naming.md).

**Estimated savings removed.** An honest "saved" figure is the difference against what *the same model* would have cost elsewhere, which needs a published per-model rate for every model in the pool. Instead one reference pair was applied to every model, so a small-model run and a large-model run contributed identically. The number moved with traffic volume and rendered to two decimal places with a currency symbol while measuring nothing. Fixing it properly means maintaining a rate table against someone else's pricing page — that's a product, and nobody asked for it. Recorded in [`no-estimated-savings-metric`](knowledge/decisions/no-estimated-savings-metric.md).

Deleting the currency also removes the `Intl.NumberFormat` currency question (whose locale? which currency?) from the migration later in this release, rather than answering it.

**On the history gap.** `history.jsonl` persists metric names verbatim, so the renamed series leaves pre-upgrade points under the old key. A read-time alias in `history.rs` would close that, and was rejected: it is a permanent compatibility shim carried forever to smooth a one-time, bounded, self-healing gap in a homelab tool. That's the kind of prototype-phase residue this release exists to remove. The gap is documented in the CHANGELOG rather than hidden.

## How it was tested

```sh
$ cargo fmt --check          # clean
$ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile [optimized + debuginfo] target(s)   # zero warnings

$ cargo test
test result: ok. 120 passed; 0 failed    # unit (was 119; +1 new regression test)
test result: ok.  90 passed; 0 failed    # e2e

# acceptance
$ grep -rn -i bench src/ tests/ knowledge/ README.md | grep -vi benchmark
# 15 hits, all in the new decision page / log / index describing the rename itself

$ grep -o 'esc(' src/dashboard.html | wc -l     # 48 — unchanged
$ grep -c 'innerHTML *=' src/dashboard.html     # 45 — unchanged
```

The `benchmark*` occurrences in `knowledge/` and `README.md` are a different word (request-shape metrics for benchmarking agents) and were deliberately left alone. `CHANGELOG.md` history keeps the old word — it describes what shipped at the time.

**Load harness not run, deliberately.** Nothing here touches pacing, the pool's limiter, the dispatcher, or the governor. The only edits in those files are comments and doc strings.

## Screenshots / output

N/A — no browser review in this PR. The visible changes are removals (a KPI tile, three table columns, a settings card) and two metric row labels; the label pass with its browser review is PR 2.

## Breaking changes & migration

Two, both operator-visible:

1. **`nimproxy_lane_benched_total` → `nimproxy_lane_cooldown_total`.** Update any dashboards, alerts, or recording rules referencing the old name. All other `nimproxy_*` series are unchanged. Retained history keeps the old name, so lane-cooldown charts gap for pre-upgrade points and recover one retention window (`history_days`) after upgrading.

2. **Pricing is gone.** `POST /api/settings/pricing` now 404s; `/api/config` no longer returns `server.pricing`; `/api/dashboard` no longer returns `price_in`/`price_out`.

**No migration needed.** `StoredConfig` has no `deny_unknown_fields`, so a `pricing` block written by 0.6.5 or earlier loads and is ignored. Nothing rewrites the store until the next settings save. Covered by `config_with_a_legacy_pricing_block_still_loads`. `REF_PRICE_IN`/`REF_PRICE_OUT` stay in the legacy-env warning list so an upgrader who still sets them gets told they do nothing.

## Checklist

### Code quality
- [x] `cargo fmt --check` is clean.
- [x] `cargo clippy --all-targets -- -D warnings` is clean (zero warnings).
- [x] `cargo test` passes locally (unit + end-to-end).
- [x] New behavior ships with tests; existing guard tests still pass. The combined `pricing_and_history_settings_reflect_in_api_config` was edited down to `history_settings_reflect_in_api_config` rather than deleted, so history coverage is preserved.
- [x] Scope is tight; commit message explains the *why*.

### Docs & knowledge base
- [x] README updated — the metrics table carries the new series name.
- [x] Affected `knowledge/` pages updated in this PR: `architecture/key-pool.md`, `architecture/governor.md`, `architecture/streaming-pipeline.md`, `architecture/dashboard.md`, `ops/configure-env.md`, `index.md`.
- [x] New decisions → `decisions/lane-cooldown-naming.md` and `decisions/no-estimated-savings-metric.md`, both in ADR shape, both with `index.md` rows.
- [x] Dated entry appended to `knowledge/log.md`, including a lint note: `key-pool.md` and `governor.md` described "benching" while `pool.rs` already named the field `cooldown_until`. The pages and the code now agree.
- [x] `CHANGELOG.md` `[Unreleased]` updated with both breaking changes.

### Security
- [x] Fail-closed posture preserved — no auth, session, or store-version logic touched.
- [x] Every dynamic value written to `innerHTML` still goes through `esc()`; count and position unchanged at 48. No `innerHTML` → `textContent` conversions. Label sanitizing in `proxy.rs` untouched.
- [x] Reviewed against the auth-posture and input-sanitizing decision pages. `settings.rs` and `config.rs` changes are pure deletions of the pricing section; the `admin_section!` gate on every remaining route is unchanged.

### Rate-limiting
- [ ] ~~Load harness~~ — not applicable. No change to pacing, the key pool's limiter, the dispatcher, affinity, or the governor; edits in those files are comments and doc strings only.

### Workflows & supply chain
- [ ] ~~Actions pinning / actionlint / zizmor~~ — no workflow files touched.
- [ ] ~~Release runbook~~ — the version bump happens in the release commit, not here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVr7XeojzNNHRKTkSMCccL)_