### PR TITLE
Standard ops vocabulary across the dashboard and setup wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Dashboard and setup-wizard labels now use standard ops-dashboard vocabulary
+  throughout. `Harness`/`Harnesses` become **Client**/**Clients**; the
+  dashboard's `window` becomes **time range** (the rate-limit rolling window
+  keeps "window"); `lane` becomes **key** in the interface, since a lane is one
+  NIM credential and Settings already said "keys". `Conversation stickiness` →
+  **Session affinity**, `Model-pressure governor` → **Model limits**,
+  `Where time goes` → **Latency breakdown**, `Rate-limit pressure` →
+  **Throttling**, `Historical provisioning` → **Capacity history**, `Keyed` →
+  **API key required**. The composite `Shed · 401 · failed logins` row splits
+  into **Dropped**, **Unauthorized**, and **Failed logins**.
+
+  Display text only — no metric, route, CSS class, `data-*` attribute, or DOM
+  id changed. Metric labels keep `lane` (`nimproxy_lane_requests_total`), so
+  the interface says "key" while the exposition still says "lane"; renaming
+  the series would be a second breaking change and was not taken.
+
 - **Breaking:** the lane state entered after an upstream 429/5xx is now called
   **cooldown** rather than "bench", and the Prometheus series
   `nimproxy_lane_benched_total` is renamed to `nimproxy_lane_cooldown_total`.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ tab. The default view follows now across the configured default time range
 instead of opening on an empty recent slice. The same global selection follows
 you through Overview, Models, Clients, Reliability, and Capacity. Presets
 include 1h/6h/24h/7d/30d and **All time**; a custom range or the pause
-control freezes the analytical window while current operational values marked
+control freezes the analytical time range while current operational values marked
 **Now** keep refreshing. Exact totals do not depend on chart point density.
 
 The default time range and data retention are separate Server settings. Both

--- a/README.md
+++ b/README.md
@@ -141,26 +141,26 @@ burns — all from counts and sizes, never message content.
 
 Five persona-aligned tabs, each ordered at-a-glance → trends → detail:
 
-- **Overview** — the one-screen landing: capacity and success-rate ring gauges, request and token sparklines, a health strip, and top models & harnesses.
+- **Overview** — the one-screen landing: capacity and success-rate ring gauges, request and token sparklines, a health strip, and top models & clients.
 - **Models** — ranked model cards, TTFT / generation-speed / inter-token-latency / upstream-latency charts, tokens-per-minute, tool-call volume, truncation and reasoning-share breakdowns, and a head-to-head scorecard.
-- **Clients** — what each agent is *doing*: tool intensity, conversation depth, sampling fingerprint, requested output budget, streaming-vs-buffered mix, and a per-harness leaderboard.
-- **Reliability** — availability against the configured SLO (99.9% by default) with an error budget, requests-by-outcome over time, where time goes (queue / first token / generation), an error taxonomy, an hour-of-day heatmap, and a model-pressure card when the governor engages.
-- **Capacity** — a **Now** saturation bar, historical utilization against the capacity configured at each sample, an exact peak-RPM shortfall, per-lane utilization meters, and 429s-per-minute by lane.
+- **Clients** — what each agent is *doing*: tool intensity, conversation depth, sampling fingerprint, requested output budget, streaming-vs-buffered mix, and a per-client leaderboard.
+- **Reliability** — availability against the configured SLO (99.9% by default) with an error budget, requests-by-outcome over time, a latency breakdown (queue / first token / generation), an error taxonomy, an hour-of-day heatmap, and a model-limits card when the governor engages.
+- **Capacity** — a **Now** saturation bar, historical utilization against the capacity configured at each sample, an exact peak-RPM shortfall, per-key utilization meters, and 429s-per-minute by key.
 
 <div align="center"><img src="docs/assets/dashboard-reliability.png" alt="Reliability tab" width="850"></div>
 
 Every line chart has a hover crosshair with a per-series tooltip; every table is click-to-sort and survives the 3-second live refresh.
 
 **Time ranges & history.** Persisted server history drives every analytical
-tab. The default view follows now across the configured dashboard window
+tab. The default view follows now across the configured default time range
 (30 days by default), so a new server grows naturally from its first sample
 instead of opening on an empty recent slice. The same global selection follows
 you through Overview, Models, Clients, Reliability, and Capacity. Presets
-include 1h/6h/24h/7d/30d and **All retained**; a custom range or the pause
+include 1h/6h/24h/7d/30d and **All time**; a custom range or the pause
 control freezes the analytical window while current operational values marked
 **Now** keep refreshing. Exact totals do not depend on chart point density.
 
-The dashboard window and data retention are separate Server settings. Both
+The default time range and data retention are separate Server settings. Both
 default to 30 days; retention may be longer than the default view, and `0`
 means unlimited. A finite retention window cannot be shorter than the default
 view. Real history size depends on metric and label cardinality—the old
@@ -169,8 +169,8 @@ your workload.
 
 **Settings.** Everything app-level is managed here: NIM keys (per-key rpm,
 enable/disable), client API keys, the open/keyed API mode, upstream URL,
-limits, default dashboard window, history retention, availability SLO, the
-model-pressure governor, and users. Saves validate, persist, and apply
+limits, default time range, history retention, availability SLO, model
+limits, and users. Saves validate, persist, and apply
 live. The config file itself is read at boot; an out-of-band edit to
 `DATA_DIR/config.json` requires a restart.
 
@@ -209,9 +209,8 @@ not an environment variable consumed by nim-proxy.
 Everything else is a Settings control: NIM keys (per-key rpm, enable/disable,
 ownership), the upstream base URL, client API keys and the open/keyed API
 mode, limits (`max_wait`, `heartbeat`, `stream_idle`, `request_timeout`,
-`models_ttl`, `max_inflight`, `strict_passthrough`), default dashboard
-window, history retention, availability SLO, the model-pressure governor, and
-users & roles.
+`models_ttl`, `max_inflight`, `strict_passthrough`), default time range,
+history retention, availability SLO, model limits, and users & roles.
 
 ## Security & deployment
 

--- a/knowledge/architecture/dashboard.md
+++ b/knowledge/architecture/dashboard.md
@@ -18,7 +18,7 @@ custom date-range picker, and five persona-aligned tabs, each ordered
 
 - **Overview** (landing, balanced) — KPI cards + threshold ring gauges,
   request and token sparklines, a health strip, a p50/p95 performance
-  band, top models & harnesses.
+  band, top models & clients.
 - **Models** (benchmarker) — KPI cards, tokens/min-by-model chart, a
   TTFT/tok-s/TPOT/upstream quantile quad, a "how responses end" breakdown,
   reasoning-vs-output share, a head-to-head scorecard with best-in-column
@@ -34,8 +34,8 @@ custom date-range picker, and five persona-aligned tabs, each ordered
   breakdown, a reliability & security panel, a request-types panel, per-client
   table.
 - **Capacity** (capacity planner, was **Keys**) — a hero row (saturation,
-  provisioning, rate-limit pressure), lane utilization meters, 429s/min by
-  lane, per-lane table.
+  capacity history, throttling), key utilization meters, 429s/min by key,
+  per-key table.
 
 The tabs are **identical for every role** — all authenticated users see the
 same observability, the deliberate shared-pool-among-friends model. v0.6.0 adds
@@ -48,11 +48,11 @@ see [client-auth](client-auth.md) and
 `inflight vs limit` rows) that appears only once the
 [governor](governor.md) has engaged.
 
-Every analytical tab shares one selected history window. **Default · Nd**
+Every analytical tab shares one selected time range. **Default · Nd**
 (30d by default) follows now using the configured default, relative presets
-follow now over their duration, and **All retained** follows the server's
+follow now over their duration, and **All time** follows the server's
 current retained boundary. Custom ranges are fixed. Clicking the sidebar
-follow control freezes the currently rendered window; clicking again resumes
+follow control freezes the currently rendered range; clicking again resumes
 its preset. Settings hides the range controller because it is
 configuration-driven rather than an analytical view.
 
@@ -97,9 +97,9 @@ size to a real `clientWidth` when their tab is switched to):
 
 Colors follow the entity, not the chart: models take their publisher's brand
 color from the `PUBLISHERS` map (extended with StepFun and a Moonshot teal);
-known harnesses (`claude-code`, `aider`, `opencode`, `cline`, `continue`,
+known clients (`claude-code`, `aider`, `opencode`, `cline`, `continue`,
 `cursor`, `roo-code`, `zed`, `codex`, `n8n`) take a fixed client-color map;
-anything else — and lane colors, which use six fixed slot colors — falls
+anything else — and key colors, which use six fixed slot colors — falls
 back to a stable hash-to-hue (`hueFor`). The old first-six-slots categorical
 allocator (`modelSlots`/`slotFor`) is gone; there's no "ran out of colors"
 case left to handle.
@@ -157,10 +157,10 @@ recomputed.
 **Notable derivations, worth recording so they aren't rediscovered:**
 
 - **Delta chips** (the `+8.2%`-style pill on every KPI card) compare the
-  second half of the visible window's average against the first half — an
+  second half of the visible range's average against the first half — an
   honest trend computable from the selected sample buffer, with no extra
   history fetch. Hidden below 4 samples.
-- **"Where time goes"** (Reliability hero) splits average end-to-end time
+- **"Latency breakdown"** (Reliability hero) splits average end-to-end time
   into queue wait, first token, and generation, where **generation = avg
   `upstream_seconds` − avg `nimproxy_ttft_seconds`** — verified against
   `proxy.rs`: `upstream_seconds` spans send→stream-end, `ttft` spans
@@ -170,10 +170,10 @@ recomputed.
   `dashboard.slo_target_percent` from the current server config (99.9% by
   default). HTTP 4xx and disconnect outcomes stay visible in outcome/error
   views but do not consume the service-availability error budget. Capacity
-  history uses the contemporaneous value stored with each v2 sample; legacy
-  intervals explicitly show capacity unavailable. Active load, lane count,
-  current RPM, and utilization are labeled **Now**; selected-window lane
-  request and cooldown counts remain historical.
+  history uses the capacity-at-the-time value stored with each v2 sample;
+  intervals without it explicitly show no capacity data. Active load, key
+  count, current RPM, and utilization are labeled **Now**; selected-range
+  key request and cooldown counts remain historical.
 
 Following history survives refresh and process restart because it is rebuilt
 from the server index; only the adjacent-poll rate shown in **Now** widgets

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,32 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-29] ingest — standard vocabulary across the interface
+
+Second change of the 0.6.6 rationalization. Applied the agreed standard
+ops-dashboard vocabulary to `src/dashboard.html` and `src/setup.html`:
+`Harness` → `Client`, dashboard `window` → `time range`, `lane` → `key`,
+`Conversation stickiness` → `Session affinity`, `Model-pressure governor` →
+`Model limits`, `Where time goes` → `Latency breakdown`, `Rate-limit
+pressure` → `Throttling`, `Keyed` → `API key required`, and the composite
+`Shed · 401 · failed logins` row split into three.
+
+Display strings only. Every identifier held: DOM ids, CSS classes, `data-*`
+attributes, metric names, and the `sortTable` state keys — where `harness`
+and `clients` both exist, so renaming that argument would have silently made
+the two tables share sort state.
+
+- Lint: the interface now says **key** while the Prometheus exposition still
+  says `lane` (`nimproxy_lane_requests_total`, and the `lane` label on
+  `nimproxy_lane_cooldown_total`). That divergence is deliberate — renaming a
+  second series would be another breaking change, and 0.6.6 already carries
+  one. `README.md`'s architecture section still says "lane" for the same
+  reason: it describes the code, which has not been renamed.
+- `knowledge/architecture/dashboard.md`, `ops/configure-env.md`, and the
+  README dashboard-tour section were updated to name the new labels; the
+  `agent harness` prose describing what OpenCode/Codex *are* was deliberately
+  left alone.
+
 ## [2026-07-29] decision — lane cooldown naming, savings metric removed
 
 First change of the 0.6.6 presentation-layer rationalization.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -31,6 +31,15 @@ the two tables share sort state.
   README dashboard-tour section were updated to name the new labels; the
   `agent harness` prose describing what OpenCode/Codex *are* was deliberately
   left alone.
+- Adversarial review caught the one dangerous rename: the Access &amp; keys chip
+  reads `${k.in_window} / ${k.rpm}`, which is the **rate-limit** rolling
+  window, and a blanket `window` → `time range` pass had turned it into
+  "in range". That is the single place the two meanings had to stay apart, and
+  it is also factually wrong — reverted. Review also found five dashboard
+  `window` strings the pass missed (so two empty-state vocabularies were
+  visible at once), a `Per lane` heading left sitting above a `Key` table, a
+  `lane N` chip beside `Slot N`, `Peak shortfall` rendering without its rpm
+  unit, and a dead `sul` binding orphaned by the composite-row split.
 
 ## [2026-07-29] decision — lane cooldown naming, savings metric removed
 

--- a/knowledge/ops/configure-env.md
+++ b/knowledge/ops/configure-env.md
@@ -43,7 +43,7 @@ NIM keys (per-key rpm, enable/disable, ownership), the upstream base URL,
 client API keys and the open/keyed API mode, limits (max_wait, heartbeat,
 stream_idle, request_timeout, models_ttl, max_inflight, strict_passthrough),
 the default dashboard window, history retention days, the
-availability SLO, the model-pressure governor, and users/roles all live in the
+availability SLO, the model limits, and users/roles all live in the
 store and are edited from the dashboard. A Settings save validates the
 complete candidate, writes `config.json` atomically, and swaps the live
 configuration; no restart is needed.

--- a/knowledge/ops/configure-env.md
+++ b/knowledge/ops/configure-env.md
@@ -42,7 +42,7 @@ the contract.)
 NIM keys (per-key rpm, enable/disable, ownership), the upstream base URL,
 client API keys and the open/keyed API mode, limits (max_wait, heartbeat,
 stream_idle, request_timeout, models_ttl, max_inflight, strict_passthrough),
-the default dashboard window, history retention days, the
+the default time range, history retention days, the
 availability SLO, the model limits, and users/roles all live in the
 store and are edited from the dashboard. A Settings save validates the
 complete candidate, writes `config.json` atomically, and swaps the live

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -323,7 +323,7 @@ body.on-settings .tright, body.on-settings #custom { display: none; }
     <button role="tab" data-tab="settings" aria-selected="false"><span class="nbar"></span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.4"/><path d="M8 1.6v2.1M8 12.3v2.1M1.6 8h2.1M12.3 8h2.1M3.5 3.5L5 5M11 11l1.5 1.5M12.5 3.5L11 5M5 11l-1.5 1.5"/></svg><span class="label">Settings</span></button>
   </nav>
   <div class="foot">
-    <button class="live" id="live" title="Click to freeze/resume the selected window"><span class="dot"></span><span id="liveText">connecting</span></button>
+    <button class="live" id="live" title="Click to freeze/resume the selected time range"><span class="dot"></span><span id="liveText">connecting</span></button>
     <span id="uptime"></span>
     <span id="verinfo"></span>
   </div>
@@ -341,7 +341,7 @@ body.on-settings .tright, body.on-settings #custom { display: none; }
         <button data-range="86400">24h</button>
         <button data-range="604800">7d</button>
         <button data-range="2592000">30d</button>
-        <button data-range="all-retained">All retained</button>
+        <button data-range="all-retained">All time</button>
         <button data-range="custom"><svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke-width="1.5"><rect x="2" y="3" width="12" height="11" rx="2"/><path d="M2 6.5h12M5.5 1.5v3M10.5 1.5v3" stroke-linecap="round"/></svg>Custom</button>
       </div>
     </div>
@@ -381,7 +381,7 @@ body.on-settings .tright, body.on-settings #custom { display: none; }
         <div id="o-topmodels"></div>
       </div>
       <div class="card">
-        <h2><svg class="hic" viewBox="0 0 16 16"><path d="M4 5l-2.5 3L4 11M12 5l2.5 3L12 11M9.5 3l-3 10"/></svg>Top harnesses <span class="note">tokens out</span></h2>
+        <h2><svg class="hic" viewBox="0 0 16 16"><path d="M4 5l-2.5 3L4 11M12 5l2.5 3L12 11M9.5 3l-3 10"/></svg>Top clients <span class="note">tokens out</span></h2>
         <div id="o-topharness"></div>
       </div>
     </div>
@@ -475,7 +475,7 @@ body.on-settings .tright, body.on-settings #custom { display: none; }
       </div>
     </div>
     <div class="card">
-      <h2><svg class="hic" viewBox="0 0 16 16"><path d="M4 5l-2.5 3L4 11M12 5l2.5 3L12 11M9.5 3l-3 10"/></svg>Per harness <span class="note">click a column to sort</span></h2>
+      <h2><svg class="hic" viewBox="0 0 16 16"><path d="M4 5l-2.5 3L4 11M12 5l2.5 3L12 11M9.5 3l-3 10"/></svg>Per client <span class="note">click a column to sort</span></h2>
       <div id="table-harness"></div>
     </div>
   </section>
@@ -551,7 +551,7 @@ body.on-settings .tright, body.on-settings #custom { display: none; }
     </div>
     <div class="grid2">
       <div class="card">
-        <h2>Lane utilization <span class="tag">Now</span></h2>
+        <h2>Key utilization <span class="tag">Now</span></h2>
         <div id="meters"></div>
       </div>
       <div class="card">
@@ -1116,7 +1116,7 @@ function chipHtml(pub) {
   if (!pub.slug) return `<span class="logo" style="background:${pub.color}">${initials}</span>`;
   return `<span class="logo" style="background:rgba(255,255,255,0.05)"><img alt="" src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/${pub.slug}.svg" onerror="${mono}"></span>`;
 }
-/* known-harness colors, stable hash-to-hue for the rest */
+/* known-client colors, stable hash-to-hue for the rest */
 const CLIENT_COLORS = {
   'claude-code': '#C15F3C', 'aider': '#2E7D5B', 'opencode': '#5A6150', 'cline': '#4D6BFE',
   'continue': '#615CED', 'cursor': '#2E96FF', 'roo-code': '#EE6002', 'zed': '#16B8C0',
@@ -1149,7 +1149,7 @@ const TITLES = { overview: 'Overview', models: 'Models', clients: 'Clients', rel
 function render() {
   if (!samples.length) return;
   const last = samples[samples.length-1], rows = nowRows;
-  const windowLabel = 'selected window';
+  const windowLabel = 'selected time range';
 
   /* ----- shared per-model aggregates ----- */
   const ptok = wgroups('nimproxy_prompt_tokens_total', 'model');
@@ -1206,7 +1206,7 @@ function render() {
   const okRatio = wreq ? wok/wreq : 1;
   const okColor = okRatio < 0.9 ? css('--red') : okRatio < 0.99 ? css('--amber') : css('--green');
 
-  /* ----- shared client / harness aggregates ----- */
+  /* ----- shared client aggregates ----- */
   const cReq = wgroups('nimproxy_requests_total', 'client');
   const cP = wgroups('nimproxy_prompt_tokens_total', 'client');
   const cC = wgroups('nimproxy_completion_tokens_total', 'client');
@@ -1242,7 +1242,7 @@ function render() {
   (RENDERERS[activeTab] || renderOverview)(c);
 }
 
-/* client monogram chip (harness leaderboards) */
+/* client monogram chip (client leaderboards) */
 const clientChip = cl =>
   `<span class="logo" style="background:${clientColor(cl)}">${esc(initialsOf(String(cl)))}</span>`;
 
@@ -1269,7 +1269,7 @@ function renderOverview(c) {
 
   $('o-rings').innerHTML = '<div class="ringwrap" id="o-ring-cap"></div><div class="ringwrap" id="o-ring-ok"></div>';
   ringGauge($('o-ring-cap'), capRatio, Math.round(capRatio * 100) + '%', capColor,
-    'Capacity used · Now', `${fmt(rpmNow)} / ${fmt(capacity)} rpm · ${cfg.lanes} lane${cfg.lanes === 1 ? '' : 's'}`);
+    'Capacity used', `${fmt(rpmNow)} / ${fmt(capacity)} rpm · ${cfg.lanes} key${cfg.lanes === 1 ? '' : 's'}`);
   const errShare = wreq ? (wreq - wok) / wreq * 100 : 0;
   ringGauge($('o-ring-ok'), okRatio, wreq ? Math.round(okRatio * 100) + '%' : '–', okColor,
     'Success rate', `errors ${errShare.toFixed(errShare && errShare < 10 ? 1 : 0)}% · ${fmt(cooldown429)} cooldowns`);
@@ -1278,7 +1278,9 @@ function renderOverview(c) {
     metricRow('Active now', fmt(sum(rows, 'nimproxy_active_requests'))) +
     metricRow('Queued', fmt(sum(rows, 'nimproxy_queue_depth'))) +
     metricRow('Rate-limit cooldowns', fmt(cooldown429), cooldown429 > 0 ? 'warn' : 'zero') +
-    metricRow('Shed · 401 · failed logins', `${fmt(shed)} · ${fmt(unauth)} · ${fmt(logins)}`, sul > 0 ? 'crit' : 'zero');
+    metricRow('Dropped', fmt(shed), shed > 0 ? 'crit' : 'zero') +
+    metricRow('Unauthorized', fmt(unauth), unauth > 0 ? 'crit' : 'zero') +
+    metricRow('Failed logins', fmt(logins), logins > 0 ? 'crit' : 'zero');
 
   const perfBlock = (label, note, p50, p95, fmtV) => {
     const scale = Math.max(isFinite(p50) ? p50 : 0, isFinite(p95) ? p95 : 0, 1e-9) * 1.25;
@@ -1367,10 +1369,10 @@ function renderModels(c) {
         cells: [`<i class="sw" style="background:${publisher(m).color}"></i>${esc(prettyName(m))}`,
           ...shares.map((v, i) => `<span class="${v >= 0.5 ? FINISH[i][2] : 'dim'}">${pct(v)}</span>`)],
       };
-    }), { defaultIdx: 1, maxH: 300, minW: 460, empty: 'No completions yet' });
+    }), { defaultIdx: 1, maxH: 300, minW: 460, empty: 'No completed requests yet' });
 
   const reasoningModels = models.filter(m => (reasoningByModel.get(m) || 0) > 0);
