### PR TITLE
Make the repo's agent instructions load automatically, and make them operational

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,10 @@
 nim-proxy is a Rust proxy that makes NVIDIA NIM's free tier usable for agent
 harnesses: it paces requests to the per-key rate limit, load-balances across
 keys, and keeps client connections alive while it waits. Source lives in
-`src/` (`main.rs`, `proxy.rs`, `pool.rs`, `dispatch.rs`, `history.rs`,
-`auth.rs`, `dashboard.html`), tests in `tests/`, load harness in `scripts/`.
+`src/` (`main.rs`, `lib.rs`, `proxy.rs`, `pool.rs`, `dispatch.rs`,
+`governor.rs`, `history.rs`, `config.rs`, `settings.rs`, `auth.rs`,
+`dashboard.html`, `setup.html`), tests in `tests/`, scripts and harnesses in
+`scripts/`, translations in `locales/`.
 
 Auth lives in `src/auth.rs` (fail-closed posture, admin-password session
 cookie, constant-time compares); the API-key gate and label sanitizing are in
@@ -12,25 +14,104 @@ cookie, constant-time compares); the API-key gate and label sanitizing are in
 `innerHTML` must keep the security invariants — see the `decisions/` pages on
 auth posture and input sanitizing before editing.
 
-## Working on the code
+## How to work here
 
-- `cargo test` runs the unit suite plus an end-to-end suite that launches the
-  real binary against a scriptable mock (see `tests/support/mod.rs`).
-- `cargo fmt` and `cargo clippy --all-targets -- -D warnings` must stay clean
-  (CI enforces both).
-- Rate-limit changes must pass the load harness:
-  `scripts/mock_nim.py --enforce` + `scripts/loadtest.py` — zero upstream
-  violations is a hard requirement, not a target.
-- The dashboard is one embedded file, `src/dashboard.html` — no build step,
-  no external assets except optional CDN logos with an offline fallback.
+**Plan → Act → Verify, at every scale.** Not once per release — once per task,
+and again per subtask. A "task" is any edit you are about to make.
+
+Before editing, write down three things:
+
+1. **Outcome** — what will be true after this change that is not true now.
+2. **Proof** — the exact command or observation that will show it, *and how it
+   would look if the change were wrong*. If you cannot describe the failing
+   case, you do not have a check; find a different proof.
+3. **Constraint** — which `knowledge/` page governs this area. Read it. The
+   reasoning that limits your change is probably already recorded.
+
+Then act. Then run the proof you named — not a different, easier one, and not
+a batch of unrelated green checks at the end.
+
+Write the check first when the change is behavioral. A test that has never
+been observed to fail has not been shown to test anything: make it fail, then
+make it pass. This is why `scripts/locale_v1.py --selftest` exists, and why
+the locale fixtures were committed one commit before the validator.
+
+**Report what happened.** If a check was skipped, say it was skipped. A green
+summary that omits the unrun check is worse than no summary.
+
+## Before adding anything new
+
+Run every proposed file, script, dependency, abstraction, or workflow down
+this ladder and stop at the first rung that answers:
+
+1. Does this need to exist? → no: skip it.
+2. Already in this codebase? → reuse it, don't rewrite.
+3. Stdlib does it? → use it.
+4. Native platform feature? → use it. (`Intl`, `Intl.PluralRules`,
+   `<dialog>`, CSS — the pages have no build step and no framework.)
+5. Installed dependency? → use it.
+6. One line? → one line.
+7. Only then: the minimum that works.
+
+Say which rung you landed on and why the ones above it did not apply. New
+components are pinned at the version you got working (`=x.y.z`).
+
+## What proves what
+
+`cargo test` **does not validate the embedded pages.** It asserts on served
+HTML *text* and never parses or executes the page JavaScript. Every page bug
+this project has shipped got past a green `cargo test`. Pick the check that
+actually covers what you changed:
+
+| Change | What proves it |
+|---|---|
+| Rust logic | `cargo test` (unit + e2e), `cargo clippy --all-targets -- -D warnings` |
+| Anything in `dashboard.html` / `setup.html` | `node --check` on each extracted `<script>` — syntax only; necessary, never sufficient |
+| Page *behavior* | render it headless with real API payloads and read the console; nothing else proves the code ran |
+| Number/date/duration formatting | `TZ=UTC LC_ALL=en_US.UTF-8 node scripts/formatter_fixture.js --check` (golden; extracts the real function bodies, and refuses to run unpinned) |
+| Strings, catalog, any new UI text | `python3 scripts/check_i18n.py` (round-trip + untagged-string lint) |
+| A locale file | `python3 scripts/locale_v1.py --all`; `--selftest` proves the validator still bites |
+| Any change to English source text | `python3 scripts/gen_pseudolocale.py --check` |
+| Pacing, key pool, dispatcher, affinity | `scripts/mock_nim.py --enforce` + `scripts/loadtest.py` — **zero** upstream violations, not "few" |
+| Anything at all, before pushing | `cargo fmt` |
+
+CI enforces all of the above. Green CI on a page change means the syntax
+parsed, not that the page works.
+
+## Traps this repo has actually sprung
+
+Real bugs that reached a branch here. Pattern-match against them before
+claiming a sweep is done:
+
+- **Blanket renames hit unrelated identifiers.** A `window` → `time range`
+  label sweep silently renamed the rate-limit *window* counter. Never
+  search-and-replace a word that is both a label and a domain term; enumerate
+  the sites and decide each one.
+- **Measuring the page at rest measures nothing.** KPI cards, ring gauges,
+  perf blocks and table bodies do not exist in the DOM until data arrives. Any
+  claim about rendered output has to be measured with API payloads replayed
+  into the page.
+- **Escape once.** Catalog values are escaped at load
+  (`decisions/message-catalog-and-escaping.md`). A second escape at the render
+  site produced `&amp;lt;` in table headers; `t()` escapes, `tRaw()` does not,
+  and four render helpers do not escape their arguments.
+- **Strings passed as arguments hide from string sweeps.** The leaks that
+  survived extraction were all label/note arguments to `ringGauge`,
+  `perfBlock` and `prow`, not text sitting in markup.
+- **Ordering.** A static-apply pass that runs after the tab-restore loop
+  applies to markup that has already been replaced.
+- **`${...}` inside single quotes** is not a template literal, and
+  **`const t`** shadows the translation function. Both parse fine.
 
 ## The knowledge base (`knowledge/`)
 
 `knowledge/` is an Open Knowledge Format bundle (the LLM-wiki pattern): the
 project's compiled memory — why decisions were made, validated research about
 NIM, how components work, and operational runbooks. **Read
