### PR TITLE
fix: normalize control-plane JSON errors

### DIFF
--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -283,11 +283,11 @@ setup POST routes. **Proof:** Raw E2E error bytes and unchanged config-store
 bytes. **Constraint:** setup GET, login/form, health, metrics, and `/v1` stay
 outside this change. **Ponytail Rung:** 5 — use Axum extractors and fallbacks.
 
-- 2026-07-30: red regression check committed after the required observed
-  failure: `cargo test --test e2e control_plane_rejections_are_typed --
-  --exact` failed at `POST /api/settings/upstream`, whose missing JSON
-  `Content-Type` rejection was Axum `text/plain; charset=utf-8` instead of the
-  required `application/json` error envelope.
+- 2026-07-30: correction to the prior red record: `cargo test --test e2e
+  control_plane_rejections_are_typed -- --exact` stopped at its first row,
+  malformed JSON at `POST /api/settings/upstream`; its Axum plain-text
+  response failed the required `application/json` assertion. It did not reach
+  the later missing-Content-Type row.
 - 2026-07-30: implementation adds `ApiJson`/`ApiQuery`, nested control-plane
   fallbacks, and typed post-claim setup conflicts. Green verification is
   complete: the named rejection test passed; `cargo test` passed 127 unit,
@@ -296,6 +296,12 @@ outside this change. **Ponytail Rung:** 5 — use Axum extractors and fallbacks.
   --all-targets -- -D warnings` was attempted but this environment's Cargo
   1.93.1 installation has no `clippy` subcommand or discoverable
   `cargo-clippy`/`clippy-driver`; the skipped check is recorded for review.
+- 2026-07-30: independent review found the nested fallback bypassed the
+  parent `route_layer`, closed setup POSTs parsed before their phase check,
+  and a claim race returned `already_configured`. Supplementary red evidence
+  is committed before the repair: unknown `/api/*` returned 404 rather than
+  pre-setup 503; malformed closed setup POST returned 400 rather than 409;
+  and the race body had `already_configured` rather than `setup_complete`.
 
 **GitHub issue title:** `v0.6.6: normalize control-plane JSON errors`
 

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -276,6 +276,19 @@ changing it.
 
 ### Task 1: Normalize JSON control-plane rejection contracts
 
+#### Execution record
+
+**Outcome:** One typed JSON rejection boundary for JSON control-plane and
+setup POST routes. **Proof:** Raw E2E error bytes and unchanged config-store
+bytes. **Constraint:** setup GET, login/form, health, metrics, and `/v1` stay
+outside this change. **Ponytail Rung:** 5 — use Axum extractors and fallbacks.
+
+- 2026-07-30: red regression check committed after the required observed
+  failure: `cargo test --test e2e control_plane_rejections_are_typed --
+  --exact` failed at `POST /api/settings/upstream`, whose missing JSON
+  `Content-Type` rejection was Axum `text/plain; charset=utf-8` instead of the
+  required `application/json` error envelope.
+
 **GitHub issue title:** `v0.6.6: normalize control-plane JSON errors`
 
 **Files:**

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -302,6 +302,42 @@ outside this change. **Ponytail Rung:** 5 — use Axum extractors and fallbacks.
   is committed before the repair: unknown `/api/*` returned 404 rather than
   pre-setup 503; malformed closed setup POST returned 400 rather than 409;
   and the race body had `already_configured` rather than `setup_complete`.
+- 2026-07-30: repair keeps the complete `/api` subtree inside
+  `require_session`, performs the setup phase check before extracting either
+  setup POST body, and uses the same `setup_complete` helper for the race
+  loser. Focused green proof passed: `unknown_control_plane_paths_are_gated_before_fallback`,
+  `closed_setup_posts_win_before_body_rejections`,
+  `setup_double_claim_is_rejected_with_409`, and the all-row
+  `control_plane_rejections_are_typed` matrix. The oversized setup proof uses
+  `Expect: 100-continue` and only a declared over-limit Content-Length, so it
+  demonstrates 409 before body buffering rather than relying on a client-side
+  broken pipe. The decision and client-auth component now distinguish bare
+  setup GET 404 from typed closed setup POST 409.
+- 2026-07-30: complete repair gate passed: `UPDATE_OPENAPI=1 cargo test
+  --test openapi` and `cargo test --test openapi` (2 each), `cargo test`
+  (127 unit, 94 E2E, 2 OpenAPI), `PATH=/home/tchawes/.local/bin:$PATH cargo
+  clippy --all-targets -- -D warnings`, `cargo fmt --check`, `git diff --check`,
+  and `git diff --exit-code -- openapi.json`. Clippy is now installed and was
+  not skipped.
+- 2026-07-30: supplementary red proof (reverted, never committed): replacing
+  the shared `api_error_response` code with `fault_injected` made the
+  all-row matrix report the body-limit, query, not-found, and method rows as
+  well as the earlier JSON/media rows; replacing only `setup_complete` with
+  that code reported both setup POST rows. This proves the strengthened table
+  collects later classes instead of stopping at its first failure.
+- 2026-07-30: pre-commit repair review added three proof hardenings: the raw
+  `Expect: 100-continue` response read is capped at 4 KiB plus a sentinel byte
+  under its existing two-second timeout; the all-row matrix records a missing
+  Content-Type instead of indexing/panicking; and a fresh-setup E2E table now
+  proves both manual setup extractors retain malformed, missing/wrong-media,
+  and 64 MiB body-limit `ApiError` responses without creating `config.json`.
+  A reverted mutation that replaced the open `/setup` extractor rejection with
+  a raw 400 made that new test fail on its missing Content-Type, confirming the
+  test reaches the manual-extraction failure branch.
+- 2026-07-30: final pre-commit repair review approved the complete delta with
+  zero blocking or nonblocking findings. The final full gate passed with 127
+  unit, 94 E2E, and 2 OpenAPI tests; both OpenAPI checks, installed Clippy,
+  formatting, diff checks, and the unchanged generated spec passed too.
 
 **GitHub issue title:** `v0.6.6: normalize control-plane JSON errors`
 
@@ -314,6 +350,7 @@ outside this change. **Ponytail Rung:** 5 — use Axum extractors and fallbacks.
 - Modify: `tests/openapi.rs`
 - Modify: `openapi.json`
 - Modify: `knowledge/decisions/typed-responses-and-generated-openapi.md`
+- Modify: `knowledge/architecture/client-auth.md`
 - Modify: `knowledge/testing/test-strategy.md`
 - Modify: `knowledge/log.md`
 

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -288,6 +288,14 @@ outside this change. **Ponytail Rung:** 5 — use Axum extractors and fallbacks.
   --exact` failed at `POST /api/settings/upstream`, whose missing JSON
   `Content-Type` rejection was Axum `text/plain; charset=utf-8` instead of the
   required `application/json` error envelope.
+- 2026-07-30: implementation adds `ApiJson`/`ApiQuery`, nested control-plane
+  fallbacks, and typed post-claim setup conflicts. Green verification is
+  complete: the named rejection test passed; `cargo test` passed 127 unit,
+  91 E2E, and 2 OpenAPI tests; the OpenAPI regenerate/check pair passed; and
+  `cargo fmt --check` plus `git diff --check` passed. `cargo clippy
+  --all-targets -- -D warnings` was attempted but this environment's Cargo
+  1.93.1 installation has no `clippy` subcommand or discoverable
+  `cargo-clippy`/`clippy-driver`; the skipped check is recorded for review.
 
 **GitHub issue title:** `v0.6.6: normalize control-plane JSON errors`
 

--- a/knowledge/architecture/client-auth.md
+++ b/knowledge/architecture/client-auth.md
@@ -32,9 +32,11 @@ true:
   response carries the `npk_` secret exactly once, so a fresh keyed-mode proxy
   serves `/v1` with no Settings detour.
 
-Post-setup the setup routes 404 (gated on the AtomicBool). Boot logs a loud
-`SETUP REQUIRED — the FIRST VISITOR becomes the superuser` line — the claim
-window is [accepted risk](../decisions/ui-managed-config-store.md).
+Post-setup `GET /setup` is a bare 404 (gated on the AtomicBool), while
+`POST /setup` and `POST /setup/validate-key` return the typed
+`409 setup_complete` conflict before inspecting their JSON request bodies.
+Boot logs a loud `SETUP REQUIRED — the FIRST VISITOR becomes the superuser`
+line — the claim window is [accepted risk](../decisions/ui-managed-config-store.md).
 
 ## API gate — `/v1/*` (`src/proxy.rs`)
 

--- a/knowledge/decisions/typed-responses-and-generated-openapi.md
+++ b/knowledge/decisions/typed-responses-and-generated-openapi.md
@@ -80,6 +80,24 @@ for a `user`, so the type says what the security posture already required.
   not every path the router answers.
 - **No served UI**, per option 2.
 
+### JSON rejection boundary
+
+The protected `/api/*` router and the two setup **POST** routes use the same
+typed rejection boundary. `ApiJson<T>` delegates parsing and the configured
+`DefaultBodyLimit` to Axum, then translates syntax/data failures to
+`invalid_json` (preserving Axum's existing 400 syntax and 422 data statuses), missing or unsuitable JSON media types to
+`unsupported_media_type`, and a limit hit to `body_too_large`. `ApiQuery<T>`
+translates dashboard-query decoding failures to `invalid_query`. The nested
+control-plane router supplies `not_found` and `method_not_allowed` fallbacks,
+so these framework-level rejections serialize as `ApiError` too.
+
+This boundary is intentionally narrow: setup **GET** retains its HTML/bare-404
+contract, and login/form, health, metrics, and `/v1` retain their existing
+contracts. After a claim, setup POSTs answer the typed `409 setup_complete`
+conflict; the page GET remains a bare 404. The generated spec documents each
+non-success dashboard/setup response with the `ApiError` schema, and its test
+rejects an untyped non-2xx response.
+
 ### Field order is the wire order
 
 The load-bearing detail. `serde` emits struct fields in **declaration order**;
@@ -135,3 +153,6 @@ every `/setup` operation explicitly waiving it.
 - The spec is a file, not a page. Operators who want a browsable UI can point
   any offline viewer at `openapi.json`; nothing is served, so the CSP and the
   scratch image are untouched.
+- Malformed JSON, wrong media type, request-size, query, route, method, and
+  post-claim setup failures now have stable codes and one raw-byte E2E matrix.
+  Every row also asserts that `config.json` is byte-identical after rejection.

--- a/knowledge/decisions/typed-responses-and-generated-openapi.md
+++ b/knowledge/decisions/typed-responses-and-generated-openapi.md
@@ -71,8 +71,9 @@ for a `user`, so the type says what the security posture already required.
   undocumented would not make them less reachable. They sit outside the
   `route_layer` because no user exists yet, so they carry an explicit empty
   `security: []` — the document-level requirement (session cookie *or* header
-  credentials) applies to everything else. Both 404 the moment a superuser
-  exists, so the window is exactly one claim wide.
+  credentials) applies to everything else. Once a superuser exists, the page
+  `GET /setup` is a bare 404 while either setup POST is a typed 409
+  `setup_complete` conflict, so the claim window is exactly one claim wide.
 - **Out of scope, deliberately:** the OpenAI-compatible `/v1` passthrough (that
   contract is the upstream's, not ours), the HTML page routes, the
   form-encoded `/login`/`/logout` browser flow, plain-text `/health`, and the
@@ -93,7 +94,8 @@ so these framework-level rejections serialize as `ApiError` too.
 
 This boundary is intentionally narrow: setup **GET** retains its HTML/bare-404
 contract, and login/form, health, metrics, and `/v1` retain their existing
-contracts. After a claim, setup POSTs answer the typed `409 setup_complete`
+contracts. After a claim, setup POSTs check that phase before inspecting JSON
+headers or buffering the body and answer the typed `409 setup_complete`
 conflict; the page GET remains a bare 404. The generated spec documents each
 non-success dashboard/setup response with the `ApiError` schema, and its test
 rejects an untyped non-2xx response.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,23 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-30] decision — typed JSON control-plane rejections
+
+The JSON control-plane and setup POST boundary now translates Axum extractor,
+body-limit, route, and method failures into the stable `ApiError` envelope.
+Recorded in [typed-responses-and-generated-openapi](decisions/typed-responses-and-generated-openapi.md).
+
+- `ApiJson` owns syntax/data, media-type, and body-limit normalization;
+  `ApiQuery` owns query normalization; the nested `/api/*` router owns only
+  its not-found and method fallbacks. Login/form, setup GET, health, metrics,
+  and `/v1` remain outside the boundary.
+- Post-claim setup POSTs now conflict with `409 setup_complete`; setup GET
+  remains a bare 404. The generated OpenAPI responses use `ApiError` for every
+  documented non-2xx API response.
+- The committed E2E table checks raw response bytes and unchanged
+  `config.json` bytes for every rejection row, rather than normalizing the
+  response through `serde_json::Value`.
+
 ## [2026-07-30] lint — enforce the agent-guide memory contract in CI
 
 PR CI now runs `python3 scripts/check_agent_guide.py --selftest`, which rejects

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,30 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-30] lint — bound raw setup-rejection proof and cover open extraction
+
+The raw `Expect: 100-continue` setup body-limit proof now caps its response
+read at 4 KiB plus a sentinel byte while retaining its two-second completion
+bound. The test also now covers the manual setup extraction path while setup
+is open, including malformed/media/body-limit rejections and no config-store
+creation. The all-row JSON rejection collector records an absent Content-Type
+as a row failure rather than panicking. See [test strategy](testing/test-strategy.md).
+
+## [2026-07-30] lint — complete the typed control-plane rejection gate
+
+Independent review found and the task proof now closes three boundary holes:
+the whole nested `/api` router, including its not-found fallback, is inside the
+session/setup gate; closed setup POSTs perform their phase check before JSON
+extraction or body buffering; and both the normal and racing claim-loser paths
+share `409 setup_complete`. The architecture and typed-response decision now
+also distinguish bare setup GET 404 from typed setup POST conflict.
+
+The new real-binary E2E proof holds an over-limit setup request at
+`Expect: 100-continue`, asserting the 409 response before 64 MiB can be sent;
+it also covers malformed and media-type request variants, fallback gating, and
+the persisted race outcome. See [test strategy](testing/test-strategy.md) and
+[typed responses](decisions/typed-responses-and-generated-openapi.md).
+
 ## [2026-07-30] decision — typed JSON control-plane rejections
 
 The JSON control-plane and setup POST boundary now translates Axum extractor,

--- a/knowledge/testing/test-strategy.md
+++ b/knowledge/testing/test-strategy.md
@@ -105,6 +105,12 @@ Two tests exist purely so the JSON contract cannot move by accident (see
   asserts the document is consumable — 14 operations, each tagged with a
   documented 200, `/api/*` inheriting the auth requirement and `/setup`
   explicitly waiving it.
+- `control_plane_rejections_are_typed` sends raw requests through the real
+  binary for malformed JSON, JSON media-type failures, body-size rejection,
+  invalid dashboard query, unknown/method-mismatched `/api/*`, and post-claim
+  setup POSTs. It asserts status, `application/json`, exact `ApiError` bytes,
+  and unchanged `config.json` bytes. Run it with `cargo test --test e2e
+  control_plane_rejections_are_typed -- --exact`.
 
 ## 3. Load — `scripts/loadtest.py` vs `scripts/mock_nim.py --enforce`
 

--- a/knowledge/testing/test-strategy.md
+++ b/knowledge/testing/test-strategy.md
@@ -111,6 +111,20 @@ Two tests exist purely so the JSON contract cannot move by accident (see
   setup POSTs. It asserts status, `application/json`, exact `ApiError` bytes,
   and unchanged `config.json` bytes. Run it with `cargo test --test e2e
   control_plane_rejections_are_typed -- --exact`.
+- `unknown_control_plane_paths_are_gated_before_fallback` proves that the
+  control-plane fallback remains inside the setup/auth gate: a fresh install
+  returns `503 setup_required`, an anonymous configured install returns 401,
+  and an authenticated caller receives typed `404 not_found`.
+- `closed_setup_posts_win_before_body_rejections` proves both setup POSTs
+  answer `409 setup_complete` before malformed, missing/wrong-media, or
+  oversized bodies are parsed. Its oversized request sends only an over-limit
+  `Content-Length` with `Expect: 100-continue`, proving the route answers
+  before buffering 64 MiB. `setup_double_claim_is_rejected_with_409` also
+  checks the race loser emits that exact envelope.
+- `open_setup_posts_keep_typed_extractor_rejections` covers both manual setup
+  extractors while setup is still open: malformed JSON, missing/wrong media
+  types, and the bounded body limit retain the exact `ApiError` bytes and do
+  not create a config store.
 
 ## 3. Load — `scripts/loadtest.py` vs `scripts/mock_nim.py --enforce`
 

--- a/openapi.json
+++ b/openapi.json
@@ -340,7 +340,14 @@
             }
           },
           "422": {
-            "description": "A field is missing or the wrong type — a partial body is never a silent reset"
+            "description": "A field is missing or the wrong type — a partial body is never a silent reset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
           }
         }
       }
@@ -404,7 +411,14 @@
             }
           },
           "422": {
-            "description": "A field is missing or the wrong type — a partial body is never a silent reset"
+            "description": "A field is missing or the wrong type — a partial body is never a silent reset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
           }
         }
       }
@@ -468,7 +482,14 @@
             }
           },
           "422": {
-            "description": "A field is missing or the wrong type — a partial body is never a silent reset"
+            "description": "A field is missing or the wrong type — a partial body is never a silent reset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
           }
         }
       }
@@ -735,11 +756,8 @@
               }
             }
           },
-          "404": {
-            "description": "Setup is already complete"
-          },
           "409": {
-            "description": "Another caller claimed the proxy first",
+            "description": "Setup is already complete or another caller claimed the proxy first",
             "content": {
               "application/json": {
                 "schema": {
@@ -790,8 +808,15 @@
               }
             }
           },
-          "404": {
-            "description": "Setup is already complete"
+          "409": {
+            "description": "Setup is already complete",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
           },
           "429": {
             "description": "Probe throttle (shared with the login throttle)",

--- a/src/api.rs
+++ b/src/api.rs
@@ -715,6 +715,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn api_error_wire_order_is_exact() {
+        let body = serde_json::to_string(&ApiError::new("invalid_json", "invalid JSON"))
+            .unwrap();
+        assert_eq!(
+            body,
+            r#"{"error":{"code":"invalid_json","message":"invalid JSON","type":"proxy_error"}}"#
+        );
+    }
+
     /// The spec must actually describe every route the router serves.
     #[test]
     fn spec_covers_every_documented_route() {

--- a/src/api.rs
+++ b/src/api.rs
@@ -21,6 +21,11 @@
 //!
 //! See `knowledge/decisions/typed-responses-and-generated-openapi.md`.
 
+use axum::extract::rejection::JsonRejection;
+use axum::extract::{FromRequest, FromRequestParts, Request};
+use axum::http::{request::Parts, StatusCode};
+use axum::response::{IntoResponse, Response};
+use serde::de::DeserializeOwned;
 use serde::Serialize;
 use utoipa::openapi::security::{ApiKey, ApiKeyValue, HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::{Modify, OpenApi, ToSchema};
@@ -61,6 +66,95 @@ impl ApiError {
             },
         }
     }
+}
+
+/// A JSON extractor whose failures use the dashboard API's stable error
+/// envelope instead of Axum's framework-default text responses.
+pub struct ApiJson<T>(pub T);
+
+impl<T, S> FromRequest<S> for ApiJson<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        match axum::Json::<T>::from_request(req, state).await {
+            Ok(axum::Json(value)) => Ok(Self(value)),
+            Err(JsonRejection::MissingJsonContentType(_)) => Err(api_error_response(
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                "unsupported_media_type",
+                "Content-Type must be application/json",
+            )),
+            Err(JsonRejection::BytesRejection(rejection)) => {
+                let (status, code, message) = if rejection.status() == StatusCode::PAYLOAD_TOO_LARGE
+                {
+                    (
+                        StatusCode::PAYLOAD_TOO_LARGE,
+                        "body_too_large",
+                        "request body is too large",
+                    )
+                } else {
+                    (StatusCode::BAD_REQUEST, "invalid_json", "invalid JSON")
+                };
+                Err(api_error_response(status, code, message))
+            }
+            Err(JsonRejection::JsonDataError(_)) => Err(api_error_response(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "invalid_json",
+                "invalid JSON",
+            )),
+            Err(_) => Err(api_error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_json",
+                "invalid JSON",
+            )),
+        }
+    }
+}
+
+/// A query extractor whose failures use the dashboard API's stable error
+/// envelope instead of Axum's framework-default text responses.
+pub struct ApiQuery<T>(pub T);
+
+impl<T, S> FromRequestParts<S> for ApiQuery<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        match axum::extract::Query::<T>::from_request_parts(parts, state).await {
+            Ok(axum::extract::Query(value)) => Ok(Self(value)),
+            Err(_) => Err(api_error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_query",
+                "invalid query",
+            )),
+        }
+    }
+}
+
+fn api_error_response(status: StatusCode, code: &str, message: &str) -> Response {
+    (status, axum::Json(ApiError::new(code, message))).into_response()
+}
+
+/// The protected `/api/*` fallback. It is deliberately not installed on page,
+/// health, metrics, login/form, setup GET, or `/v1` routes.
+pub async fn api_not_found() -> Response {
+    api_error_response(StatusCode::NOT_FOUND, "not_found", "not found")
+}
+
+/// The protected `/api/*` method fallback. It has the same narrow scope as
+/// [`api_not_found`].
+pub async fn api_method_not_allowed() -> Response {
+    api_error_response(
+        StatusCode::METHOD_NOT_ALLOWED,
+        "method_not_allowed",
+        "method not allowed",
+    )
 }
 
 /// A settings write that applied. Success carries no data: the dashboard
@@ -717,8 +811,7 @@ mod tests {
 
     #[test]
     fn api_error_wire_order_is_exact() {
-        let body = serde_json::to_string(&ApiError::new("invalid_json", "invalid JSON"))
-            .unwrap();
+        let body = serde_json::to_string(&ApiError::new("invalid_json", "invalid JSON")).unwrap();
         assert_eq!(
             body,
             r#"{"error":{"code":"invalid_json","message":"invalid JSON","type":"proxy_error"}}"#

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ struct DashboardQuery {
 )]
 async fn api_dashboard(
     State(state): State<Arc<AppState>>,
-    axum::extract::Query(query): axum::extract::Query<DashboardQuery>,
+    api::ApiQuery(query): api::ApiQuery<DashboardQuery>,
 ) -> Response {
     let stored = state.store.lock().unwrap();
     let config_revision = state
@@ -536,21 +536,26 @@ pub async fn run() {
     // middleware requires an authenticated user (session cookie, or
     // user:password header credentials for scrapers); pre-setup it routes
     // everything to the wizard.
+    let control_plane = Router::new()
+        .route("/dashboard", get(api_dashboard))
+        .route("/dashboard/now", get(api_dashboard_now))
+        .route("/config", get(settings::api_config))
+        .route("/settings/nim-keys", post(settings::nim_keys))
+        .route("/settings/clients", post(settings::clients))
+        .route("/settings/upstream", post(settings::upstream))
+        .route("/settings/limits", post(settings::limits))
+        .route("/settings/history", post(settings::history))
+        .route("/settings/governor", post(settings::governor_cfg))
+        .route("/settings/users", post(settings::users))
+        .route("/settings/account", post(settings::account))
+        .route("/settings/validate-key", post(settings::validate_key))
+        .fallback(api::api_not_found)
+        .method_not_allowed_fallback(api::api_method_not_allowed);
+
     let protected = Router::new()
         .route("/", get(dash))
         .route("/dash", get(dash))
-        .route("/api/dashboard", get(api_dashboard))
-        .route("/api/dashboard/now", get(api_dashboard_now))
-        .route("/api/config", get(settings::api_config))
-        .route("/api/settings/nim-keys", post(settings::nim_keys))
-        .route("/api/settings/clients", post(settings::clients))
-        .route("/api/settings/upstream", post(settings::upstream))
-        .route("/api/settings/limits", post(settings::limits))
-        .route("/api/settings/history", post(settings::history))
-        .route("/api/settings/governor", post(settings::governor_cfg))
-        .route("/api/settings/users", post(settings::users))
-        .route("/api/settings/account", post(settings::account))
-        .route("/api/settings/validate-key", post(settings::validate_key))
+        .nest("/api", control_plane)
         .route("/metrics", get(metrics_text))
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -550,17 +550,21 @@ pub async fn run() {
         .route("/settings/account", post(settings::account))
         .route("/settings/validate-key", post(settings::validate_key))
         .fallback(api::api_not_found)
-        .method_not_allowed_fallback(api::api_method_not_allowed);
+        .method_not_allowed_fallback(api::api_method_not_allowed)
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            auth::require_session,
+        ));
 
     let protected = Router::new()
         .route("/", get(dash))
         .route("/dash", get(dash))
-        .nest("/api", control_plane)
         .route("/metrics", get(metrics_text))
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth::require_session,
-        ));
+        ))
+        .nest("/api", control_plane);
 
     // Public surface: health probe, login flow, the first-run wizard (404
     // once setup completes), and the API (its own key gate + setup gate).

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,8 +13,8 @@ use serde::Deserialize;
 use utoipa::ToSchema;
 
 use crate::api::{
-    ApiError, ClientKeyRow, ClientsResponse, ConfigResponse, HistorySettings, MintedClientKey,
-    NimKeyRow, OkResponse, PoolSummary, ServerSettings, SetupResponse, UserRow,
+    ApiError, ApiJson, ClientKeyRow, ClientsResponse, ConfigResponse, HistorySettings,
+    MintedClientKey, NimKeyRow, OkResponse, PoolSummary, ServerSettings, SetupResponse, UserRow,
     ValidateKeyResponse,
 };
 use crate::config::{self, NimKey, Role, StoredConfig, User};
@@ -106,17 +106,21 @@ pub struct SetupKey {
         (status = 200, description = "Claimed. Sets the session cookie; `client_key` carries \
             the minted secret, which is never retrievable again.", body = SetupResponse),
         (status = 400, description = "Weak password or a config the store rejects", body = ApiError),
-        (status = 404, description = "Setup is already complete"),
-        (status = 409, description = "Another caller claimed the proxy first", body = ApiError),
+        (status = 409, description = "Setup is already complete or another caller claimed the \
+            proxy first", body = ApiError),
     ),
 )]
 pub async fn setup_submit(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    axum::Json(req): axum::Json<SetupReq>,
+    ApiJson(req): ApiJson<SetupReq>,
 ) -> Response {
     if !state.setup_required.load(Ordering::SeqCst) {
-        return not_found();
+        return json_error(
+            StatusCode::CONFLICT,
+            "setup_complete",
+            "setup is already complete",
+        );
     }
     if req.password.len() < 10 {
         return json_error(
@@ -227,17 +231,21 @@ pub struct ValidateKeyReq {
         (status = 200, description = "Probe finished; `ok` says whether the key worked",
             body = ValidateKeyResponse),
         (status = 400, description = "`base_url` is not an allowed upstream", body = ApiError),
-        (status = 404, description = "Setup is already complete"),
+        (status = 409, description = "Setup is already complete", body = ApiError),
         (status = 429, description = "Probe throttle (shared with the login throttle)",
             body = ApiError),
     ),
 )]
 pub async fn setup_validate_key(
     State(state): State<Arc<AppState>>,
-    axum::Json(req): axum::Json<ValidateKeyReq>,
+    ApiJson(req): ApiJson<ValidateKeyReq>,
 ) -> Response {
     if !state.setup_required.load(Ordering::SeqCst) {
-        return not_found();
+        return json_error(
+            StatusCode::CONFLICT,
+            "setup_complete",
+            "setup is already complete",
+        );
     }
     if state.admin.is_throttled() {
         return json_error(
@@ -521,7 +529,7 @@ pub struct SetNimKey {
 pub async fn nim_keys(
     State(state): State<Arc<AppState>>,
     Extension(Identity(username)): Extension<Identity>,
-    axum::Json(req): axum::Json<NimKeysReq>,
+    ApiJson(req): ApiJson<NimKeysReq>,
 ) -> Response {
     let mut guard = state.store.lock().unwrap();
     let Some(role) = role_of(&guard, &username) else {
@@ -614,7 +622,7 @@ pub struct AddClient {
 pub async fn clients(
     State(state): State<Arc<AppState>>,
     Extension(Identity(username)): Extension<Identity>,
-    axum::Json(req): axum::Json<ClientsReq>,
+    ApiJson(req): ApiJson<ClientsReq>,
 ) -> Response {
     let mut guard = state.store.lock().unwrap();
     let Some(role) = role_of(&guard, &username) else {
@@ -684,13 +692,13 @@ macro_rules! admin_section {
                     body = ApiError),
                 (status = 403, description = "Server settings require an admin", body = ApiError),
                 (status = 422, description = "A field is missing or the wrong type — a partial \
-                    body is never a silent reset"),
+                    body is never a silent reset", body = ApiError),
             ),
         )]
         pub async fn $fn_name(
             State(state): State<Arc<AppState>>,
             Extension(Identity(username)): Extension<Identity>,
-            axum::Json(req): axum::Json<$req>,
+            ApiJson(req): ApiJson<$req>,
         ) -> Response {
             let mut guard = state.store.lock().unwrap();
             match role_of(&guard, &username) {
@@ -734,7 +742,7 @@ pub struct UpstreamReq {
 pub async fn upstream(
     State(state): State<Arc<AppState>>,
     Extension(Identity(username)): Extension<Identity>,
-    axum::Json(req): axum::Json<UpstreamReq>,
+    ApiJson(req): ApiJson<UpstreamReq>,
 ) -> Response {
     let result = {
         let mut guard = state.store.lock().unwrap();
@@ -908,7 +916,7 @@ fn parse_role(s: &str) -> Option<Role> {
 pub async fn users(
     State(state): State<Arc<AppState>>,
     Extension(Identity(username)): Extension<Identity>,
-    axum::Json(req): axum::Json<UsersReq>,
+    ApiJson(req): ApiJson<UsersReq>,
 ) -> Response {
     // Hash outside the store lock (PBKDF2 is deliberately slow).
     let new_hash = match (&req.add, &req.reset_password) {
@@ -1070,7 +1078,7 @@ pub async fn account(
     State(state): State<Arc<AppState>>,
     Extension(Identity(username)): Extension<Identity>,
     headers: HeaderMap,
-    axum::Json(req): axum::Json<AccountReq>,
+    ApiJson(req): ApiJson<AccountReq>,
 ) -> Response {
     if req.new_password.len() < 10 {
         return json_error(
@@ -1164,7 +1172,7 @@ pub async fn account(
 )]
 pub async fn validate_key(
     State(state): State<Arc<AppState>>,
-    axum::Json(req): axum::Json<ValidateKeyReq>,
+    ApiJson(req): ApiJson<ValidateKeyReq>,
 ) -> Response {
     let base = state.store.lock().unwrap().upstream.base_url.clone();
     let base = base.trim().trim_end_matches('/').to_owned();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -6,7 +6,7 @@
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-use axum::extract::State;
+use axum::extract::{FromRequest, Request, State};
 use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
@@ -54,6 +54,14 @@ fn json_error(status: StatusCode, code: &str, message: impl Into<String>) -> Res
 
 fn not_found() -> Response {
     StatusCode::NOT_FOUND.into_response()
+}
+
+fn setup_complete() -> Response {
+    json_error(
+        StatusCode::CONFLICT,
+        "setup_complete",
+        "setup is already complete",
+    )
 }
 
 /// `GET /setup` — the first-run wizard (404 once setup is complete).
@@ -110,18 +118,15 @@ pub struct SetupKey {
             proxy first", body = ApiError),
     ),
 )]
-pub async fn setup_submit(
-    State(state): State<Arc<AppState>>,
-    headers: HeaderMap,
-    ApiJson(req): ApiJson<SetupReq>,
-) -> Response {
+pub async fn setup_submit(State(state): State<Arc<AppState>>, req: Request) -> Response {
     if !state.setup_required.load(Ordering::SeqCst) {
-        return json_error(
-            StatusCode::CONFLICT,
-            "setup_complete",
-            "setup is already complete",
-        );
+        return setup_complete();
     }
+    let headers = req.headers().clone();
+    let ApiJson(req) = match ApiJson::<SetupReq>::from_request(req, &state).await {
+        Ok(req) => req,
+        Err(response) => return response,
+    };
     if req.password.len() < 10 {
         return json_error(
             StatusCode::BAD_REQUEST,
@@ -139,11 +144,7 @@ pub async fn setup_submit(
         let mut guard = state.store.lock().unwrap();
         if guard.superuser().is_some() {
             // Two claimers raced; the store lock made the first win whole.
-            return json_error(
-                StatusCode::CONFLICT,
-                "already_configured",
-                "setup was just completed by someone else",
-            );
+            return setup_complete();
         }
         let mut cand = guard.clone();
         cand.users = vec![User {
@@ -236,17 +237,14 @@ pub struct ValidateKeyReq {
             body = ApiError),
     ),
 )]
-pub async fn setup_validate_key(
-    State(state): State<Arc<AppState>>,
-    ApiJson(req): ApiJson<ValidateKeyReq>,
-) -> Response {
+pub async fn setup_validate_key(State(state): State<Arc<AppState>>, req: Request) -> Response {
     if !state.setup_required.load(Ordering::SeqCst) {
-        return json_error(
-            StatusCode::CONFLICT,
-            "setup_complete",
-            "setup is already complete",
-        );
+        return setup_complete();
     }
+    let ApiJson(req) = match ApiJson::<ValidateKeyReq>::from_request(req, &state).await {
+        Ok(req) => req,
+        Err(response) => return response,
+    };
     if state.admin.is_throttled() {
         return json_error(
             StatusCode::TOO_MANY_REQUESTS,

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1828,7 +1828,11 @@ async fn setup_wizard_claims_the_proxy() {
         .send()
         .await
         .unwrap();
-    assert_eq!(post_setup.status(), 404, "POST /setup 404 after claim");
+    assert_eq!(
+        post_setup.status(),
+        409,
+        "POST /setup conflicts after claim"
+    );
     let post_validate = client()
         .post(proxy.url("/setup/validate-key"))
         .json(&serde_json::json!({"key": "k"}))
@@ -1837,8 +1841,8 @@ async fn setup_wizard_claims_the_proxy() {
         .unwrap();
     assert_eq!(
         post_validate.status(),
-        404,
-        "POST /setup/validate-key 404 after claim"
+        409,
+        "POST /setup/validate-key conflicts after claim"
     );
 
     // The /v1 setup gate has lifted: it no longer answers 503 setup_required.
@@ -1986,7 +1990,13 @@ async fn control_plane_rejections_are_typed() {
         }
 
         let response = request.send().await.unwrap();
-        assert_eq!(response.status(), case.status, "{} {}", case.method, case.path);
+        assert_eq!(
+            response.status(),
+            case.status,
+            "{} {}",
+            case.method,
+            case.path
+        );
         assert_eq!(
             response.headers()["content-type"],
             "application/json",

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1855,6 +1855,167 @@ async fn setup_wizard_claims_the_proxy() {
     assert_eq!(v["error"]["code"], "unauthorized");
 }
 
+/// Every rejection from the JSON control plane keeps the same typed envelope
+/// and leaves the durable config store untouched. Removing the narrow
+/// extractors or `/api` fallbacks makes one or more rows answer Axum's plain
+/// text defaults instead.
+#[tokio::test]
+async fn control_plane_rejections_are_typed() {
+    struct RejectionCase {
+        method: reqwest::Method,
+        path: &'static str,
+        content_type: Option<&'static str>,
+        body: &'static str,
+        status: reqwest::StatusCode,
+        code: &'static str,
+        message: &'static str,
+        oversized: bool,
+    }
+
+    let mock = start_mock().await;
+    let proxy = start_proxy(&mock.url, &[]).await;
+    let cookie = login(&proxy).await;
+    let before = std::fs::read(proxy.data_dir.join("config.json")).unwrap();
+    let cases = [
+        RejectionCase {
+            method: reqwest::Method::POST,
+            path: "/api/settings/upstream",
+            content_type: Some("application/json"),
+            body: "{",
+            status: reqwest::StatusCode::BAD_REQUEST,
+            code: "invalid_json",
+            message: "invalid JSON",
+            oversized: false,
+        },
+        RejectionCase {
+            method: reqwest::Method::POST,
+            path: "/api/settings/upstream",
+            content_type: None,
+            body: r#"{"base_url":"http://example.invalid"}"#,
+            status: reqwest::StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            code: "unsupported_media_type",
+            message: "Content-Type must be application/json",
+            oversized: false,
+        },
+        RejectionCase {
+            method: reqwest::Method::POST,
+            path: "/api/settings/upstream",
+            content_type: Some("text/plain"),
+            body: r#"{"base_url":"http://example.invalid"}"#,
+            status: reqwest::StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            code: "unsupported_media_type",
+            message: "Content-Type must be application/json",
+            oversized: false,
+        },
+        RejectionCase {
+            method: reqwest::Method::POST,
+            path: "/api/settings/upstream",
+            content_type: Some("application/json"),
+            body: "",
+            status: reqwest::StatusCode::PAYLOAD_TOO_LARGE,
+            code: "body_too_large",
+            message: "request body is too large",
+            oversized: true,
+        },
+        RejectionCase {
+            method: reqwest::Method::GET,
+            path: "/api/dashboard?from=not-a-timestamp",
+            content_type: None,
+            body: "",
+            status: reqwest::StatusCode::BAD_REQUEST,
+            code: "invalid_query",
+            message: "invalid query",
+            oversized: false,
+        },
+        RejectionCase {
+            method: reqwest::Method::GET,
+            path: "/api/not-a-route",
+            content_type: None,
+            body: "",
+            status: reqwest::StatusCode::NOT_FOUND,
+            code: "not_found",
+            message: "not found",
+            oversized: false,
+        },
+        RejectionCase {
+            method: reqwest::Method::PUT,
+            path: "/api/dashboard",
+            content_type: None,
+            body: "",
+            status: reqwest::StatusCode::METHOD_NOT_ALLOWED,
+            code: "method_not_allowed",
+            message: "method not allowed",
+            oversized: false,
+        },
+        RejectionCase {
+            method: reqwest::Method::POST,
+            path: "/setup",
+            content_type: Some("application/json"),
+            body: r#"{"username":"another","password":"long-enough-password"}"#,
+            status: reqwest::StatusCode::CONFLICT,
+            code: "setup_complete",
+            message: "setup is already complete",
+            oversized: false,
+        },
+        RejectionCase {
+            method: reqwest::Method::POST,
+            path: "/setup/validate-key",
+            content_type: Some("application/json"),
+            body: r#"{"key":"another"}"#,
+            status: reqwest::StatusCode::CONFLICT,
+            code: "setup_complete",
+            message: "setup is already complete",
+            oversized: false,
+        },
+    ];
+
+    for case in cases {
+        let body = if case.oversized {
+            "x".repeat(64 * 1024 * 1024 + 1)
+        } else {
+            case.body.to_owned()
+        };
+        let mut request = client()
+            .request(case.method.clone(), proxy.url(case.path))
+            .body(body);
+        if case.path.starts_with("/api/") {
+            request = request.header("cookie", &cookie);
+        }
+        if let Some(content_type) = case.content_type {
+            request = request.header("content-type", content_type);
+        }
+
+        let response = request.send().await.unwrap();
+        assert_eq!(response.status(), case.status, "{} {}", case.method, case.path);
+        assert_eq!(
+            response.headers()["content-type"],
+            "application/json",
+            "{} {}",
+            case.method,
+            case.path
+        );
+        let body = response.bytes().await.unwrap();
+        assert_eq!(
+            body.as_ref(),
+            format!(
+                r#"{{"error":{{"code":"{}","message":"{}","type":"proxy_error"}}}}"#,
+                case.code, case.message
+            )
+            .as_bytes(),
+            "{} {}",
+            case.method,
+            case.path
+        );
+        assert_eq!(
+            std::fs::read(proxy.data_dir.join("config.json")).unwrap(),
+            before,
+            "{} {} changed config.json",
+            case.method,
+            case.path
+        );
+    }
+}
+
 /// The claim persists: after a restart on the same data dir, the created user
 /// can log in and the setup-provided key is still in the pool.
 #[tokio::test]

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -27,6 +27,21 @@ fn no_redirect_client() -> reqwest::Client {
         .unwrap()
 }
 
+async fn assert_exact_api_error(
+    response: reqwest::Response,
+    status: reqwest::StatusCode,
+    code: &str,
+    message: &str,
+) {
+    assert_eq!(response.status(), status);
+    assert_eq!(response.headers()["content-type"], "application/json");
+    assert_eq!(
+        response.bytes().await.unwrap().as_ref(),
+        format!(r#"{{"error":{{"code":"{code}","message":"{message}","type":"proxy_error"}}}}"#)
+            .as_bytes()
+    );
+}
+
 /// A keyed-`/v1` fixture: one client key (name, secret), otherwise defaults.
 fn keyed(name: &str, secret: &str) -> StoreOpts {
     StoreOpts {
@@ -1973,6 +1988,7 @@ async fn control_plane_rejections_are_typed() {
         },
     ];
 
+    let mut failures = Vec::new();
     for case in cases {
         let body = if case.oversized {
             "x".repeat(64 * 1024 * 1024 + 1)
@@ -1990,39 +2006,162 @@ async fn control_plane_rejections_are_typed() {
         }
 
         let response = request.send().await.unwrap();
-        assert_eq!(
-            response.status(),
-            case.status,
-            "{} {}",
-            case.method,
-            case.path
-        );
-        assert_eq!(
-            response.headers()["content-type"],
-            "application/json",
-            "{} {}",
-            case.method,
-            case.path
-        );
+        let mut errors = Vec::new();
+        if response.status() != case.status {
+            errors.push(format!("status {:?}", response.status()));
+        }
+        if response.headers()["content-type"] != "application/json" {
+            errors.push(format!(
+                "content-type {:?}",
+                response.headers()["content-type"]
+            ));
+        }
         let body = response.bytes().await.unwrap();
-        assert_eq!(
-            body.as_ref(),
-            format!(
-                r#"{{"error":{{"code":"{}","message":"{}","type":"proxy_error"}}}}"#,
-                case.code, case.message
+        let expected = format!(
+            r#"{{"error":{{"code":"{}","message":"{}","type":"proxy_error"}}}}"#,
+            case.code, case.message
+        );
+        if body.as_ref() != expected.as_bytes() {
+            errors.push(format!("body {:?}", String::from_utf8_lossy(&body)));
+        }
+        if std::fs::read(proxy.data_dir.join("config.json")).unwrap() != before {
+            errors.push("config.json changed".to_owned());
+        }
+        if !errors.is_empty() {
+            failures.push(format!(
+                "{} {}: {}",
+                case.method,
+                case.path,
+                errors.join(", ")
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "rejection failures:\n{}",
+        failures.join("\n")
+    );
+}
+
+/// An unknown `/api/*` path is still an operator-surface request: it must not
+/// disclose its typed fallback before the setup/session gate has run.
+#[tokio::test]
+async fn unknown_control_plane_paths_are_gated_before_fallback() {
+    let fresh = start_proxy_fresh().await;
+    let before_fresh = std::fs::read(fresh.data_dir.join("config.json")).ok();
+    assert_exact_api_error(
+        client()
+            .get(fresh.url("/api/not-a-route"))
+            .send()
+            .await
+            .unwrap(),
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "setup_required",
+        "first-time setup has not been completed; open the dashboard to create the superuser",
+    )
+    .await;
+    assert_eq!(
+        std::fs::read(fresh.data_dir.join("config.json")).ok(),
+        before_fresh
+    );
+
+    let mock = start_mock().await;
+    let proxy = start_proxy(&mock.url, &[]).await;
+    let before = std::fs::read(proxy.data_dir.join("config.json")).unwrap();
+    assert_exact_api_error(
+        client()
+            .get(proxy.url("/api/not-a-route"))
+            .send()
+            .await
+            .unwrap(),
+        reqwest::StatusCode::UNAUTHORIZED,
+        "unauthorized",
+        "authentication required (session cookie, or Authorization: Bearer <username>:<password>)",
+    )
+    .await;
+    assert_eq!(
+        std::fs::read(proxy.data_dir.join("config.json")).unwrap(),
+        before
+    );
+
+    let cookie = login(&proxy).await;
+    assert_exact_api_error(
+        client()
+            .get(proxy.url("/api/not-a-route"))
+            .header("cookie", cookie)
+            .send()
+            .await
+            .unwrap(),
+        reqwest::StatusCode::NOT_FOUND,
+        "not_found",
+        "not found",
+    )
+    .await;
+    assert_eq!(
+        std::fs::read(proxy.data_dir.join("config.json")).unwrap(),
+        before
+    );
+}
+
+/// Once claimed, setup POSTs reject before they inspect headers or buffer a
+/// body, so the closed phase always has one stable conflict result.
+#[tokio::test]
+async fn closed_setup_posts_win_before_body_rejections() {
+    struct ClosedCase {
+        content_type: Option<&'static str>,
+        body: &'static str,
+        oversized: bool,
+    }
+
+    let mock = start_mock().await;
+    let proxy = start_proxy(&mock.url, &[]).await;
+    let before = std::fs::read(proxy.data_dir.join("config.json")).unwrap();
+    let cases = [
+        ClosedCase {
+            content_type: Some("application/json"),
+            body: "{",
+            oversized: false,
+        },
+        ClosedCase {
+            content_type: None,
+            body: r#"{"key":"k"}"#,
+            oversized: false,
+        },
+        ClosedCase {
+            content_type: Some("text/plain"),
+            body: r#"{"key":"k"}"#,
+            oversized: false,
+        },
+        ClosedCase {
+            content_type: Some("application/json"),
+            body: "",
+            oversized: true,
+        },
+    ];
+
+    for path in ["/setup", "/setup/validate-key"] {
+        for case in &cases {
+            let body = if case.oversized {
+                "x".repeat(64 * 1024 * 1024 + 1)
+            } else {
+                case.body.to_owned()
+            };
+            let mut request = client().post(proxy.url(path)).body(body);
+            if let Some(content_type) = case.content_type {
+                request = request.header("content-type", content_type);
+            }
+            assert_exact_api_error(
+                request.send().await.unwrap(),
+                reqwest::StatusCode::CONFLICT,
+                "setup_complete",
+                "setup is already complete",
             )
-            .as_bytes(),
-            "{} {}",
-            case.method,
-            case.path
-        );
-        assert_eq!(
-            std::fs::read(proxy.data_dir.join("config.json")).unwrap(),
-            before,
-            "{} {} changed config.json",
-            case.method,
-            case.path
-        );
+            .await;
+            assert_eq!(
+                std::fs::read(proxy.data_dir.join("config.json")).unwrap(),
+                before
+            );
+        }
     }
 }
 
@@ -3330,13 +3469,25 @@ async fn setup_double_claim_is_rejected_with_409() {
         client().post(proxy.url("/setup")).json(&body).send(),
         client().post(proxy.url("/setup")).json(&body).send(),
     );
-    let mut statuses = [a.unwrap().status().as_u16(), b.unwrap().status().as_u16()];
-    statuses.sort_unstable();
-    assert_eq!(
-        statuses,
-        [200, 409],
-        "exactly one claim wins, the other 409s"
-    );
+    let (a, b) = (a.unwrap(), b.unwrap());
+    let (success, conflict) = if a.status() == reqwest::StatusCode::OK {
+        (a, b)
+    } else {
+        (b, a)
+    };
+    assert_eq!(success.status(), reqwest::StatusCode::OK);
+    assert_exact_api_error(
+        conflict,
+        reqwest::StatusCode::CONFLICT,
+        "setup_complete",
+        "setup is already complete",
+    )
+    .await;
+    let stored: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(proxy.data_dir.join("config.json")).unwrap())
+            .unwrap();
+    assert_eq!(stored["users"].as_array().unwrap().len(), 1);
+    assert_eq!(stored["users"][0]["username"], "admin");
 }
 
 /// A lockout-recovery store (users hand-emptied) keeps orphan-owned client

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -9,6 +9,9 @@ mod support;
 use std::os::unix::fs::PermissionsExt;
 use std::time::{Duration, Instant};
 
+use reqwest::header::CONTENT_TYPE;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
 use support::{
     chat_body, complete_setup, expect_refuses_to_start, login, login_as, metrics, read_sse,
     restart, scratch_data_dir, start_mock, start_proxy, start_proxy_fresh, start_proxy_in,
@@ -34,11 +37,55 @@ async fn assert_exact_api_error(
     message: &str,
 ) {
     assert_eq!(response.status(), status);
-    assert_eq!(response.headers()["content-type"], "application/json");
+    assert_eq!(
+        response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|content_type| content_type.to_str().ok()),
+        Some("application/json")
+    );
     assert_eq!(
         response.bytes().await.unwrap().as_ref(),
         format!(r#"{{"error":{{"code":"{code}","message":"{message}","type":"proxy_error"}}}}"#)
             .as_bytes()
+    );
+}
+
+/// Send only headers for an over-limit body. `Expect: 100-continue` keeps the
+/// client from streaming 64 MiB into a setup route that must reject its closed
+/// phase before body buffering; the request limit still sees the declared size.
+async fn assert_closed_setup_rejects_oversized_body(proxy: &support::Proxy, path: &str) {
+    const MAX_RESPONSE_BYTES: u64 = 4 * 1024;
+
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", proxy.port))
+        .await
+        .unwrap();
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nExpect: 100-continue\r\nConnection: close\r\n\r\n",
+        64 * 1024 * 1024 + 1,
+    );
+    stream.write_all(request.as_bytes()).await.unwrap();
+
+    let mut response = Vec::new();
+    let mut bounded = stream.take(MAX_RESPONSE_BYTES + 1);
+    tokio::time::timeout(Duration::from_secs(2), bounded.read_to_end(&mut response))
+        .await
+        .expect("closed setup route should respond without the oversized body")
+        .unwrap();
+    assert!(
+        response.len() <= MAX_RESPONSE_BYTES as usize,
+        "closed setup response exceeded {MAX_RESPONSE_BYTES} bytes"
+    );
+    let response = String::from_utf8(response).unwrap();
+    let (headers, body) = response.split_once("\r\n\r\n").unwrap();
+    assert!(headers.starts_with("HTTP/1.1 409"), "{headers}");
+    assert!(
+        headers.contains("content-type: application/json"),
+        "{headers}"
+    );
+    assert_eq!(
+        body,
+        r#"{"error":{"code":"setup_complete","message":"setup is already complete","type":"proxy_error"}}"#
     );
 }
 
@@ -2010,11 +2057,10 @@ async fn control_plane_rejections_are_typed() {
         if response.status() != case.status {
             errors.push(format!("status {:?}", response.status()));
         }
-        if response.headers()["content-type"] != "application/json" {
-            errors.push(format!(
-                "content-type {:?}",
-                response.headers()["content-type"]
-            ));
+        match response.headers().get(CONTENT_TYPE) {
+            Some(content_type) if content_type == "application/json" => {}
+            Some(content_type) => errors.push(format!("content-type {content_type:?}")),
+            None => errors.push("content-type missing".to_owned()),
         }
         let body = response.bytes().await.unwrap();
         let expected = format!(
@@ -2041,6 +2087,82 @@ async fn control_plane_rejections_are_typed() {
         "rejection failures:\n{}",
         failures.join("\n")
     );
+}
+
+/// The raw-request setup handlers phase-check first, but while setup remains
+/// open their manual `ApiJson` call must preserve the typed extractor errors.
+#[tokio::test]
+async fn open_setup_posts_keep_typed_extractor_rejections() {
+    struct OpenCase {
+        content_type: Option<&'static str>,
+        body: &'static str,
+        status: reqwest::StatusCode,
+        code: &'static str,
+        message: &'static str,
+        oversized: bool,
+    }
+
+    let proxy = start_proxy_fresh().await;
+    let before = std::fs::read(proxy.data_dir.join("config.json")).ok();
+    let cases = [
+        OpenCase {
+            content_type: Some("application/json"),
+            body: "{",
+            status: reqwest::StatusCode::BAD_REQUEST,
+            code: "invalid_json",
+            message: "invalid JSON",
+            oversized: false,
+        },
+        OpenCase {
+            content_type: None,
+            body: r#"{"key":"k"}"#,
+            status: reqwest::StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            code: "unsupported_media_type",
+            message: "Content-Type must be application/json",
+            oversized: false,
+        },
+        OpenCase {
+            content_type: Some("text/plain"),
+            body: r#"{"key":"k"}"#,
+            status: reqwest::StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            code: "unsupported_media_type",
+            message: "Content-Type must be application/json",
+            oversized: false,
+        },
+        OpenCase {
+            content_type: Some("application/json"),
+            body: "",
+            status: reqwest::StatusCode::PAYLOAD_TOO_LARGE,
+            code: "body_too_large",
+            message: "request body is too large",
+            oversized: true,
+        },
+    ];
+
+    for path in ["/setup", "/setup/validate-key"] {
+        for case in &cases {
+            let body = if case.oversized {
+                "x".repeat(64 * 1024 * 1024 + 1)
+            } else {
+                case.body.to_owned()
+            };
+            let mut request = client().post(proxy.url(path)).body(body);
+            if let Some(content_type) = case.content_type {
+                request = request.header(CONTENT_TYPE, content_type);
+            }
+            assert_exact_api_error(
+                request.send().await.unwrap(),
+                case.status,
+                case.code,
+                case.message,
+            )
+            .await;
+            assert_eq!(
+                std::fs::read(proxy.data_dir.join("config.json")).ok(),
+                before
+            );
+        }
+    }
 }
 
 /// An unknown `/api/*` path is still an operator-surface request: it must not
@@ -2110,7 +2232,6 @@ async fn closed_setup_posts_win_before_body_rejections() {
     struct ClosedCase {
         content_type: Option<&'static str>,
         body: &'static str,
-        oversized: bool,
     }
 
     let mock = start_mock().await;
@@ -2120,33 +2241,20 @@ async fn closed_setup_posts_win_before_body_rejections() {
         ClosedCase {
             content_type: Some("application/json"),
             body: "{",
-            oversized: false,
         },
         ClosedCase {
             content_type: None,
             body: r#"{"key":"k"}"#,
-            oversized: false,
         },
         ClosedCase {
             content_type: Some("text/plain"),
             body: r#"{"key":"k"}"#,
-            oversized: false,
-        },
-        ClosedCase {
-            content_type: Some("application/json"),
-            body: "",
-            oversized: true,
         },
     ];
 
     for path in ["/setup", "/setup/validate-key"] {
         for case in &cases {
-            let body = if case.oversized {
-                "x".repeat(64 * 1024 * 1024 + 1)
-            } else {
-                case.body.to_owned()
-            };
-            let mut request = client().post(proxy.url(path)).body(body);
+            let mut request = client().post(proxy.url(path)).body(case.body);
             if let Some(content_type) = case.content_type {
                 request = request.header("content-type", content_type);
             }
@@ -2162,6 +2270,11 @@ async fn closed_setup_posts_win_before_body_rejections() {
                 before
             );
         }
+        assert_closed_setup_rejects_oversized_body(&proxy, path).await;
+        assert_eq!(
+            std::fs::read(proxy.data_dir.join("config.json")).unwrap(),
+            before
+        );
     }
 }
 

--- a/tests/openapi.rs
+++ b/tests/openapi.rs
@@ -83,6 +83,21 @@ fn spec_is_usable() {
         }
     }
 
+    for (path, item) in paths {
+        for (method, op) in item.as_object().expect("path item") {
+            for (status, response) in op["responses"].as_object().expect("responses") {
+                if status.starts_with('2') {
+                    continue;
+                }
+                assert_eq!(
+                    response["content"]["application/json"]["schema"]["$ref"],
+                    "#/components/schemas/ApiError",
+                    "{method} {path} {status}: every JSON API rejection uses ApiError"
+                );
+            }
+        }
+    }
+
     // The document-level requirement the /api/* routes inherit.
     let global = spec["security"].as_array().expect("document security");
     assert_eq!(global.len(), 2, "session cookie or header credentials");


### PR DESCRIPTION
Implements Task 1 of the v0.6.6 foundation plan. Refs #90 and parent #69.

## Outcome

One typed JSON rejection boundary now covers the protected control plane and setup POST routes. Unknown `/api/*` paths stay behind the setup/session gate, and closed setup POSTs return `409 setup_complete` before parsing or buffering request bodies.

## Proof

- committed red → green sequence: `38b4760` → `3c26474`
- independent review exposed fallback-auth, phase-ordering, race-code, and knowledge contradictions
- committed repair red → green sequence: `4ccc520` → `ac9f846`
- exact raw-byte assertions for JSON/media/body-limit/query/path/method/setup rejections
- unchanged `config.json` assertions and exact concurrent-claim durable state
- bounded `Expect: 100-continue` proof that closed setup rejects before a 64 MiB body is buffered
- final independent committed-state review: 0 blocking, 0 nonblocking findings

## Constraint

Setup GET, login/form, health, metrics, and `/v1` remain outside the typed control-plane boundary. Open-setup extraction retains typed 400/413/415 behavior.

## Ponytail rung

5 — uses Axum’s installed extractor, child-router layer, and fallback machinery.

## Fresh verification

- 5 focused E2E boundary tests passed
- `cargo test`: 127 unit, 94 E2E, 2 OpenAPI, 0 doc failures
- `cargo clippy --all-targets -- -D warnings` passed
- `cargo fmt --check` passed
- `python3 scripts/check_agent_guide.py` passed
- generated OpenAPI and diff checks passed

Target is the `release/v0.6.6` integration branch. `main` is untouched.