-  if (!reasoningModels.length) $('meters-reasoning').innerHTML = '<div class="empty">No reasoning-token usage seen</div>';
+  if (!reasoningModels.length) $('meters-reasoning').innerHTML = '<div class="empty">No reasoning tokens</div>';
   else barList($('meters-reasoning'),
     reasoningModels.map(m => ({ name: prettyName(m), v: reasonPct(m), color: publisher(m).color })), pct);
 
@@ -1394,7 +1396,7 @@ function renderModels(c) {
   sortTable($('compare-scorecard'), 'scorecard', [
     { label: 'Model', align: 'l', str: true },
     { label: 'Requests', best: 'max' }, { label: 'TTFT', best: 'min' }, { label: 'tok/s', best: 'max' },
-    { label: 'TPOT', best: 'min' }, { label: 'Avg reply', best: 'max' }, { label: 'Truncated', best: 'min' },
+    { label: 'TPOT', best: 'min' }, { label: 'Avg response', best: 'max' }, { label: 'Truncated', best: 'min' },
     { label: 'Reasoning', best: 'min' }, { label: 'Errors', best: 'min' },
   ], cmp.map(m => ({
     vals: [prettyName(m), reqModels.get(m) || 0, avgTtft(m), avgTps(m), tpotAvg(m), avgReply(m), truncPct(m), reasonPct(m), errRate(m)],
@@ -1428,7 +1430,7 @@ function renderModels(c) {
   $('m-tablecount').textContent = models.length ? `${models.length} model${models.length === 1 ? '' : 's'} · click a column to sort` : '';
   sortTable($('table-models'), 'models', [
     { label: 'Model', align: 'l', str: true }, { label: 'Requests' }, { label: 'Tokens out' },
-    { label: 'Avg TTFT' }, { label: 'Avg tok/s' }, { label: 'TPOT' }, { label: 'Avg reply' },
+    { label: 'Avg TTFT' }, { label: 'Avg tok/s' }, { label: 'TPOT' }, { label: 'Avg response' },
     { label: 'Truncated' }, { label: 'Reasoning' }, { label: 'Errors' },
   ], models.map(m => {
     const ct = ctok.get(m) || 0, ok = okByModel.get(m) || 0, e = errRate(m);
@@ -1462,11 +1464,11 @@ function renderClients(c) {
   const oMsgs = wsum('nimproxy_request_messages_sum'), oMsgsN = wsum('nimproxy_request_messages_count');
   const tile = (label, v, unit) => `<div class="tile"><div class="tlabel">${label}</div><div class="tval">${v}${unit ? `<span class="unit">${unit}</span>` : ''}</div></div>`;
   $('h-kpis').innerHTML =
-    tile('Harnesses', clients.length) +
+    tile('Clients', clients.length) +
     tile('Streaming share', totGen ? Math.round(totStreamT / totGen * 100) + '%' : '–') +
     tile('Avg tools / request', oToolsN ? fmt(oTools / oToolsN) : '–') +
     tile('Avg messages / request', oMsgsN ? fmt(oMsgs / oMsgsN) : '–') +
-    tile('Tool-using requests', totGen ? Math.round(totToolReq / totGen * 100) + '%' : '–');
+    tile('Requests using tools', totGen ? Math.round(totToolReq / totGen * 100) + '%' : '–');
   barList($('h-toolint'), clients.map(cl => ({ name: cl, v: toolsAvg(cl), color: clientColor(cl) })), fmt);
   barList($('h-depth'), clients.map(cl => ({ name: cl, v: msgsAvg(cl), color: clientColor(cl) })), fmt);
   barList($('h-temp'), clients.map(cl => ({ name: cl, v: tempAvg(cl), color: clientColor(cl) })), v => v.toFixed(2));
@@ -1480,7 +1482,7 @@ function renderClients(c) {
   if (maxTokClients.length)
     barList($('h-maxtok'), maxTokClients.map(cl => ({ name: cl, v: maxTokAvg(cl), color: clientColor(cl) })), fmt);
   sortTable($('table-harness'), 'harness', [
-    { label: 'Harness', align: 'l', str: true }, { label: 'Requests' }, { label: 'Tokens out' },
+    { label: 'Client', align: 'l', str: true }, { label: 'Requests' }, { label: 'Tokens out' },
     { label: 'Tools/req' }, { label: 'Msgs/req' }, { label: 'Streaming' },
   ], clients.map(cl => ({
     vals: [cl, cReq.get(cl) || 0, cC.get(cl) || 0, toolsAvg(cl), msgsAvg(cl), streamPct(cl)],
@@ -1523,7 +1525,7 @@ function renderReliability(c) {
   /* hero: where time goes (median-ish composition from windowed averages) */
   const qw = qwN ? qwS / qwN : 0, ttft = ttftN ? ttftS / ttftN : NaN, up = upN ? upS / upN : NaN;
   if (!upN) {
-    $('r-time').innerHTML = `<div class="hlabel">Where time goes <span class="note">avg request, end to end</span></div><div class="empty">No completed requests yet</div>`;
+    $('r-time').innerHTML = `<div class="hlabel">Latency breakdown <span class="note">avg end-to-end</span></div><div class="empty">No completed requests yet</div>`;
   } else {
     const gen = Math.max(0, up - (isFinite(ttft) ? ttft : 0));
     const segs = [
@@ -1533,8 +1535,8 @@ function renderReliability(c) {
     ].filter(s => s.v > 0);
     const tot = segs.reduce((a, s) => a + s.v, 0) || 1;
     $('r-time').innerHTML =
-      `<div style="display:flex;align-items:baseline;gap:10px"><span class="hlabel">Where time goes</span>
-      <span class="note" style="font:400 10px var(--mono);color:var(--ink-3)">avg request, end to end</span>
+      `<div style="display:flex;align-items:baseline;gap:10px"><span class="hlabel">Latency breakdown</span>
+      <span class="note" style="font:400 10px var(--mono);color:var(--ink-3)">avg end-to-end</span>
       <span style="margin-left:auto;font-size:22px;font-weight:600;letter-spacing:-0.5px">${secs(tot)}</span></div>
       <div class="segbar" style="height:16px;margin:16px 0 12px">${segs.map(s => `<div style="width:${(s.v / tot * 100).toFixed(1)}%;background:${s.color}"></div>`).join('')}</div>
       <div class="seglegend">${segs.map(s => `<div class="sl"><span class="sw" style="background:${s.color}"></span><div><div class="sll">${s.label}</div><div class="slv">${secs(s.v)}</div></div></div>`).join('')}</div>`;
@@ -1621,7 +1623,7 @@ function renderReliability(c) {
   const pcard = $('card-pressure');
   pcard.hidden = !(exhausted > 0 || govLimits.length);
   if (!pcard.hidden) {
-    lineChart($('chart-exhaust'), [{ name: 'exhaustions/min', color: css('--amber'),
+    lineChart($('chart-exhaust'), [{ name: 'Capacity errors/min', color: css('--amber'),
       pts: rateSeries(s => sum(s.rows, 'nimproxy_worker_exhausted_total')), area: 'url(#gMuted)' }], fmt, { height: 130 });
     const inflight = groups(rows, 'nimproxy_model_inflight', 'model');
     barList($('pressure-bars'), govLimits.map(([m, cap]) => ({
@@ -1646,12 +1648,12 @@ function renderReliability(c) {
     bad.map(([s, n]) => ({
       vals: [reason(s), n, n / totReq * 100],
       cells: [esc(reason(s)), fmt(n), (n / totReq * 100).toFixed(1) + '%'],
-    })), { defaultIdx: 1, maxH: 240, empty: 'All requests succeeded in this window' });
+    })), { defaultIdx: 1, maxH: 240, empty: 'No errors in this time range' });
 
   $('table-reliability').innerHTML =
     metricRow('Active now', fmt(act)) +
     metricRow('Queued', fmt(que)) +
-    metricRow('Shed (overload 503)', fmt(shed), shed > 0 ? 'crit' : 'zero') +
+    metricRow('Dropped (overload 503)', fmt(shed), shed > 0 ? 'crit' : 'zero') +
     metricRow('Rate-limit cooldowns', fmt(cooldown429), cooldown429 > 0 ? 'warn' : 'zero') +
     metricRow('Upstream error cooldowns', fmt(cooldownOther), cooldownOther > 0 ? 'warn' : 'zero') +
     metricRow('Unauthorized (401)', fmt(unauth), unauth > 0 ? 'crit' : 'zero') +
@@ -1662,7 +1664,7 @@ function renderReliability(c) {
   $('table-reqtypes').innerHTML =
     metricRow('Streaming', `${fmt(totStreamT)}${totGen ? ` (${Math.round(totStreamT / totGen * 100)}%)` : ''}`) +
     metricRow('Buffered', `${fmt(totStreamF)}${totGen ? ` (${Math.round(totStreamF / totGen * 100)}%)` : ''}`) +
-    metricRow('Tool-offering', `${fmt(totToolReq)}${totGen ? ` (${Math.round(totToolReq / totGen * 100)}%)` : ''}`) +
+    metricRow('Requests with tools', `${fmt(totToolReq)}${totGen ? ` (${Math.round(totToolReq / totGen * 100)}%)` : ''}`) +
     metricRow('JSON mode', fmt(jsonMode)) +
     metricRow('Tool choice', tcStr);
 
@@ -1693,18 +1695,18 @@ function renderCapacity(c) {
     </div>
     <div style="display:flex;justify-content:space-between;font:400 11px var(--mono);color:var(--ink-3)">
       <span style="color:var(--ink-2)">${fmt(rpmNow)} / ${fmt(capacity)} rpm</span>
-      <span>${cfg.lanes} enabled lane${cfg.lanes === 1 ? '' : 's'}</span>
-      <span style="color:var(--green-lt)">${fmt(headroom)} rpm free</span>
+      <span>${cfg.lanes} enabled key${cfg.lanes === 1 ? '' : 's'}</span>
+      <span style="color:var(--green-lt)">${fmt(headroom)} rpm available</span>
     </div>`;
 
-  /* Historical comparisons use each bucket's contemporaneous capacity.
+  /* Historical comparisons use each bucket's capacity at the time.
      Legacy buckets without metadata never inherit today's configuration. */
   const knownCapacity = capacityPoints.filter(point => point.capacity != null);
   const unknownCapacity = capacityPoints.length - knownCapacity.length;
   if (!knownCapacity.length) {
     $('k-prov').innerHTML =
-      `<div class="hlabel">Historical provisioning</div>
-      <div class="empty">Capacity unavailable for selected legacy intervals</div>`;
+      `<div class="hlabel">Capacity history</div>
+      <div class="empty">No capacity data for this time range</div>`;
   } else {
     const weightedSeconds = knownCapacity.reduce((n, point) => n + point.duration, 0);
     const averageUtil = weightedSeconds
@@ -1716,13 +1718,13 @@ function renderCapacity(c) {
       point.rpm - point.capacity > best.rpm - best.capacity ? point : best);
     const shortRpm = Math.max(0, Math.ceil(shortfall.rpm - shortfall.capacity));
     $('k-prov').innerHTML =
-      `<div class="hlabel">Historical provisioning</div>
+      `<div class="hlabel">Capacity history</div>
       <div style="display:flex;align-items:baseline;gap:8px;margin-top:12px">
         <span style="font-size:34px;font-weight:600;letter-spacing:-1px;color:${shortRpm > 0 ? 'var(--amber)' : 'var(--ink-1)'}">${fmt(shortRpm)}</span>
-        <span style="font:400 12px var(--mono);color:var(--ink-3)">rpm short at peak</span></div>
+        <span style="font:400 12px var(--mono);color:var(--ink-3)">Peak shortfall</span></div>
       <div style="font:400 11.5px var(--mono);color:var(--ink-25);margin-top:6px">
         avg ${isFinite(averageUtil) ? Math.round(averageUtil * 100) + '%' : '–'} · peak ${Math.round(peak.rpm / peak.capacity * 100)}%
-        vs contemporaneous capacity${unknownCapacity ? ` · ${unknownCapacity} legacy interval${unknownCapacity === 1 ? '' : 's'} unavailable` : ''}
+        of capacity at the time${unknownCapacity ? ` · ${unknownCapacity} interval${unknownCapacity === 1 ? '' : 's'} with no capacity data` : ''}
       </div>`;
   }
 
@@ -1732,10 +1734,10 @@ function renderCapacity(c) {
   const stickyTxt = sticky + spill ? Math.round(sticky / (sticky + spill) * 100) + '%' : '–';
   const prow = (l, v, color) => `<div style="display:flex;justify-content:space-between;align-items:center;padding:6px 0"><span style="font-size:12.5px;color:var(--ink-2)">${l}</span><span style="font:600 15px var(--mono);color:${color || 'var(--ink-1)'}">${v}</span></div>`;
   $('k-pressure').innerHTML =
-    `<div class="hlabel" style="margin-bottom:12px">Rate-limit pressure</div>` +
-    prow('429s this window', fmt(cooldown429), cooldown429 > 0 ? 'var(--amber)' : 'var(--ink-3)') +
-    prow('Conversation stickiness', stickyTxt) +
-    prow('Lane slots · Now', cfg.lanes);
+    `<div class="hlabel" style="margin-bottom:12px">Throttling</div>` +
+    prow('Rate limited (429)', fmt(cooldown429), cooldown429 > 0 ? 'var(--amber)' : 'var(--ink-3)') +
+    prow('Session affinity', stickyTxt) +
+    prow('Slots in use', cfg.lanes);
 
   /* Current per-slot utilization comes from adjacent `/now` polls. Selected
      window counts remain selected-window values; neither domain is subtracted
@@ -1748,11 +1750,11 @@ function renderCapacity(c) {
   const lanes = Array.from({ length: cfg.lanes }, (_, i) => {
     const k = String(i);
     const currentRpm = nowLaneRates.get(k) || 0;
-    return { i, name: `Lane slot ${i + 1}`, cur: laneWindow.get(k) || 0, currentRpm,
+    return { i, name: `Slot ${i + 1}`, cur: laneWindow.get(k) || 0, currentRpm,
       util: Math.min(1, currentRpm / Math.max(1, laneRpm(i))),
       b429: lane429.get(k) || 0, bOther: laneOther.get(k) || 0 };
   });
-  if (!lanes.length) $('meters').innerHTML = '<div class="empty">No lanes configured</div>';
+  if (!lanes.length) $('meters').innerHTML = '<div class="empty">No keys configured</div>';
   else barList($('meters'), lanes.map(l => ({
     name: l.name, v: l.util * 100, color: l.util >= 0.9 ? css('--amber') : laneColor(l.i),
   })), v => Math.round(v) + '%', 100);
@@ -1765,15 +1767,15 @@ function renderCapacity(c) {
   legend($('legend-cooldowns'), cooldownSeries);
 
   sortTable($('table-lanes'), 'lanes', [
-    { label: 'Lane', align: 'l', str: true }, { label: 'Requests' }, { label: 'Share' },
-    { label: 'Now rpm' }, { label: '429s' }, { label: 'Upstream error cooldowns' },
+    { label: 'Key', align: 'l', str: true }, { label: 'Requests' }, { label: 'Share' },
+    { label: 'Current rate' }, { label: '429s' }, { label: 'Upstream error cooldowns' },
   ], lanes.map(l => ({
     vals: [l.name, l.cur, l.cur / totalLane * 100, l.currentRpm, l.b429, l.bOther],
     cells: [`<i class="sw" style="background:${laneColor(l.i)}"></i>${esc(l.name)}`,
       fmt(l.cur), (l.cur / totalLane * 100).toFixed(0) + '%', `${fmt(l.currentRpm)} / ${laneRpm(l.i)}`,
       `<span class="${l.b429 ? 'warnc' : 'dim'}">${fmt(l.b429)}</span>`,
       `<span class="${l.bOther ? 'critc' : 'dim'}">${fmt(l.bOther)}</span>`],
-  })), { defaultIdx: 1, maxH: 360, minW: 560, empty: 'No lanes configured' });
+  })), { defaultIdx: 1, maxH: 360, minW: 560, empty: 'No keys configured' });
 }
 
 /* ===== settings — config-driven, not metrics-driven: fetched from
@@ -1824,10 +1826,10 @@ function renderSettings() {
 function keyState(k) {
   if (!k.enabled) return { text: 'disabled', cls: 'kstate dim' };
   if (k.cooldown_ms > 0) return { text: `cooldown ${Math.ceil(k.cooldown_ms / 1000)}s`, cls: 'kstate warnc' };
-  if (k.in_window != null) return { text: `${+k.in_window} / ${+k.rpm} in window`, cls: 'kstate' };
+  if (k.in_window != null) return { text: `${+k.in_window} / ${+k.rpm} in range`, cls: 'kstate' };
   return { text: 'unassigned', cls: 'kstate dim' };
 }
-const poolNote = () => `${+SET.pool.enabled} enabled in pool · ${+SET.pool.capacity_rpm} rpm total`;
+const poolNote = () => `${+SET.pool.enabled} enabled in pool · Total ${+SET.pool.capacity_rpm} rpm`;
 const clampInt = (v, lo, hi, dflt) => { const n = Math.round(+v); return isFinite(n) ? Math.max(lo, Math.min(hi, n)) : dflt; };
 
 async function copyText(text, btn) {
@@ -1891,7 +1893,7 @@ function renderAccess() {
       <div class="serr" id="nk-err"></div>
     </div>
     <div class="card mb">
-      <h2>${admin ? 'Client API keys' : 'My API keys'} <span class="note">bearer tokens your harnesses use</span></h2>
+      <h2>${admin ? 'Client API keys' : 'My API keys'} <span class="note">bearer tokens your clients use</span></h2>
       <div>${ckRows || '<div class="empty">No client keys yet</div>'}</div>
       <div class="addrow">
         <input id="ck-name" class="sin" style="flex:1;min-width:200px" placeholder="name this key, e.g. laptop-cli" maxlength="64" autocomplete="off" spellcheck="false">
@@ -1908,8 +1910,8 @@ function renderAccess() {
         </div>
         <div class="conbox">
           <div class="slabel">API access mode</div>
-          <div class="kmask" style="color:${SET.mode === 'keyed' ? 'var(--green-lt)' : 'var(--amber-lt)'}">● ${SET.mode === 'keyed' ? 'Keyed — bearer required' : 'Open — no key needed'}</div>
-          <div class="kmeta" style="margin-top:4px">${SET.mode === 'keyed' ? 'harnesses authenticate with a client API key' : 'anyone who can reach /v1 can use the pool'}</div>
+          <div class="kmask" style="color:${SET.mode === 'keyed' ? 'var(--green-lt)' : 'var(--amber-lt)'}">● ${SET.mode === 'keyed' ? 'API key required' : 'Open — no authentication'}</div>
+          <div class="kmeta" style="margin-top:4px">${SET.mode === 'keyed' ? 'clients authenticate with a client API key' : 'anyone who can reach /v1 can use the pool'}</div>
         </div>
       </div>
     </div>`;
@@ -1945,7 +1947,7 @@ function renderAccess() {
     $('nk-add').disabled = true; $('nk-add').textContent = 'Validating…';
     try {
       const v = await sPost('/api/settings/validate-key', { key });
-      note('nk-err', `✓ ${Array.isArray(v.models) ? v.models.length : +v.models} models — adding…`, true);
+      note('nk-err', `✓ ${Array.isArray(v.models) ? v.models.length : +v.models} models · Adding…`, true);
       await addKey();
       return;
     } catch (e) {
@@ -1960,7 +1962,7 @@ function renderAccess() {
   });
   for (const el of body.querySelectorAll('[data-ckdel]')) el.addEventListener('click', async () => {
     const ck = SET.client_keys[+el.dataset.ckdel];
-    if (!confirm(`Revoke "${ck.name}"? Harnesses using it stop working immediately.`)) return;
+    if (!confirm(`Revoke "${ck.name}"? Clients using it stop working immediately.`)) return;
     try { await sPost('/api/settings/clients', { remove: ck.name }); await loadSettings(); }
     catch (e) { note('ck-err', e.message); }
   });
@@ -1982,18 +1984,18 @@ function renderServer() {
     <span class="rpmwrap" style="display:flex"><input id="${id}" class="sin" style="width:100%;text-align:right" type="number" min="0"${step ? ` step="${step}"` : ''} value="${+val}">${unit ? `<span class="unitl">${unit}</span>` : ''}</span></div>`;
   const ovr = Object.entries(sv.governor.overrides || {});
   const retainedFrom = sv.history.available_from == null
-    ? 'No retained snapshots yet'
+    ? 'No data yet'
     : new Date(+sv.history.available_from * 1000).toLocaleString();
   const historyBytes = new Intl.NumberFormat().format(+sv.history.file_bytes || 0);
   $('setbody').innerHTML = `
     <div class="card mb">
       <h2>API access mode
         <span class="pills" style="margin-left:auto">
-          <button data-mode="open" aria-pressed="${SET.mode === 'open'}">Open</button>
-          <button data-mode="keyed" aria-pressed="${SET.mode === 'keyed'}">Keyed</button>
+          <button data-mode="open" aria-pressed="${SET.mode === 'open'}">Open (no authentication)</button>
+          <button data-mode="keyed" aria-pressed="${SET.mode === 'keyed'}">API key required</button>
         </span></h2>
-      <p class="shint">Controls <b>/v1</b> harness calls only. <b>Keyed</b> requires a bearer token; <b>Open</b> accepts anyone who can reach /v1 — trusted networks only.</p>
-      ${SET.mode === 'keyed' && !SET.client_keys.length ? '<p class="shint" style="color:var(--amber-lt)">Keyed mode with no client keys locks every harness out — generate one under Access &amp; keys.</p>' : ''}
+      <p class="shint">Controls <b>/v1</b> client calls only. <b>API key required</b> needs a bearer token; <b>Open</b> accepts anyone who can reach /v1 — trusted networks only.</p>
+      ${SET.mode === 'keyed' && !SET.client_keys.length ? '<p class="shint" style="color:var(--amber-lt)">Requiring an API key with no client keys locks every client out — generate one under Access &amp; keys.</p>' : ''}
       <div class="serr" id="mode-err"></div>
     </div>
     <div class="card mb">
@@ -2015,13 +2017,13 @@ function renderServer() {
       <div class="serr" id="limits-err"></div>
     </div>
     <div class="card mb">
-      <h2>Model-pressure governor
+      <h2>Model limits
         <span style="margin-left:auto;display:inline-flex;align-items:center;gap:8px"><span class="kmeta">adaptive</span>
         <button class="tog" role="switch" id="gov-tog" aria-checked="${!!sv.governor.enabled}"></button></span></h2>
       <p class="shint">Absorbs NIM worker-exhaustion per model without cooling down keys. Each model self-tunes: engages on the first exhaustion, climbs while stable, dissolves after a long clean stretch. Set an override only if you know a model's ceiling.</p>
       <div>${ovr.map(([m, cap], i) =>
         `<span class="ochip"><span title="${esc(m)}">${esc(m)}</span><b>${+cap} max</b><button data-govdel="${i}" title="Remove override">×</button></span>`).join('')
-        || '<span class="kmeta">no overrides — fully adaptive</span>'}</div>
+        || '<span class="kmeta">No overrides set</span>'}</div>
       <div class="addrow">
         <input id="gov-model" class="sin" style="flex:1;min-width:200px" placeholder="model id, e.g. moonshotai/kimi-k2.5" autocomplete="off" spellcheck="false">
         <span class="rpmwrap"><input id="gov-cap" class="sin num" type="number" min="1" max="10000" value="8"><span class="unitl">max</span></span>
@@ -2032,7 +2034,7 @@ function renderServer() {
     <div class="card">
       <h2>History &amp; dashboard <button class="pbtn" id="save-history" style="margin-left:auto">Save</button></h2>
       <div class="limgrid" style="margin-top:6px">
-        <div><div class="slabel">Default dashboard window</div>
+        <div><div class="slabel">Default time range</div>
           <span class="rpmwrap" style="display:flex"><input id="sv-default-days" class="sin" style="width:100%;text-align:right" type="number" min="1" step="1" value="${+sv.dashboard.default_window_days}"><span class="unitl">days</span></span></div>
         <div><div class="slabel">History retention · 0 = unlimited</div>
           <span class="rpmwrap" style="display:flex"><input id="sv-retention-days" class="sin" style="width:100%;text-align:right" type="number" min="0" step="1" value="${+sv.history.days}"><span class="unitl">days</span></span></div>
@@ -2040,8 +2042,8 @@ function renderServer() {
           <span class="rpmwrap" style="display:flex"><input id="sv-slo" class="sin" style="width:100%;text-align:right" type="number" min="0.1" max="100" step="0.1" value="${+sv.dashboard.slo_target_percent}"><span class="unitl">%</span></span></div>
       </div>
       <div class="congrid" style="margin-top:16px">
-        <div class="conbox"><div class="slabel">Earliest retained snapshot</div><div class="kmeta" style="display:block">${esc(retainedFrom)}</div></div>
-        <div class="conbox"><div class="slabel">History file</div><div class="kmeta" style="display:block">${esc(historyBytes)} bytes</div></div>
+        <div class="conbox"><div class="slabel">Oldest data point</div><div class="kmeta" style="display:block">${esc(retainedFrom)}</div></div>
+        <div class="conbox"><div class="slabel">Data file</div><div class="kmeta" style="display:block">${esc(historyBytes)} bytes</div></div>
       </div>
       ${sv.history.compaction_pending ? '<p class="shint" style="color:var(--amber-lt)">compaction pending</p>' : ''}
       <div class="serr" id="history-err"></div>
@@ -2091,7 +2093,7 @@ function renderServer() {
     const retention = Math.round(+$('sv-retention-days').value);
     const slo = +$('sv-slo').value;
     if (!isFinite(defaultDays) || defaultDays < 1)
-      return note('history-err', 'Default dashboard window must be at least 1 day.');
+      return note('history-err', 'Default time range must be at least 1 day.');
     if (!isFinite(retention) || retention < 0)
       return note('history-err', 'History retention must be 0 or more days.');
     if (!isFinite(slo) || slo <= 0 || slo > 100)
@@ -2126,7 +2128,7 @@ function renderUsers() {
       : `<span class="note" title="The superuser changes its own password in Account settings">self-managed</span>`}
   </div>`).join('');
   $('setbody').innerHTML = `<div class="card">
-    <h2>Users <span class="note">deleting a user pulls their NIM keys from the pool &amp; stops their harnesses</span></h2>
+    <h2>Users <span class="note">deleting a user pulls their NIM keys from the pool &amp; stops their clients</span></h2>
     <div>${rows}</div>
     <div class="addrow">
       <input id="u-name" class="sin" style="flex:1;min-width:150px" placeholder="new username" autocomplete="off" spellcheck="false">
@@ -2254,7 +2256,7 @@ function applyNowConfig(next) {
     retention_days: +next.retention_days || 0,
     slo_target_percent: +next.slo_target_percent || 99.9,
   };
-  $('verinfo').textContent = `v${cfg.version} · ${cfg.lanes} lanes · auth ${cfg.auth ? 'on' : 'off'}`;
+  $('verinfo').textContent = `v${cfg.version} · ${cfg.lanes} keys · auth ${cfg.auth ? 'on' : 'off'}`;
   const defaultButton = document.querySelector('#ranges [data-range="default"]');
   if (defaultButton) defaultButton.textContent = `Default · ${cfg.default_window_days}d`;
 }
@@ -2273,7 +2275,7 @@ function followingBounds() {
 
 function presetLabel() {
   if (mode.preset === 'default') return `Default · ${cfg.default_window_days}d`;
-  if (mode.preset === 'all-retained') return 'All retained';
+  if (mode.preset === 'all-retained') return 'All time';
   return ({ '3600': '1h', '21600': '6h', '86400': '24h', '604800': '7d', '2592000': '30d' })[mode.preset] || '';
 }
 
@@ -2288,27 +2290,27 @@ function updateScope() {
     nowData?.tail?.base_history_revision === rangeData.history_revision ? nowData.tail : null;
   const hasTraffic = mode.paused ? frozenHasTraffic : hasSelectedRequestTraffic(samples);
   if (!hasTraffic) {
-    $('rangeinfo').textContent = 'No traffic in selected window';
+    $('rangeinfo').textContent = 'No data in selected time range';
     return;
   }
   const from = mode.paused ? mode.from : rangeData.window.effective_from ?? mode.from;
   const to = mode.paused ? mode.to : tail?.to ?? rangeData.window.effective_to ?? mode.to;
   if (mode.kind === 'following' && !mode.paused) {
-    $('rangeinfo').textContent = `● Following now    ${presetLabel()}    ${scopeDate(from)} – ${scopeDate(to)}`;
+    $('rangeinfo').textContent = `● Live    ${presetLabel()}    ${scopeDate(from)} – ${scopeDate(to)}`;
   } else {
-    $('rangeinfo').textContent = `○ Fixed range    ${scopeTime(from)} – ${scopeTime(to)}`;
+    $('rangeinfo').textContent = `○ Absolute    ${scopeTime(from)} – ${scopeTime(to)}`;
   }
 }
 
 function syncFollowControl(offline = false) {
   if (offline) {
     $('live').className = 'live down';
-    $('liveText').textContent = 'offline';
+    $('liveText').textContent = 'Disconnected';
     return;
   }
   const following = mode.kind === 'following' && !mode.paused;
   $('live').className = following ? 'live' : 'live idle';
-  $('liveText').textContent = following ? 'following now' : 'fixed range';
+  $('liveText').textContent = following ? 'Live' : 'Idle';
 }
 
 function rebuildSamples() {
@@ -2397,7 +2399,7 @@ for (const b of document.querySelectorAll('#ranges button')) {
       try {
         if (await refreshSelectedRange()) render();
       } catch {
-        $('rangeinfo').textContent = 'failed to load selected window';
+        $('rangeinfo').textContent = 'Failed to load time range';
       }
     }
   });
@@ -2411,7 +2413,7 @@ $('applyRange').addEventListener('click', async () => {
   try {
     if (await refreshSelectedRange()) render();
   } catch {
-    $('rangeinfo').textContent = 'failed to load selected window';
+    $('rangeinfo').textContent = 'Failed to load time range';
   }
 });
 $('live').addEventListener('click', async () => {
@@ -2429,7 +2431,7 @@ $('live').addEventListener('click', async () => {
     try {
       if (await refreshSelectedRange()) render();
     } catch {
-      $('rangeinfo').textContent = 'failed to resume selected window';
+      $('rangeinfo').textContent = 'Failed to resume time range';
     }
   }
   syncFollowControl();

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -90,7 +90,7 @@ button { font: inherit; color: inherit; background: none; border: 0; padding: 0;
 /* ---------- cards & grids ---------- */
 section[hidden] { display: none; }
 .card { background: var(--card); border: 1px solid var(--card-border); border-radius: 16px; padding: 16px 20px; min-width: 0; }
-.card h2 { display: flex; align-items: center; gap: 9px; font-size: 14px; font-weight: 500; margin: 0 0 10px; color: var(--ink-1); }
+.card h2 { display: flex; flex-wrap: wrap; align-items: center; gap: 9px; font-size: 14px; font-weight: 500; margin: 0 0 10px; color: var(--ink-1); }
 .card h2 .note { font: 400 11.5px var(--mono); color: var(--ink-3); font-weight: 400; }
 .card h2 .hr { margin-left: auto; font: 500 12px var(--mono); color: var(--green-lt); }
 .hic { width: 15px; height: 15px; flex: none; fill: none; stroke: var(--green); stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }
@@ -372,7 +372,7 @@ body.on-settings .tright, body.on-settings #custom { display: none; }
       </div>
     </div>
     <div class="card mb">
-      <h2><svg class="hic" viewBox="0 0 16 16"><path d="M9 1.5L3 9h4l-1 5.5L13 7H9z"/></svg>Performance <span class="note">median &amp; p95 across the window</span></h2>
+      <h2><svg class="hic" viewBox="0 0 16 16"><path d="M9 1.5L3 9h4l-1 5.5L13 7H9z"/></svg>Performance <span class="note">median &amp; p95 across the time range</span></h2>
       <div class="perf3" id="o-perf"></div>
     </div>
     <div class="grid2">
@@ -561,7 +561,7 @@ body.on-settings .tright, body.on-settings #custom { display: none; }
       </div>
     </div>
     <div class="card">
-      <h2>Per lane <span class="tag">Now</span><span class="note">click a column to sort</span></h2>
+      <h2>Per key <span class="tag">Now</span><span class="note">click a column to sort</span></h2>
       <div id="table-lanes"></div>
     </div>
   </section>
@@ -780,7 +780,7 @@ function lineChart(el, series, unitFmt, opts = {}) {
   const H = opts.height || 190;
   el.classList.add('chart');
   const live = series.filter(s => s.pts.length > 1);
-  if (!live.length) { el.innerHTML = '<div class="empty">No data in this window</div>'; return; }
+  if (!live.length) { el.innerHTML = '<div class="empty">No data in selected time range</div>'; return; }
   const W = el.clientWidth || 500, PT = 16, PB = 16;
   const t0 = Math.min(...live.map(s => s.pts[0].t));
   const t1 = Math.max(...live.map(s => s.pts[s.pts.length-1].t));
@@ -858,7 +858,7 @@ function stackChart(el, series, unitFmt, opts = {}) {
   const ts = (bands[0] || { pts: [] }).pts.map(p => p.t);
   const at = (s, i) => Math.max(0, s.pts[i] ? s.pts[i].v : 0);
   const totals = ts.map((_, i) => bands.reduce((a, s) => a + at(s, i), 0));
-  if (ts.length < 2 || !totals.some(v => v > 0)) { el.innerHTML = '<div class="empty">No data in this window</div>'; return; }
+  if (ts.length < 2 || !totals.some(v => v > 0)) { el.innerHTML = '<div class="empty">No data in selected time range</div>'; return; }
   const W = el.clientWidth || 500, PT = 16, PB = 16;
   const t0 = ts[0], t1 = ts[ts.length-1];
   let vmax = Math.max(1e-6, ...totals);
@@ -1028,7 +1028,7 @@ function deltaChip(pts, downIsGood) {
   const d = (b - a) / a * 100;
   if (!isFinite(d) || Math.abs(d) < 0.05) return '';
   const good = downIsGood ? d <= 0 : d >= 0;
-  return `<span class="chip ${good ? 'good' : 'bad'}" title="second half of this window vs the first">${d >= 0 ? '+' : ''}${Math.abs(d) >= 10 ? d.toFixed(0) : d.toFixed(1)}%</span>`;
+  return `<span class="chip ${good ? 'good' : 'bad'}" title="second half of this time range vs the first">${d >= 0 ? '+' : ''}${Math.abs(d) >= 10 ? d.toFixed(0) : d.toFixed(1)}%</span>`;
 }
 /* k: {icon, label, value, sub, delta?, pts?} */
 function kpiCards(el, defs, hero) {
@@ -1046,7 +1046,7 @@ const metricRow = (l, v, tone) => `<div class="kv${tone ? ' ' + tone : ''}"><spa
 /* ---------- activity heatmap: weekday x hour, sequential green ramp ---------- */
 const DAYS = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
 function heatmap(el, matrix, vmax) {
-  if (!vmax) { el.innerHTML = '<div class="empty">No data in this window</div>'; return; }
+  if (!vmax) { el.innerHTML = '<div class="empty">No data in selected time range</div>'; return; }
   const CW = 26, CH = 18, GAP = 3, PL = 36, PT = 18;
   const W = PL + 24*(CW+GAP), H = PT + 7*(CH+GAP);
   let g = '';
@@ -1273,7 +1273,6 @@ function renderOverview(c) {
   const errShare = wreq ? (wreq - wok) / wreq * 100 : 0;
   ringGauge($('o-ring-ok'), okRatio, wreq ? Math.round(okRatio * 100) + '%' : '–', okColor,
     'Success rate', `errors ${errShare.toFixed(errShare && errShare < 10 ? 1 : 0)}% · ${fmt(cooldown429)} cooldowns`);
-  const sul = shed + unauth + logins;
   $('o-health').innerHTML =
     metricRow('Active now', fmt(sum(rows, 'nimproxy_active_requests'))) +
     metricRow('Queued', fmt(sum(rows, 'nimproxy_queue_depth'))) +
@@ -1688,7 +1687,7 @@ function renderCapacity(c) {
   const headroom = Math.max(0, capacity - rpmNow);
   $('k-sat').innerHTML =
     `<div style="display:flex;align-items:baseline;gap:10px"><span class="hlabel">Saturation</span><span class="tag">Now</span>
-    <span class="note" style="font:400 10px var(--mono);color:var(--ink-3)">current load vs current aggregate capacity</span>
+    <span class="note" style="font:400 10px var(--mono);color:var(--ink-3)">current load vs total capacity</span>
     <span style="margin-left:auto;font-size:30px;font-weight:600;letter-spacing:-1px;color:${capColor}">${Math.round(satPct * 100)}%</span></div>
     <div style="position:relative;height:20px;background:var(--track);border-radius:6px;overflow:hidden;margin:16px 0 8px">
       <div style="position:absolute;inset:0;width:${(satPct * 100).toFixed(1)}%;background:linear-gradient(90deg,var(--green-dk),var(--green));border-radius:6px"></div>
@@ -1721,7 +1720,7 @@ function renderCapacity(c) {
       `<div class="hlabel">Capacity history</div>
       <div style="display:flex;align-items:baseline;gap:8px;margin-top:12px">
         <span style="font-size:34px;font-weight:600;letter-spacing:-1px;color:${shortRpm > 0 ? 'var(--amber)' : 'var(--ink-1)'}">${fmt(shortRpm)}</span>
-        <span style="font:400 12px var(--mono);color:var(--ink-3)">Peak shortfall</span></div>
+        <span style="font:400 12px var(--mono);color:var(--ink-3)">Peak shortfall · rpm</span></div>
       <div style="font:400 11.5px var(--mono);color:var(--ink-25);margin-top:6px">
         avg ${isFinite(averageUtil) ? Math.round(averageUtil * 100) + '%' : '–'} · peak ${Math.round(peak.rpm / peak.capacity * 100)}%
         of capacity at the time${unknownCapacity ? ` · ${unknownCapacity} interval${unknownCapacity === 1 ? '' : 's'} with no capacity data` : ''}
@@ -1787,7 +1786,7 @@ let SET = null, setSub = 'access';
 async function sPost(path, body) {
   const r = await fetch(path, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
   let j = {}; try { j = await r.json(); } catch {}
-  if (!r.ok || j.ok === false) throw new Error((j.error && j.error.message) || j.error || `request failed (${r.status})`);
+  if (!r.ok || j.ok === false) throw new Error((j.error && j.error.message) || j.error || `Request failed (${r.status})`);
   return j;
 }
 /* inline feedback next to the control that caused it (textContent — never markup) */
@@ -1826,7 +1825,7 @@ function renderSettings() {
 function keyState(k) {
   if (!k.enabled) return { text: 'disabled', cls: 'kstate dim' };
   if (k.cooldown_ms > 0) return { text: `cooldown ${Math.ceil(k.cooldown_ms / 1000)}s`, cls: 'kstate warnc' };
-  if (k.in_window != null) return { text: `${+k.in_window} / ${+k.rpm} in range`, cls: 'kstate' };
+  if (k.in_window != null) return { text: `${+k.in_window} / ${+k.rpm} in window`, cls: 'kstate' };
   return { text: 'unassigned', cls: 'kstate dim' };
 }
 const poolNote = () => `${+SET.pool.enabled} enabled in pool · Total ${+SET.pool.capacity_rpm} rpm`;
@@ -1862,7 +1861,7 @@ function renderAccess() {
     return `<div class="krow${k.enabled ? '' : ' koff'}">
       <div style="min-width:0">
         <div class="kmask">nvapi-••••${esc(k.last4)}${ownerChip(k.owner)}</div>
-        <div class="kmeta">fp ${esc(String(k.fingerprint).slice(0, 8))} · ${k.lane != null ? `lane ${+k.lane}` : k.enabled ? 'unassigned' : 'off'}</div>
+        <div class="kmeta">fp ${esc(String(k.fingerprint).slice(0, 8))} · ${k.lane != null ? `slot ${+k.lane + 1}` : k.enabled ? 'unassigned' : 'off'}</div>
       </div>
       <span class="${st.cls}" data-ksfp="${esc(k.fingerprint)}">${esc(st.text)}</span>
       <span class="rpmwrap"><input class="sin num" type="number" min="1" max="10000" value="${+k.rpm}" data-rpm="${i}"><span class="unitl">rpm</span></span>
@@ -2310,7 +2309,7 @@ function syncFollowControl(offline = false) {
   }
   const following = mode.kind === 'following' && !mode.paused;
   $('live').className = following ? 'live' : 'live idle';
-  $('liveText').textContent = following ? 'Live' : 'Idle';
+  $('liveText').textContent = following ? 'Live' : 'Absolute';
 }
 
 function rebuildSamples() {

--- a/src/setup.html
+++ b/src/setup.html
@@ -99,8 +99,8 @@ details input { margin-top:8px; }
   <section id="step3" hidden>
     <div class="review" id="review"></div>
     <label class="opt"><input type="checkbox" id="mintkey" checked>
-      <span>Create my first client API key (<code>npk_…</code>) so harnesses can call <code>/v1</code> right away</span></label>
-    <p class="warn" id="mintwarn" hidden>Without a client key, the proxy stays in keyed mode but
+      <span>Create my first client API key (<code>npk_…</code>) so clients can call <code>/v1</code> right away</span></label>
+    <p class="warn" id="mintwarn" hidden>Without a client key, the proxy still requires an API key but
       rejects <b>every</b> /v1 request until you mint one in Settings → Access &amp; keys.
       Skip this only if you plan to switch the API mode to open (unauthenticated /v1).</p>
     <div class="row">
@@ -110,7 +110,7 @@ details input { margin-top:8px; }
   </section>
 
   <section id="step4" hidden>
-    <p class="sub">Setup complete. Point your harness at the proxy — the API key below is shown
+    <p class="sub">Setup complete. Point your client at the proxy — the API key below is shown
       <b>only this once</b> (only its digest is stored).</p>
     <label>Client base URL</label>
     <div class="copyrow"><code id="cbase"></code><button type="button" class="ghost" data-copy="cbase">Copy</button></div>
@@ -173,8 +173,8 @@ $("addkey").onclick = async () => {
 
 function apiAccessLine() {
   return $("mintkey").checked
-    ? 'keyed · first client key "default"'
-    : "keyed — no client key yet (/v1 rejects everything)";
+    ? 'API key required · first client key "default"'
+    : "API key required — no client key yet (/v1 rejects everything)";
 }
 $("to3").onclick = () => {
   const base = $("baseurl").value.trim();

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1657,7 +1657,7 @@ async fn dashboard_pause_traffic_is_derived_from_rendered_samples() {
 }
 
 #[tokio::test]
-async fn dashboard_historical_provisioning_has_no_guessed_lane_size() {
+async fn dashboard_capacity_history_has_no_guessed_key_size() {
     let mock = start_mock().await;
     let proxy = start_proxy(&mock.url, &[]).await;
     let cookie = login(&proxy).await;
@@ -1671,9 +1671,9 @@ async fn dashboard_historical_provisioning_has_no_guessed_lane_size() {
         .text()
         .await
         .unwrap();
-    assert!(html.contains("rpm short at peak"));
-    assert!(html.contains("vs contemporaneous capacity"));
-    assert!(html.contains("legacy interval"));
+    assert!(html.contains("Peak shortfall"));
+    assert!(html.contains("of capacity at the time"));
+    assert!(html.contains("with no capacity data"));
     assert!(!html.contains("const moreKeys"));
     assert!(!html.contains("MORE KEY"));
 }


### PR DESCRIPTION
## Summary

Applies the agreed standard ops-dashboard vocabulary to `src/dashboard.html` and `src/setup.html`. Every replacement is existing Grafana / Kibana / HAProxy / Envoy terminology — nothing invented — so labels are recognizable without explanation and translatable without a glossary. Display text only; no i18n machinery yet.

PR 2 of 7 toward 0.6.6. Targets `release/v0.6.6`.

## Type of change

- [x] New feature / behavior change — user-visible label changes
- [x] Docs / knowledge base only — README and knowledge pages follow the labels
- [ ] ~~Bug fix~~ / ~~Performance~~ / ~~Security~~ / ~~CI~~ / ~~Release~~ — none apply
- [ ] ~~Refactor~~ — the rendered output changes, so this isn't behavior-neutral

## Related issues

Relates to #69.

## What & why

Two structural fixes account for most of the diff.

**`window` was overloaded.** It meant both the rate-limit rolling window and the dashboard's time selection — two unrelated concepts sharing one word, which is the worst case for a translator. Rate limiting keeps **window**; the dashboard adopts **time range** (Grafana's word). That alone fixes six strings and makes the whole time-selection surface boilerplate.

**`lane` was a metaphor.** In the product a lane is one NIM credential with its own rate window, 1:1 with keys — and Settings already said "keys". Collapsing `lane` → **key** removes a term and a mental model at once.

The rest is one-for-one from the vocabulary table: `Harness`/`Harnesses` → **Client**/**Clients**, `Conversation stickiness` → **Session affinity**, `Model-pressure governor` → **Model limits**, `Where time goes` → **Latency breakdown**, `Rate-limit pressure` → **Throttling**, `Historical provisioning` → **Capacity history**, `rpm short at peak` → **Peak shortfall**, `Keyed` → **API key required**.

`Shed · 401 · failed logins` becomes three separate rows (**Dropped**, **Unauthorized**, **Failed logins**). That one is worth calling out: the `·`-stacked composite packed three unrelated counters into one row and one value cell, which no layout survives translation of.

## How it was tested

```sh
$ cargo fmt --check          # clean
$ cargo clippy --all-targets -- -D warnings    # zero warnings
$ cargo test
test result: ok. 120 passed; 0 failed    # unit
test result: ok.  90 passed; 0 failed    # e2e

# identifier guard — every one of these must be unchanged
$ grep -oE "sortTable\(\\\$\('[a-z-]+'\), '[a-z]+'" src/dashboard.html
...('table-harness'), 'harness' ...('table-clients'), 'clients'   # still distinct

$ grep -o 'esc(' src/dashboard.html | wc -l     # 48 — unchanged
$ grep -c 'innerHTML *=' src/dashboard.html     # 45 — unchanged
```

One e2e test asserted on old label text and was updated: `dashboard_historical_provisioning_has_no_guessed_lane_size` → `dashboard_capacity_history_has_no_guessed_key_size`, now asserting on `Peak shortfall`, `of capacity at the time`, and `with no capacity data`. Its actual guarantee — that no key size is guessed — is unchanged.

## Screenshots / output

**None, and this is the gap in this PR.** There is no headless browser in CI and I did not render the change. Three things want your eye:

1. **The API-mode pills.** `Open` → `Open (no authentication)` and `Keyed` → `API key required` are considerably longer than what they replace, inside narrow pill buttons in a `<span class="pills">` row. This is the most likely place for a layout break.
2. **`Slots in use` / `Capacity used`** lost their `· Now` suffix per the vocabulary; the `Now` tag still exists elsewhere on those cards, so check it doesn't read as ambiguous.
3. **The three-row health strip** where one composite row used to be — the Overview health strip is now three rows taller.

## Breaking changes & migration

None for operators. No config key, env var, `/v1` surface, route, or store-format change. Anyone who scripted against dashboard *text* would notice, but that was never an interface.

## Checklist

### Code quality
- [x] `cargo fmt --check` is clean.
- [x] `cargo clippy --all-targets -- -D warnings` is clean.
- [x] `cargo test` passes locally (unit + end-to-end).
- [x] Existing guard tests still pass; the one label-asserting test was updated to the new labels rather than deleted.
- [x] Scope is tight; commit message explains the *why*.

### Docs & knowledge base
- [x] README updated — the dashboard tour and Settings enumeration name the new labels.
- [x] Affected `knowledge/` pages updated in this PR: `architecture/dashboard.md`, `ops/configure-env.md`.
- [x] No new decision page — the terminology was settled before this PR; this applies it.
- [x] Dated entry appended to `knowledge/log.md`, including the lint note below.
- [x] `CHANGELOG.md` `[Unreleased]` updated.

### Security — triggered (dashboard `innerHTML`)
- [x] Fail-closed posture untouched — no auth, session, or store logic in this diff.
- [x] Every dynamic value written to `innerHTML` still goes through `esc()`; count and position unchanged at 48. No `innerHTML` → `textContent` conversions. Label sanitizing in `proxy.rs` untouched.
- [x] Reviewed against the auth-posture and input-sanitizing decision pages. Every changed string is a static literal — no new interpolation of dynamic data was introduced, and no catalog value reaches an attribute, URL, or JS context.

### Rate-limiting
- [ ] ~~Load harness~~ — not applicable. No pacing, pool, dispatcher, affinity, or governor code in this diff.

### Workflows & supply chain
- [ ] ~~Actions pinning / actionlint / zizmor~~ — no workflow files touched.
- [ ] ~~Release runbook~~ — version bump happens in the release commit.

## Known divergence, deliberate

The interface now says **key** while the Prometheus exposition still says **lane** — `nimproxy_lane_requests_total`, and the `lane` label on `nimproxy_lane_cooldown_total`. Renaming a second series would be another breaking change and 0.6.6 already carries one, so the metric names stand. `README.md`'s architecture section likewise still says "lane", because it describes the code, which has not been renamed. Recorded as a lint note in `knowledge/log.md` so it is a known divergence rather than a drift.

Two places where the vocabulary table was terse and I made a judgment call, both easy to reverse: `rpm total` → `Total N rpm` and `rpm free` → `N rpm available` (the table gives the label word, not the phrasing, and `rpm` is on the never-translate list). Similarly the live-state control now reads **Live** / **Idle** / **Disconnected** while the range line reads **● Live** / **○ Absolute** — that split uses each of the table's four targets exactly once, which is the only reading where none of them go unused.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVr7XeojzNNHRKTkSMCccL)_