-`knowledge/index.md` before making non-trivial changes**; the reasoning that
-constrains your change is probably recorded there.
+`knowledge/index.md` before making non-trivial changes**, and read the
+decision page for the area you are about to touch before you touch it. The
+constraint is usually already written down, and contradicting your own
+decision page is the most common way work here goes wrong.
 
 Schema:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-@AGENTS.md
+AGENTS.md


### PR DESCRIPTION
## Summary

`AGENTS.md` described the project but never said how to work in it, and
`CLAUDE.md` did not exist — so nothing was loaded into an agent's context
automatically and the guidance that would have prevented this release's bugs
was not written anywhere an agent would look. This makes `CLAUDE.md` a symlink
to `AGENTS.md`, and turns `AGENTS.md` from a description into an operating
procedure.

Docs only. No source, no CI, no dependency. Targets `release/v0.6.6`.

## Type of change

- [ ] Bug fix (no behavior change beyond the fix)
- [ ] New feature / behavior change
- [ ] Performance / rate-limiting
- [ ] Security / hardening
- [ ] Refactor (no behavior change)
- [x] Docs / knowledge base only
- [ ] CI / build / release infrastructure
- [ ] Release (version bump)

## Related issues

None. Part of the 0.6.6 rationalization series; this one is process rather
than product.

## What & why

**`CLAUDE.md` → `AGENTS.md`, as a symlink.** `CLAUDE.md` is loaded into an
agent's context at session start; `AGENTS.md` is only ever read if the agent
chooses to read it. A symlink makes the repo's instructions unconditional
while keeping `AGENTS.md` as the single file that gets edited — and because
it is a symlink rather than a pointer file, opening `CLAUDE.md` *is* opening
the guide. There is no second read to follow, which is the whole point: an
indirection an agent has to act on is an indirection an agent can skip.

Git stores it as mode `120000`, so the link is the tracked object.

**`AGENTS.md` gains four sections**, each of which exists because its absence
cost this release real time:

1. **How to work here.** Plan → Act → Verify stated at *task* scale, with the
   plan required to name the proof *and the failing case* before the edit.
   Writing this down matters because the failures in this release were not at
   the release-plan scale — they were individual edits made with no stated
   expectation and no check.

2. **Before adding anything new.** The minimality ladder, so a proposed file,
   script, dependency or abstraction has to justify itself against reuse and
   native platform capability first, and the answer has to name the rung.

3. **What proves what.** A table mapping each kind of change to the check that
   covers it. It is led by the single most load-bearing fact about this
   codebase: **`cargo test` does not validate the embedded pages.** It asserts
   on served HTML text and never parses or executes the page JavaScript. Every
   page bug in this release got past a green `cargo test`, and knowing that up
   front is the difference between "tests pass" and "I checked".

4. **Traps this repo has actually sprung.** Six real bugs from this release —
   blanket renames hitting a domain identifier, measuring the page at rest,
   double-escaping a value that was already escaped at load, strings hiding as
   render-helper arguments, an apply pass ordered after the markup it targets,
   `${...}` inside single quotes — written down so the next sweep
   pattern-matches instead of rediscovering them.

### Alternatives weighed

- *A one-line `CLAUDE.md` containing `@AGENTS.md`.* This is what the first
  commit on this branch did, and it was wrong: it re-introduces exactly the
  optional second read the file exists to eliminate. Replaced with the
  symlink in `86fcdfb`.
- *Duplicate the content into `CLAUDE.md`.* Two copies of one thing, and the
  one being edited would drift from the one being loaded.
- *Put the operating guidance in `CONTRIBUTING.md` instead.* That file is
  aimed at human contributors and covers process (issues, review, releases).
  These are working instructions for whoever is editing, and `AGENTS.md`
  already had the audience.

## How it was tested

Every command named in the new "What proves what" table was run before
committing, on this branch:

```sh
$ python3 scripts/check_i18n.py
i18n OK — 166 ids referenced, round-trip clean

$ python3 scripts/locale_v1.py --all
locale-v1 ok — 2 locale(s) clean

$ python3 scripts/locale_v1.py --selftest
selftest ok — 9 fixtures, every check observed to fail

$ python3 scripts/gen_pseudolocale.py --check
en-XA up to date — 166 messages across 2 catalogs

$ TZ=UTC LC_ALL=en_US.UTF-8 node scripts/formatter_fixture.js --check
formatters unchanged — 125 cases
```

That run is why the table is correct rather than plausible: the first draft of
the formatter row omitted the environment, and the script **refuses to run
unpinned** (`refusing to run: set TZ=UTC so the fixture is reproducible`). The
row now carries `TZ=UTC LC_ALL=en_US.UTF-8`, matching what CI does.

The symlink was verified as a symlink, not as a file that happens to contain a
path:

```sh
$ git ls-files -s CLAUDE.md
120000 47dc3e3d863cfb5727b87d785d09abf9743c0a72 0	CLAUDE.md

$ head -1 CLAUDE.md
# Agent guide for nim-proxy
```

The source-file list was checked against `ls src/`. `api.rs` and the
`UPDATE_OPENAPI=1` regeneration row are **deliberately absent** — they arrive
with the typed-responses PR and would have described a tree that does not
exist at this commit. They get added when that PR lands, which is exactly the
lockstep rule this file is asking for.

## Screenshots / output

N/A — no user-facing surface changes.

## Breaking changes & migration

None. No config key, env var, `/v1` behavior, or on-disk format is touched.

## Checklist

### Code quality
- ~~`cargo fmt --check`~~ / ~~`cargo clippy`~~ / ~~`cargo test`~~ — N/A: no
  Rust source in the diff. CI runs them anyway and they are green.
- ~~New behavior ships with tests~~ — N/A: no behavior. The verification that
  applies to a claims-making document is running the claims, which is in
  "How it was tested" above.
- [x] Scope is tight; commit messages explain the *why*.

### Docs & knowledge base
- ~~README / `examples/`~~ — N/A: no user-facing behavior or setup changed.
- [x] No `knowledge/` page contradicts this change; the new "What proves what"
      table is consistent with `knowledge/testing/test-strategy.md`, and the
      trap list restates constraints already recorded in
      `knowledge/decisions/message-catalog-and-escaping.md` and
      `knowledge/decisions/locale-guards.md` rather than adding new ones.
- ~~New decision page~~ — N/A: this records no new architectural decision. It
  writes down how to work, not what to build. `knowledge/` remains the *why*
  of the product; `AGENTS.md` is the *how* of contributing to it.
- ~~`knowledge/log.md` entry~~ — N/A per the above: nothing was ingested into
  the knowledge base.
- ~~`CHANGELOG.md`~~ — N/A: Keep a Changelog documents what changes for users
  of the proxy. Contributor instructions are not part of that surface.

### Security
- ~~Required-if~~ — N/A: touches no auth path, no config, no settings, no
  API-key gate, no label sanitizing, and no `innerHTML` sink. The diff is one
  Markdown file and one symlink.

### Rate-limiting
- ~~Load harness~~ — N/A: nothing touches pacing, the key pool, the
  dispatcher, or affinity.

### Workflows & supply chain
- ~~Actions pinning~~ — N/A: `.github/workflows/**` is untouched, no Action
  added or changed, and no dependency added. Ladder rung 6: the whole
  mechanism is one symlink.
- ~~Release / version changes~~ — N/A: no version bump.