### PR TITLE
test: enforce HTTP trust boundaries

### DIFF
--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -499,6 +499,29 @@ the generated spec.
   -- --nocapture` ran 2 tests, passed the own/other ownership matrix, and
   failed the behavior matrix as `route-contract:phase/auth` for before-setup
   `GET /health` (actual 200, seeded expectation 503).
+- 2026-07-30: independent review found five important proof gaps and three
+  minor completion gaps. The green delta now reconciles all 12 relative live
+  `/api` registration constants to full inventory paths; rejects duplicate
+  method/path and probe identities; uses the single
+  `/v1/chat/completions` probe; distinguishes missing `config.json` from other
+  read failures and requires post-write bytes; asserts exact inherited
+  `session_cookie`/`basic_auth` alternatives; requires exact one-call upstream
+  deltas; narrows the knowledge proof claims to observable effects; and
+  records the review and staging state here.
+- 2026-07-30: three negative self-tests deliberately drift a nested
+  registration, replace global OpenAPI security, and remove post-write config
+  bytes. Their expected panics name `route-contract:registration`,
+  `route-contract:openapi-security`, and `route-contract:durable-bytes`.
+  Focused green proof passed 2 route-inventory tests, 4 route-contract E2E
+  tests, and 3 OpenAPI tests.
+- 2026-07-30: the fresh complete gate passed 128 library tests, 98 E2E tests,
+  and 3 OpenAPI tests. The adjacent `auth_` filter passed 4 tests. Clippy with
+  warnings denied, formatting, agent-guide/local-link validation, generated
+  OpenAPI regeneration plus byte-drift check, and `git diff --check` all
+  passed. `openapi.json` remained byte-identical because the task strengthened
+  membership/security proof without changing the generated wire contract.
+  Final review of the refreshed staged delta approved it with zero blocking
+  and zero nonblocking findings.
 
 **GitHub issue title:** `v0.6.6: document and enforce HTTP trust boundaries`
 
@@ -564,13 +587,13 @@ for own and other users' resources. The knowledge map carries the same
 dimensions and links to these tests rather than pretending the smaller
 production metadata proves them.
 
-- [ ] **Step 1: Write the failing route matrix**
+- [x] **Step 1: Write the failing route matrix**
 
 Seed the matrix with every live route from `src/lib.rs`, including page, asset
 (none yet), setup, control-plane, metrics, health, and `/v1/{*path}` rows. Add
 one intentionally wrong auth/phase row during the red run.
 
-- [ ] **Step 2: Observe the named failure**
+- [x] **Step 2: Observe the named failure**
 
 ```sh
 cargo test routes::tests --lib -- --nocapture
@@ -580,20 +603,20 @@ cargo test --test e2e route_contract_ -- --nocapture
 Expected: `route-contract:phase` or `route-contract:auth` names the seeded
 wrong row; a missing OpenAPI decision reports `route-contract:openapi`.
 
-- [ ] **Step 3: Make the matrix reflect live behavior**
+- [x] **Step 3: Make the matrix reflect live behavior**
 
 Use existing router middleware and role checks; do not move a route merely to
 make the table convenient. Keep the durable knowledge matrix columns:
 consumer, public/private, pre/post setup, auth/role, request type, success type,
 stable error codes, side effects, UI caller, OpenAPI coverage, committed proof.
 
-- [ ] **Step 4: Strengthen OpenAPI membership checks**
+- [x] **Step 4: Strengthen OpenAPI membership checks**
 
 Assert every matrix row marked `openapi: true` is present with matching method
 and security, and every omitted operator JSON route has an explicit
 `openapi: false` decision. Do not document `/v1` as a nim-proxy schema.
 
-- [ ] **Step 5: Run proof**
+- [x] **Step 5: Run proof**
 
 ```sh
 cargo test routes::tests --lib
@@ -606,13 +629,13 @@ python3 scripts/check_agent_guide.py
 git diff --check
 ```
 
-- [ ] **Step 6: Ingest and review before commit**
+- [x] **Step 6: Ingest and review before commit**
 
 Create the architecture page in Component shape, link rather than duplicate
 auth/streaming/OpenAPI decisions, update the index and newest-first log, and
 review the real-request matrix against the live registration.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```sh
 git add src/routes.rs src/lib.rs src/api.rs tests/e2e.rs tests/openapi.rs \

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -479,6 +479,27 @@ git commit -m "fix: normalize control-plane JSON errors"
 
 ### Task 2: Establish the HTTP trust-boundary contract
 
+#### Execution record
+
+**Outcome:** One tested HTTP trust-boundary inventory. **Proof:** A
+real-request route matrix agrees with generated OpenAPI. **Constraint:**
+Metadata describes the live handlers; it is never a second router or handler
+registry. **Ponytail Rung:** 2 — reuse live route registration constants and
+the generated spec.
+
+- 2026-07-30: implementation started from `release/v0.6.6` at `1aacb6d` in
+  the isolated `work/v0.6.6-task-02-http-trust-boundaries` worktree. The live
+  registration reconciles to 23 method/path contracts and no asset routes.
+  `OperatorSuperuser` has no exclusive route because superuser is an
+  undeletable/undemotable admin invariant, not an additional endpoint-power
+  tier. No scope delta was identified.
+- 2026-07-30: committed red proof prepared with the intentionally wrong
+  `/health` phase row. `cargo test routes::tests --lib -- --nocapture` passed
+  1 inventory/OpenAPI test; `cargo test --test e2e route_contract_
+  -- --nocapture` ran 2 tests, passed the own/other ownership matrix, and
+  failed the behavior matrix as `route-contract:phase/auth` for before-setup
+  `GET /health` (actual 200, seeded expectation 503).
+
 **GitHub issue title:** `v0.6.6: document and enforce HTTP trust boundaries`
 
 **Files:**

--- a/knowledge/architecture/client-auth.md
+++ b/knowledge/architecture/client-auth.md
@@ -96,5 +96,12 @@ credentials), and the two `/setup` operations carry an explicit empty
 any admin resets any password. Total lockout: the documented
 [volume edit](../ops/configure-env.md).
 
+The complete method/path inventory—including public routes, setup phases,
+role/ownership gates, request/success types, side effects, UI callers, and
+OpenAPI decisions—lives in the
+[HTTP trust-boundary map](http-trust-boundary-map.md). Superuser has zero
+exclusive routes; its distinction is the undeletable/undemotable invariant,
+not endpoint power beyond admin.
+
 TLS is not built in — terminate it at a reverse proxy / platform edge and set
 `TRUST_PROXY=true` so the session cookie is marked `Secure`.

--- a/knowledge/architecture/http-trust-boundary-map.md
+++ b/knowledge/architecture/http-trust-boundary-map.md
@@ -1,0 +1,94 @@
+---
+type: Component
+title: HTTP trust-boundary map
+description: Live route inventory across setup phase, client/operator authentication, roles, wire types, side effects, UI callers, and generated OpenAPI.
+tags: [http, routes, auth, openapi, security]
+timestamp: 2026-07-30T00:00:00Z
+---
+
+# HTTP trust-boundary map
+
+`src/lib.rs` is the only handler registry. It registers handlers through the
+fixed path constants in `src/routes.rs`; the `RouteContract` rows in that
+module are test-only descriptive metadata and cannot dispatch a request.
+`RouteContract.path` is the registered/OpenAPI template, while
+`probe_path` is a concrete fixture-backed request path. This distinction is
+load-bearing for `/v1/{*path}` and future parameterized routes.
+
+The current router has 23 method/path contracts and no asset routes. A
+superuser has no exclusive route: it has admin endpoint power plus the
+undeletable/undemotable account invariant. `OperatorSuperuser` exists so a
+future exclusive boundary must be declared deliberately, not inferred from
+the role name.
+
+## Contract matrix
+
+The compact proof labels are:
+
+- **M** — `routes::tests::inventory_agrees_with_generated_openapi` owns the
+  compiled inventory, method/path membership, OpenAPI security inheritance,
+  phase counts, fixture probe paths, the explicit no-assets decision, and the
+  no-superuser-exclusive-route decision.
+- **B** — `route_contract_behavior_matrix` sends real requests through the
+  binary in before-setup, anonymous configured, ordinary-user, admin, and
+  superuser states. Each row asserts status/error, request and success content
+  types, exact `config.json` before/after bytes, session-cookie presence, and
+  exact coarse upstream-call deltas. Endpoint-specific tests and component
+  pages, not B, own internal publication, cache, pool, and session semantics.
+- **C** — `route_contract_client_auth_matrix` proves pre-setup closure and
+  keyed-mode missing/wrong/valid bearer behavior independently of operator
+  sessions, including upstream and durable-byte effects.
+- **O** — `route_contract_ownership_matrix` adds own/other rows for NIM and
+  client keys and proves rejected foreign writes preserve durable bytes.
+
+Every JSON `/api` and setup POST additionally inherits the extractor codes
+`body_too_large`, `invalid_json`, and `unsupported_media_type`; the `/api`
+subtree owns `invalid_query`, `method_not_allowed`, and `not_found` where
+applicable. Their exact envelopes and ordering live in
+[typed responses and generated OpenAPI](../decisions/typed-responses-and-generated-openapi.md),
+not a second copy here.
+
+| Method and path | Consumer | Public/private | Phase | Authentication / role | Request type | Success type | Stable boundary errors | Side effects | UI caller | OpenAPI | Proof |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| `GET /` | Browser operator | Private | Post-setup | Session; any role | None | HTML | Pre-setup/anonymous redirect | None | Dashboard navigation | No | B, M |
+| `GET /dash` | Browser operator | Private | Post-setup | Session; any role | None | HTML | Pre-setup/anonymous redirect | None | Dashboard alias | No | B, M |
+| `GET /metrics` | Prometheus/operator | Private | Post-setup | Session, Basic, or header credentials; any role | None | Prometheus text | `setup_required`, `unauthorized` | Config unchanged; no upstream call | External scraper | No | B, M |
+| `GET /api/dashboard` | Browser operator | Private | Post-setup | Session/header credentials; any role | Query | JSON | `setup_required`, `unauthorized`, `invalid_query`, `invalid_time_window` | Config unchanged; no upstream call | Dashboard range load | Yes | B, M |
+| `GET /api/dashboard/now` | Browser operator | Private | Post-setup | Session/header credentials; any role | None | JSON | `setup_required`, `unauthorized` | Config unchanged; no upstream call | Dashboard polling | Yes | B, M |
+| `GET /api/config` | Browser operator | Private | Post-setup | Session/header credentials; any role; response filtered by role/ownership | None | JSON | `setup_required`, `unauthorized` | Config unchanged; no upstream call | Settings startup | Yes | B, M |
+| `POST /api/settings/nim-keys` | Browser/operator API | Private | Post-setup | Session/header credentials; own keys for user, any key for admin | JSON | JSON | `setup_required`, `unauthorized`, `forbidden`, `invalid_config` | Success changes config bytes; rejection does not | Settings Access & keys | Yes | B, O, M |
+| `POST /api/settings/clients` | Browser/operator API | Private | Post-setup | Session/header credentials; own keys for user, any key/mode for admin | JSON | JSON | `setup_required`, `unauthorized`, `forbidden`, `invalid_config` | Success changes config bytes; rejection does not | Settings Access & keys | Yes | B, O, M |
+| `POST /api/settings/upstream` | Browser/operator API | Private | Post-setup | Session/header credentials; admin or superuser | JSON | JSON | `setup_required`, `unauthorized`, `forbidden`, `invalid_config` | Success changes config bytes; rejection does not | Settings Server | Yes | B, M |
+| `POST /api/settings/limits` | Browser/operator API | Private | Post-setup | Session/header credentials; admin or superuser | JSON | JSON | `setup_required`, `unauthorized`, `forbidden`, `invalid_config` | Success changes config bytes; rejection does not | Settings Server | Yes | B, M |
+| `POST /api/settings/history` | Browser/operator API | Private | Post-setup | Session/header credentials; admin or superuser | JSON | JSON | `setup_required`, `unauthorized`, `forbidden`, `invalid_config` | Success changes config bytes; rejection does not | Settings Server | Yes | B, M |
+| `POST /api/settings/governor` | Browser/operator API | Private | Post-setup | Session/header credentials; admin or superuser | JSON | JSON | `setup_required`, `unauthorized`, `forbidden`, `invalid_config` | Success changes config bytes; rejection does not | Settings Server | Yes | B, M |
+| `POST /api/settings/users` | Browser/operator API | Private | Post-setup | Session/header credentials; admin or superuser; superuser target protected | JSON | JSON | `setup_required`, `unauthorized`, `forbidden`, `weak_password`, `invalid_config` | Success changes config bytes; rejection does not | Settings Users | Yes | B, M |
+| `POST /api/settings/account` | Browser/operator API | Private | Post-setup | Session/header credentials; any role, own account only | JSON | JSON + session cookie | `setup_required`, `unauthorized`, `wrong_password`, `weak_password`, `password_changed`, `invalid_config` | Success changes config bytes and sets a session cookie | Settings Account | Yes | B, M |
+| `POST /api/settings/validate-key` | Browser/operator API | Private | Post-setup | Session/header credentials; any role | JSON | JSON | `setup_required`, `unauthorized` | Success makes one upstream call; config unchanged | Settings key validation | Yes | B, M |
+| `GET /health` | Orchestrator | Public | Always | None | None | Plain text | None | None | Container healthcheck | No | B, M |
+| `GET /login` | Browser operator | Public | Always | None; authenticated callers redirect | None | HTML/redirect | None (HTML flow) | None | Login page | No | B, M |
+| `POST /login` | Browser operator | Public | Always | Username/password form | Form URL encoded | Redirect + session cookie | HTML 401 or plain 429; no `ApiError` code | Success sets a session cookie; config unchanged | Login form | No | B, M |
+| `POST /logout` | Browser operator | Public | Always | None required | None | Redirect + clearing cookie | None | Response sets a clearing cookie; config unchanged | Account/logout control | No | B, M |
+| `GET /setup` | First operator | Public | Pre-setup | None | None | HTML | Post-setup bare 404 | None | Setup wizard | No | B, M |
+| `POST /setup` | First operator | Public | Pre-setup | None; first complete claim wins | JSON | JSON + session cookie | `weak_password`, `invalid_config`, `setup_complete` | Success creates config bytes and sets a session cookie | Setup wizard finish | Yes, explicit no security | B, M |
+| `POST /setup/validate-key` | First operator | Public | Pre-setup | None; pre-auth throttle | JSON | JSON | `invalid_base_url`, `throttled`, `setup_complete` | Success makes one upstream call; config unchanged | Setup wizard key step | Yes, explicit no security | B, M |
+| `ANY /v1/{*path}` (`POST /v1/chat/completions` probe) | OpenAI-compatible client | Client boundary: keyed private or explicitly open trusted-network mode | Post-setup | Client bearer in keyed mode; none in open mode | Upstream-owned bytes | Upstream content type or locally framed SSE | `setup_required`, `unauthorized`, `invalid_deadline`, `overloaded`, transport codes | Success makes one upstream call; config unchanged | External agent harness | No: upstream owns schema | B, C, M |
+
+## Boundary ownership
+
+Phase and operator authentication are owned by `require_session`; client
+authentication and pre-setup data-plane closure are owned by the proxy handler.
+Setup POST handlers perform their phase check before extraction. Handler role
+and resource-ownership checks run only after the session boundary. The exact
+identity and role rules remain in [client auth](client-auth.md).
+
+All config writers follow build candidate → validate → persist → publish live
+state. The E2E table therefore treats a rejected write as wrong if even one
+durable byte changes. Upstream-only probes must change no config bytes. The
+data-plane scheduling, response, and observation details remain in the
+[streaming pipeline](streaming-pipeline.md).
+
+Generated OpenAPI describes only the 12 `/api` operations and two setup POST
+operations. HTML/form, health, metrics, and `/v1` omissions are explicit
+decisions. The generated-file authority and error schema remain in
+[typed responses and generated OpenAPI](../decisions/typed-responses-and-generated-openapi.md).

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -68,6 +68,7 @@ page describes a conclusion, a plan describes the live state.
 | [metrics-history](architecture/metrics-history.md) | Prometheus registry + versioned JSONL, reset-aware startup index, exact rollups, and atomic retention |
 | [dashboard](architecture/dashboard.md) | Embedded operator console; one persisted window across 5 tabs plus clearly scoped Now values |
 | [client-auth](architecture/client-auth.md) | `/v1` client keys (open/keyed) + store-backed multi-user dashboard sessions; fail-closed posture |
+| [http-trust-boundary-map](architecture/http-trust-boundary-map.md) | Every live route mapped across phase, authentication, roles, wire types, side effects, callers, OpenAPI, and real-request proof |
 
 ## Operations — runbooks
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,22 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-30] ingest — map and enforce every HTTP trust boundary
+
+Added the [HTTP trust-boundary map](architecture/http-trust-boundary-map.md)
+and compiled/real-request proofs for all 23 live method/path contracts. Fixed
+path constants now feed the existing router without changing its nesting or
+handler placement; test-only metadata describes phase/access/OpenAPI rather
+than becoming a second dispatch registry.
+
+The real-binary table covers before setup, anonymous configured, ordinary
+user, admin, and superuser states; request/success content types, stable
+boundary errors, exact coarse upstream-call deltas, session-cookie presence,
+and exact config bytes. Separate own/other rows protect NIM-key and client-key
+ownership. The map also records zero current asset routes, zero
+superuser-exclusive routes, and the deliberate exclusion of upstream-owned
+`/v1` schemas from OpenAPI.
+
 ## [2026-07-30] lint — bound raw setup-rejection proof and cover open extraction
 
 The raw `Expect: 100-continue` setup body-limit proof now caps its response

--- a/knowledge/testing/test-strategy.md
+++ b/knowledge/testing/test-strategy.md
@@ -27,6 +27,11 @@ that proof.
 - **Rust logic:** `cargo test` and `cargo clippy --all-targets -- -D warnings`.
 - **Handlers or wire types:** `UPDATE_OPENAPI=1 cargo test --test openapi`,
   then verify that `openapi.json` has only the deliberate diff.
+- **HTTP trust boundaries:** `cargo test routes::tests --lib` proves the
+  compiled inventory agrees with generated OpenAPI; `cargo test --test e2e
+  route_contract_ -- --nocapture` proves real phase/auth/role behavior,
+  request and success content types, side effects, ownership, and durable
+  bytes. Neither table is a router.
 - **Embedded pages:** `node scripts/render_check.js --syntax-selftest` proves
   the syntax gate can reject its fixtures. `node scripts/render_check.js
   --syntax-only` parses the real dashboard and setup scripts without launching
@@ -105,6 +110,16 @@ Two tests exist purely so the JSON contract cannot move by accident (see
   asserts the document is consumable — 14 operations, each tagged with a
   documented 200, `/api/*` inheriting the auth requirement and `/setup`
   explicitly waiving it.
+- `routes::tests::inventory_agrees_with_generated_openapi` owns the 23-row
+  compiled method/path inventory, including explicit OpenAPI omissions, the
+  `/v1/{*path}` template versus concrete probe, zero current asset routes, and
+  zero superuser-exclusive routes. `route_contract_behavior_matrix` sends the
+  five-state matrix through the real binary and asserts request/success
+  content types, stable boundary errors, side effects, and `config.json`
+  bytes. `route_contract_ownership_matrix` adds own/other NIM-key and
+  client-key mutations; `route_contract_client_auth_matrix` separately proves
+  keyed missing/wrong/valid bearer behavior and pre-setup closure. See the
+  [HTTP trust-boundary map](../architecture/http-trust-boundary-map.md).
 - `control_plane_rejections_are_typed` sends raw requests through the real
   binary for malformed JSON, JSON media-type failures, body-size rejection,
   invalid dashboard query, unknown/method-mismatched `/api/*`, and post-claim

--- a/src/api.rs
+++ b/src/api.rs
@@ -817,35 +817,4 @@ mod tests {
             r#"{"error":{"code":"invalid_json","message":"invalid JSON","type":"proxy_error"}}"#
         );
     }
-
-    /// The spec must actually describe every route the router serves.
-    #[test]
-    fn spec_covers_every_documented_route() {
-        let spec: serde_json::Value = serde_json::from_str(&openapi_json()).unwrap();
-        let paths = spec["paths"].as_object().expect("paths");
-        let mut got: Vec<&str> = paths.keys().map(String::as_str).collect();
-        got.sort_unstable();
-        assert_eq!(
-            got,
-            [
-                "/api/config",
-                "/api/dashboard",
-                "/api/dashboard/now",
-                "/api/settings/account",
-                "/api/settings/clients",
-                "/api/settings/governor",
-                "/api/settings/history",
-                "/api/settings/limits",
-                "/api/settings/nim-keys",
-                "/api/settings/upstream",
-                "/api/settings/users",
-                "/api/settings/validate-key",
-                "/setup",
-                "/setup/validate-key",
-            ]
-        );
-        // The 12 `/api/*` routes are exactly the ones behind the session
-        // guard; the two `/setup` routes are documented as unauthenticated.
-        assert_eq!(got.iter().filter(|p| p.starts_with("/api/")).count(), 12);
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,18 +538,21 @@ pub async fn run() {
     // user:password header credentials for scrapers); pre-setup it routes
     // everything to the wizard.
     let control_plane = Router::new()
-        .route("/dashboard", get(api_dashboard))
-        .route("/dashboard/now", get(api_dashboard_now))
-        .route("/config", get(settings::api_config))
-        .route("/settings/nim-keys", post(settings::nim_keys))
-        .route("/settings/clients", post(settings::clients))
-        .route("/settings/upstream", post(settings::upstream))
-        .route("/settings/limits", post(settings::limits))
-        .route("/settings/history", post(settings::history))
-        .route("/settings/governor", post(settings::governor_cfg))
-        .route("/settings/users", post(settings::users))
-        .route("/settings/account", post(settings::account))
-        .route("/settings/validate-key", post(settings::validate_key))
+        .route(routes::API_DASHBOARD, get(api_dashboard))
+        .route(routes::API_DASHBOARD_NOW, get(api_dashboard_now))
+        .route(routes::API_CONFIG, get(settings::api_config))
+        .route(routes::API_SETTINGS_NIM_KEYS, post(settings::nim_keys))
+        .route(routes::API_SETTINGS_CLIENTS, post(settings::clients))
+        .route(routes::API_SETTINGS_UPSTREAM, post(settings::upstream))
+        .route(routes::API_SETTINGS_LIMITS, post(settings::limits))
+        .route(routes::API_SETTINGS_HISTORY, post(settings::history))
+        .route(routes::API_SETTINGS_GOVERNOR, post(settings::governor_cfg))
+        .route(routes::API_SETTINGS_USERS, post(settings::users))
+        .route(routes::API_SETTINGS_ACCOUNT, post(settings::account))
+        .route(
+            routes::API_SETTINGS_VALIDATE_KEY,
+            post(settings::validate_key),
+        )
         .fallback(api::api_not_found)
         .method_not_allowed_fallback(api::api_method_not_allowed)
         .layer(axum::middleware::from_fn_with_state(
@@ -558,28 +561,34 @@ pub async fn run() {
         ));
 
     let protected = Router::new()
-        .route("/", get(dash))
-        .route("/dash", get(dash))
-        .route("/metrics", get(metrics_text))
+        .route(routes::ROOT, get(dash))
+        .route(routes::DASH, get(dash))
+        .route(routes::METRICS, get(metrics_text))
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth::require_session,
         ))
-        .nest("/api", control_plane);
+        .nest(routes::API_PREFIX, control_plane);
 
     // Public surface: health probe, login flow, the first-run wizard (404
     // once setup completes), and the API (its own key gate + setup gate).
     let app = Router::new()
         .merge(protected)
-        .route("/health", get(|| async { "ok" }))
-        .route("/login", get(auth::login_page).post(auth::login_submit))
-        .route("/logout", post(auth::logout))
+        .route(routes::HEALTH, get(|| async { "ok" }))
         .route(
-            "/setup",
+            routes::LOGIN,
+            get(auth::login_page).post(auth::login_submit),
+        )
+        .route(routes::LOGOUT, post(auth::logout))
+        .route(
+            routes::SETUP,
             get(settings::setup_page).post(settings::setup_submit),
         )
-        .route("/setup/validate-key", post(settings::setup_validate_key))
-        .route("/v1/{*path}", any(proxy::handle))
+        .route(
+            routes::SETUP_VALIDATE_KEY,
+            post(settings::setup_validate_key),
+        )
+        .route(routes::V1_WILDCARD, any(proxy::handle))
         .layer(axum::middleware::from_fn(security_headers))
         .layer(DefaultBodyLimit::max(64 * 1024 * 1024))
         .with_state(state);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod governor;
 mod history;
 mod pool;
 mod proxy;
+mod routes;
 mod settings;
 
 pub use api::openapi_json;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,0 +1,328 @@
+//! Fixed route paths and test-only descriptive trust-boundary metadata.
+//!
+//! The constants below are consumed by the live router in `lib.rs`. The
+//! contract inventory is deliberately test-only: it describes those live
+//! registrations and must never become a second handler registry.
+
+pub const ROOT: &str = "/";
+pub const DASH: &str = "/dash";
+pub const METRICS: &str = "/metrics";
+
+pub const API_PREFIX: &str = "/api";
+pub const API_DASHBOARD: &str = "/dashboard";
+pub const API_DASHBOARD_NOW: &str = "/dashboard/now";
+pub const API_CONFIG: &str = "/config";
+pub const API_SETTINGS_NIM_KEYS: &str = "/settings/nim-keys";
+pub const API_SETTINGS_CLIENTS: &str = "/settings/clients";
+pub const API_SETTINGS_UPSTREAM: &str = "/settings/upstream";
+pub const API_SETTINGS_LIMITS: &str = "/settings/limits";
+pub const API_SETTINGS_HISTORY: &str = "/settings/history";
+pub const API_SETTINGS_GOVERNOR: &str = "/settings/governor";
+pub const API_SETTINGS_USERS: &str = "/settings/users";
+pub const API_SETTINGS_ACCOUNT: &str = "/settings/account";
+pub const API_SETTINGS_VALIDATE_KEY: &str = "/settings/validate-key";
+
+pub const HEALTH: &str = "/health";
+pub const LOGIN: &str = "/login";
+pub const LOGOUT: &str = "/logout";
+pub const SETUP: &str = "/setup";
+pub const SETUP_VALIDATE_KEY: &str = "/setup/validate-key";
+pub const V1_WILDCARD: &str = "/v1/{*path}";
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Access {
+    Client,
+    Public,
+    OperatorAny,
+    OperatorAdmin,
+    OperatorSuperuser,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Phase {
+    Always,
+    PreSetup,
+    PostSetup,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug)]
+pub struct RouteContract {
+    pub access: Access,
+    pub method: &'static str,
+    pub openapi: bool,
+    pub path: &'static str,
+    pub phase: Phase,
+    pub probe_path: &'static str,
+}
+
+#[cfg(test)]
+const ROUTES: &[RouteContract] = &[
+    RouteContract {
+        access: Access::OperatorAny,
+        method: "GET",
+        openapi: false,
+        path: ROOT,
+        phase: Phase::PostSetup,
+        probe_path: ROOT,
+    },
+    RouteContract {
+        access: Access::OperatorAny,
+        method: "GET",
+        openapi: false,
+        path: DASH,
+        phase: Phase::PostSetup,
+        probe_path: DASH,
+    },
+    RouteContract {
+        access: Access::OperatorAny,
+        method: "GET",
+        openapi: false,
+        path: METRICS,
+        phase: Phase::PostSetup,
+        probe_path: METRICS,
+    },
+    RouteContract {
+        access: Access::OperatorAny,
+        method: "GET",
+        openapi: true,
+        path: "/api/dashboard",
+        phase: Phase::PostSetup,
+        probe_path: "/api/dashboard",
+    },
+    RouteContract {
+        access: Access::OperatorAny,
+        method: "GET",
+        openapi: true,
+        path: "/api/dashboard/now",
+        phase: Phase::PostSetup,
+        probe_path: "/api/dashboard/now",
+    },
+    RouteContract {
+        access: Access::OperatorAny,
+        method: "GET",
+        openapi: true,
+        path: "/api/config",
+        phase: Phase::PostSetup,
+        probe_path: "/api/config",
+    },
+    RouteContract {
+        access: Access::OperatorAny,
+        method: "POST",
+        openapi: true,
+        path: "/api/settings/nim-keys",
+        phase: Phase::PostSetup,
+        probe_path: "/api/settings/nim-keys",
+    },
+    RouteContract {
+        access: Access::OperatorAny,
+        method: "POST",
+        openapi: true,
+        path: "/api/settings/clients",
+        phase: Phase::PostSetup,
+        probe_path: "/api/settings/clients",
+    },
+    RouteContract {
+        access: Access::OperatorAdmin,
+        method: "POST",
+        openapi: true,
+        path: "/api/settings/limits",
+        phase: Phase::PostSetup,
+        probe_path: "/api/settings/limits",
+    },
+    RouteContract {
+        access: Access::OperatorAdmin,
+        method: "POST",
+        openapi: true,
+        path: "/api/settings/history",
+        phase: Phase::PostSetup,
+        probe_path: "/api/settings/history",
+    },
+    RouteContract {
+        access: Access::OperatorAdmin,
+        method: "POST",
+        openapi: true,
+        path: "/api/settings/governor",
+        phase: Phase::PostSetup,
+        probe_path: "/api/settings/governor",
+    },
+    RouteContract {
+        access: Access::OperatorAdmin,
+        method: "POST",
+        openapi: true,
+        path: "/api/settings/users",
+        phase: Phase::PostSetup,
+        probe_path: "/api/settings/users",
+    },
+    RouteContract {
+        access: Access::OperatorAny,
+        method: "POST",
+        openapi: true,
+        path: "/api/settings/validate-key",
+        phase: Phase::PostSetup,
+        probe_path: "/api/settings/validate-key",
+    },
+    RouteContract {
+        access: Access::OperatorAdmin,
+        method: "POST",
+        openapi: true,
+        path: "/api/settings/upstream",
+        phase: Phase::PostSetup,
+        probe_path: "/api/settings/upstream",
+    },
+    RouteContract {
+        access: Access::OperatorAny,
+        method: "POST",
+        openapi: true,
+        path: "/api/settings/account",
+        phase: Phase::PostSetup,
+        probe_path: "/api/settings/account",
+    },
+    // Intentionally wrong for the committed red proof: /health is reachable
+    // in both phases, so the E2E matrix must report route-contract:phase.
+    RouteContract {
+        access: Access::Public,
+        method: "GET",
+        openapi: false,
+        path: HEALTH,
+        phase: Phase::PostSetup,
+        probe_path: HEALTH,
+    },
+    RouteContract {
+        access: Access::Public,
+        method: "GET",
+        openapi: false,
+        path: LOGIN,
+        phase: Phase::Always,
+        probe_path: LOGIN,
+    },
+    RouteContract {
+        access: Access::Public,
+        method: "POST",
+        openapi: false,
+        path: LOGIN,
+        phase: Phase::Always,
+        probe_path: LOGIN,
+    },
+    RouteContract {
+        access: Access::Public,
+        method: "POST",
+        openapi: false,
+        path: LOGOUT,
+        phase: Phase::Always,
+        probe_path: LOGOUT,
+    },
+    RouteContract {
+        access: Access::Public,
+        method: "GET",
+        openapi: false,
+        path: SETUP,
+        phase: Phase::PreSetup,
+        probe_path: SETUP,
+    },
+    RouteContract {
+        access: Access::Public,
+        method: "POST",
+        openapi: true,
+        path: SETUP,
+        phase: Phase::PreSetup,
+        probe_path: SETUP,
+    },
+    RouteContract {
+        access: Access::Public,
+        method: "POST",
+        openapi: true,
+        path: SETUP_VALIDATE_KEY,
+        phase: Phase::PreSetup,
+        probe_path: SETUP_VALIDATE_KEY,
+    },
+    RouteContract {
+        access: Access::Client,
+        method: "ANY",
+        openapi: false,
+        path: V1_WILDCARD,
+        phase: Phase::PostSetup,
+        probe_path: "/v1/models",
+    },
+];
+
+/// Assets do not have live routes until the presentation split. Keeping the
+/// decision explicit prevents callers from inferring that assets were missed.
+#[cfg(test)]
+const ASSET_ROUTES: &[RouteContract] = &[];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inventory_agrees_with_generated_openapi() {
+        let spec: serde_json::Value =
+            serde_json::from_str(&crate::api::openapi_json()).expect("generated OpenAPI JSON");
+        let paths = spec["paths"].as_object().expect("OpenAPI paths");
+
+        assert_eq!(ROUTES.len(), 23, "route-contract:inventory");
+        assert!(ASSET_ROUTES.is_empty(), "route-contract:assets");
+        assert!(
+            !ROUTES
+                .iter()
+                .any(|route| route.access == Access::OperatorSuperuser),
+            "route-contract:auth: superuser is an invariant, not extra endpoint power"
+        );
+
+        for route in ROUTES.iter().filter(|route| route.openapi) {
+            let method = route.method.to_ascii_lowercase();
+            let operation = paths
+                .get(route.path)
+                .and_then(|item| item.get(&method))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "route-contract:openapi: missing {} {}",
+                        route.method, route.path
+                    )
+                });
+            match route.access {
+                Access::Public => assert_eq!(
+                    operation["security"].as_array().map(Vec::len),
+                    Some(0),
+                    "route-contract:openapi: public {} {} must waive security",
+                    route.method,
+                    route.path
+                ),
+                Access::OperatorAny | Access::OperatorAdmin | Access::OperatorSuperuser => {
+                    assert!(
+                        operation.get("security").is_none(),
+                        "route-contract:openapi: operator {} {} must inherit security",
+                        route.method,
+                        route.path
+                    );
+                }
+                Access::Client => {
+                    panic!("route-contract:openapi: /v1 is upstream-owned and must stay omitted")
+                }
+            }
+        }
+
+        for (path, item) in paths {
+            for method in item.as_object().expect("OpenAPI path item").keys() {
+                assert!(
+                    ROUTES.iter().any(|route| {
+                        route.openapi
+                            && route.path == path
+                            && route.method.eq_ignore_ascii_case(method)
+                    }),
+                    "route-contract:openapi: undocumented inventory decision for {method} {path}"
+                );
+            }
+        }
+
+        assert!(
+            ROUTES
+                .iter()
+                .all(|route| { !route.path.contains('{') || !route.probe_path.contains('{') }),
+            "route-contract:probe: parameterized routes need fixture-backed probe paths"
+        );
+    }
+}

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -180,14 +180,12 @@ const ROUTES: &[RouteContract] = &[
         phase: Phase::PostSetup,
         probe_path: "/api/settings/account",
     },
-    // Intentionally wrong for the committed red proof: /health is reachable
-    // in both phases, so the E2E matrix must report route-contract:phase.
     RouteContract {
         access: Access::Public,
         method: "GET",
         openapi: false,
         path: HEALTH,
-        phase: Phase::PostSetup,
+        phase: Phase::Always,
         probe_path: HEALTH,
     },
     RouteContract {
@@ -244,7 +242,7 @@ const ROUTES: &[RouteContract] = &[
         openapi: false,
         path: V1_WILDCARD,
         phase: Phase::PostSetup,
-        probe_path: "/v1/models",
+        probe_path: "/v1/chat/completions",
     },
 ];
 
@@ -256,6 +254,47 @@ const ASSET_ROUTES: &[RouteContract] = &[];
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
+
+    const REGISTERED_API_PATHS: [&str; 12] = [
+        API_DASHBOARD,
+        API_DASHBOARD_NOW,
+        API_CONFIG,
+        API_SETTINGS_NIM_KEYS,
+        API_SETTINGS_CLIENTS,
+        API_SETTINGS_UPSTREAM,
+        API_SETTINGS_LIMITS,
+        API_SETTINGS_HISTORY,
+        API_SETTINGS_GOVERNOR,
+        API_SETTINGS_USERS,
+        API_SETTINGS_ACCOUNT,
+        API_SETTINGS_VALIDATE_KEY,
+    ];
+
+    fn assert_registered_api_paths(registered_api_paths: &[&str]) {
+        assert_eq!(
+            registered_api_paths.len(),
+            12,
+            "route-contract:registration: every nested /api registration must be reconciled"
+        );
+        for registered_path in registered_api_paths {
+            let full_path = format!("{API_PREFIX}{registered_path}");
+            assert!(
+                ROUTES
+                    .iter()
+                    .any(|route| route.path == full_path && route.openapi),
+                "route-contract:registration: {API_PREFIX} + {registered_path} is absent from the inventory"
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "route-contract:registration")]
+    fn registration_self_test_names_relative_path_drift() {
+        let mut drifted = REGISTERED_API_PATHS;
+        drifted[0] = "/drifted-dashboard";
+        assert_registered_api_paths(&drifted);
+    }
 
     #[test]
     fn inventory_agrees_with_generated_openapi() {
@@ -265,6 +304,47 @@ mod tests {
 
         assert_eq!(ROUTES.len(), 23, "route-contract:inventory");
         assert!(ASSET_ROUTES.is_empty(), "route-contract:assets");
+        assert_registered_api_paths(&REGISTERED_API_PATHS);
+        let mut method_paths = HashSet::new();
+        let mut probes = HashSet::new();
+        for route in ROUTES {
+            assert!(
+                method_paths.insert((route.method, route.path)),
+                "route-contract:inventory: duplicate {} {}",
+                route.method,
+                route.path
+            );
+            assert!(
+                probes.insert((route.method, route.probe_path)),
+                "route-contract:probe: duplicate {} {}",
+                route.method,
+                route.probe_path
+            );
+        }
+        assert_eq!(
+            ROUTES
+                .iter()
+                .filter(|route| route.phase == Phase::Always)
+                .count(),
+            4,
+            "route-contract:phase: health, both login methods, and logout are phase-independent"
+        );
+        assert_eq!(
+            ROUTES
+                .iter()
+                .filter(|route| route.phase == Phase::PreSetup)
+                .count(),
+            3,
+            "route-contract:phase: setup GET and both setup POST routes"
+        );
+        assert_eq!(
+            ROUTES
+                .iter()
+                .filter(|route| route.phase == Phase::PostSetup)
+                .count(),
+            16,
+            "route-contract:phase: operator and client routes"
+        );
         assert!(
             !ROUTES
                 .iter()

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -87,6 +87,10 @@ impl ContractActor {
             Self::BeforeSetup | Self::Anonymous | Self::Superuser => support::TEST_USER,
         }
     }
+
+    fn ordinal(self) -> usize {
+        self.index() + 1
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -162,7 +166,26 @@ fn configured_contract_expectations(
 }
 
 fn contract_config_bytes(proxy: &support::Proxy) -> Option<Vec<u8>> {
-    std::fs::read(proxy.data_dir.join("config.json")).ok()
+    match std::fs::read(proxy.data_dir.join("config.json")) {
+        Ok(bytes) => Some(bytes),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => panic!("route-contract:durable-read: config.json: {error}"),
+    }
+}
+
+fn assert_contract_durable_change(
+    before: &Option<Vec<u8>>,
+    after: &Option<Vec<u8>>,
+    context: &str,
+) {
+    assert!(
+        after.is_some(),
+        "route-contract:durable-bytes: successful {context} removed config.json"
+    );
+    assert_ne!(
+        after, before,
+        "route-contract:durable-bytes: successful {context} did not change config.json"
+    );
 }
 
 fn contract_upstream_calls(mock: &support::MockNim) -> usize {
@@ -190,7 +213,7 @@ fn contract_body(
         }
         "api-settings-limits" => serde_json::json!({
             "heartbeat_secs": 1,
-            "max_inflight": 513,
+            "max_inflight": 512 + actor.ordinal(),
             "max_wait_secs": 31,
             "models_ttl_secs": 300,
             "request_timeout_secs": 300,
@@ -198,11 +221,13 @@ fn contract_body(
             "strict_passthrough": false
         }),
         "api-settings-history" => serde_json::json!({
-            "days": 60,
+            "days": 60 + actor.ordinal(),
             "default_window_days": 30,
             "slo_target_percent": 99.8
         }),
-        "api-settings-governor" => serde_json::json!({"enabled": false}),
+        "api-settings-governor" => {
+            serde_json::json!({"enabled": matches!(actor, ContractActor::Superuser)})
+        }
         "api-settings-users" => serde_json::json!({
             "add": {
                 "password": "matrix-password-1",
@@ -252,8 +277,8 @@ async fn send_contract_request(
     mock: &support::MockNim,
 ) -> reqwest::Response {
     let mut request = match row.method {
-        "GET" => client().get(proxy.url(row.path)),
-        "POST" => client().post(proxy.url(row.path)),
+        "GET" => no_redirect_client().get(proxy.url(row.path)),
+        "POST" => no_redirect_client().post(proxy.url(row.path)),
         other => panic!("route-contract:request: unsupported method {other}"),
     };
     if row.accept_html {
@@ -286,10 +311,8 @@ async fn route_contract_behavior_matrix() {
         RouteBehavior {
             access: ContractAccess::Public,
             accept_html: false,
-            // Intentionally wrong for the committed red proof. /health is
-            // phase-independent and really returns 200 before setup.
             expectations: [
-                contract_expectation(503, Some("setup_required")),
+                contract_expectation(200, None),
                 contract_expectation(200, None),
                 contract_expectation(200, None),
                 contract_expectation(200, None),
@@ -297,7 +320,7 @@ async fn route_contract_behavior_matrix() {
             ],
             method: "GET",
             name: "health",
-            phase: ContractPhase::PostSetup,
+            phase: ContractPhase::Always,
             request: ContractRequest::None,
             side_effect: ContractSideEffect::None,
             success_content_type: Some("text/plain; charset=utf-8"),
@@ -518,19 +541,6 @@ async fn route_contract_behavior_matrix() {
             path: "/api/settings/upstream",
         },
         RouteBehavior {
-            access: ContractAccess::OperatorAny,
-            accept_html: false,
-            expectations: configured_contract_expectations(200, 200),
-            method: "POST",
-            name: "api-settings-account",
-            phase: ContractPhase::PostSetup,
-            request: ContractRequest::Json,
-            side_effect: ContractSideEffect::DurableConfigAndSession,
-            success_content_type: Some("application/json"),
-            success_status: 200,
-            path: "/api/settings/account",
-        },
-        RouteBehavior {
             access: ContractAccess::Public,
             accept_html: true,
             expectations: [
@@ -625,6 +635,21 @@ async fn route_contract_behavior_matrix() {
             success_status: 200,
             path: "/setup/validate-key",
         },
+        // Password rotation invalidates every prior cookie for that actor, so
+        // keep this after all other authenticated probes.
+        RouteBehavior {
+            access: ContractAccess::OperatorAny,
+            accept_html: false,
+            expectations: configured_contract_expectations(200, 200),
+            method: "POST",
+            name: "api-settings-account",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::Json,
+            side_effect: ContractSideEffect::DurableConfigAndSession,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/api/settings/account",
+        },
         // Keep the successful claim last: it intentionally closes the
         // before-setup fixture for every subsequent request.
         RouteBehavior {
@@ -704,9 +729,21 @@ async fn route_contract_behavior_matrix() {
                 }
             }
 
+            let response_content_type = response
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_owned);
             let has_session_cookie = response.headers().contains_key("set-cookie");
             let body = response.bytes().await.unwrap();
             if let Some(error) = expected.error {
+                assert_eq!(
+                    response_content_type.as_deref(),
+                    Some("application/json"),
+                    "route-contract:error-content-type: {} {} actor={actor:?}",
+                    row.method,
+                    row.path
+                );
                 let value: serde_json::Value = serde_json::from_slice(&body).unwrap_or_else(|e| {
                     panic!(
                         "route-contract:error: {} {} actor={actor:?} was not JSON: {e}",
@@ -746,13 +783,18 @@ async fn route_contract_behavior_matrix() {
                         "route-contract:session: {} {} actor={actor:?}",
                         row.method, row.path
                     );
+                    assert_eq!(
+                        upstream_after, upstream_before,
+                        "route-contract:side-effect: {} {} actor={actor:?}",
+                        row.method, row.path
+                    );
                 }
                 ContractSideEffect::DurableConfig => {
                     if succeeded {
-                        assert_ne!(
-                            config_after, config_before,
-                            "route-contract:durable-bytes: {} {} actor={actor:?}",
-                            row.method, row.path
+                        assert_contract_durable_change(
+                            &config_before,
+                            &config_after,
+                            &format!("{} {} actor={actor:?}", row.method, row.path),
                         );
                     } else {
                         assert_eq!(
@@ -761,13 +803,18 @@ async fn route_contract_behavior_matrix() {
                             row.method, row.path
                         );
                     }
+                    assert_eq!(
+                        upstream_after, upstream_before,
+                        "route-contract:side-effect: {} {} actor={actor:?}",
+                        row.method, row.path
+                    );
                 }
                 ContractSideEffect::DurableConfigAndSession => {
                     if succeeded {
-                        assert_ne!(
-                            config_after, config_before,
-                            "route-contract:durable-bytes: {} {} actor={actor:?}",
-                            row.method, row.path
+                        assert_contract_durable_change(
+                            &config_before,
+                            &config_after,
+                            &format!("{} {} actor={actor:?}", row.method, row.path),
                         );
                     } else {
                         assert_eq!(
@@ -781,11 +828,16 @@ async fn route_contract_behavior_matrix() {
                         "route-contract:session: {} {} actor={actor:?}",
                         row.method, row.path
                     );
+                    assert_eq!(
+                        upstream_after, upstream_before,
+                        "route-contract:side-effect: {} {} actor={actor:?}",
+                        row.method, row.path
+                    );
                 }
                 ContractSideEffect::Upstream => {
                     assert_eq!(
-                        upstream_after > upstream_before,
-                        succeeded,
+                        upstream_after,
+                        upstream_before + usize::from(succeeded),
                         "route-contract:side-effect: {} {} actor={actor:?}",
                         row.method,
                         row.path
@@ -798,6 +850,111 @@ async fn route_contract_behavior_matrix() {
                 }
             }
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ClientAuthBehavior {
+    bearer: Option<&'static str>,
+    error: Option<&'static str>,
+    status: u16,
+    upstream: bool,
+}
+
+#[tokio::test]
+async fn route_contract_client_auth_matrix() {
+    let mock = start_mock().await;
+    let before_setup = start_proxy_fresh().await;
+    let keyed_proxy = start_proxy_with(
+        &mock.url,
+        StoreOpts {
+            clients: vec![("matrix-client".into(), "matrix-secret".into())],
+            open: false,
+            ..Default::default()
+        },
+        &[],
+    )
+    .await;
+    let rows = [
+        (
+            &before_setup,
+            ClientAuthBehavior {
+                bearer: None,
+                error: Some("setup_required"),
+                status: 503,
+                upstream: false,
+            },
+        ),
+        (
+            &keyed_proxy,
+            ClientAuthBehavior {
+                bearer: None,
+                error: Some("unauthorized"),
+                status: 401,
+                upstream: false,
+            },
+        ),
+        (
+            &keyed_proxy,
+            ClientAuthBehavior {
+                bearer: Some("wrong-secret"),
+                error: Some("unauthorized"),
+                status: 401,
+                upstream: false,
+            },
+        ),
+        (
+            &keyed_proxy,
+            ClientAuthBehavior {
+                bearer: Some("matrix-secret"),
+                error: None,
+                status: 200,
+                upstream: true,
+            },
+        ),
+    ];
+
+    for (proxy, row) in rows {
+        let config_before = contract_config_bytes(proxy);
+        let upstream_before = contract_upstream_calls(&mock);
+        let mut request = no_redirect_client()
+            .post(proxy.url("/v1/chat/completions"))
+            .header(CONTENT_TYPE, "application/json")
+            .body(serde_json::to_vec(&chat_body("route-contract-client-auth", false)).unwrap());
+        if let Some(bearer) = row.bearer {
+            request = request.bearer_auth(bearer);
+        }
+        let response = request.send().await.unwrap();
+        assert_eq!(
+            response.status().as_u16(),
+            row.status,
+            "route-contract:client-auth: {row:?}"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("application/json"),
+            "route-contract:client-auth-content-type: {row:?}"
+        );
+        let body: serde_json::Value = response.json().await.unwrap();
+        if let Some(error) = row.error {
+            assert_eq!(
+                body["error"]["code"], error,
+                "route-contract:client-auth: {row:?}"
+            );
+        }
+        assert_eq!(
+            contract_upstream_calls(&mock),
+            upstream_before + usize::from(row.upstream),
+            "route-contract:client-auth-side-effect: {row:?}"
+        );
+        assert_eq!(
+            contract_config_bytes(proxy),
+            config_before,
+            "route-contract:client-auth-durable-bytes: {row:?}"
+        );
     }
 }
 
@@ -904,10 +1061,10 @@ async fn route_contract_ownership_matrix() {
         );
         let after = contract_config_bytes(&proxy);
         if row.durable_change {
-            assert_ne!(
-                after, before,
-                "route-contract:durable-bytes: {:?} {}",
-                row.ownership, row.path
+            assert_contract_durable_change(
+                &before,
+                &after,
+                &format!("{:?} {}", row.ownership, row.path),
             );
         } else {
             assert_eq!(
@@ -922,6 +1079,16 @@ async fn route_contract_ownership_matrix() {
             );
         }
     }
+}
+
+#[test]
+#[should_panic(expected = "route-contract:durable-bytes")]
+fn route_contract_durable_self_test_names_missing_post_write_file() {
+    assert_contract_durable_change(
+        &Some(b"before".to_vec()),
+        &None,
+        "self-test configured writer",
+    );
 }
 
 /// Send only headers for an over-limit body. `Expect: 100-continue` keeps the

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -7,6 +7,7 @@
 mod support;
 
 use std::os::unix::fs::PermissionsExt;
+use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
 use reqwest::header::CONTENT_TYPE;
@@ -49,6 +50,878 @@ async fn assert_exact_api_error(
         format!(r#"{{"error":{{"code":"{code}","message":"{message}","type":"proxy_error"}}}}"#)
             .as_bytes()
     );
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ContractActor {
+    BeforeSetup,
+    Anonymous,
+    User,
+    Admin,
+    Superuser,
+}
+
+impl ContractActor {
+    const ALL: [Self; 5] = [
+        Self::BeforeSetup,
+        Self::Anonymous,
+        Self::User,
+        Self::Admin,
+        Self::Superuser,
+    ];
+
+    fn index(self) -> usize {
+        match self {
+            Self::BeforeSetup => 0,
+            Self::Anonymous => 1,
+            Self::User => 2,
+            Self::Admin => 3,
+            Self::Superuser => 4,
+        }
+    }
+
+    fn username(self) -> &'static str {
+        match self {
+            Self::User => "matrix-user",
+            Self::Admin => "matrix-admin",
+            Self::BeforeSetup | Self::Anonymous | Self::Superuser => support::TEST_USER,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ContractAccess {
+    Client,
+    Public,
+    OperatorAny,
+    OperatorAdmin,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ContractPhase {
+    Always,
+    PreSetup,
+    PostSetup,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ContractRequest {
+    None,
+    Json,
+    Form,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ContractSideEffect {
+    None,
+    SessionCookie,
+    DurableConfig,
+    DurableConfigAndSession,
+    Upstream,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ContractExpectation {
+    status: u16,
+    error: Option<&'static str>,
+}
+
+const fn contract_expectation(status: u16, error: Option<&'static str>) -> ContractExpectation {
+    ContractExpectation { status, error }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct RouteBehavior {
+    access: ContractAccess,
+    accept_html: bool,
+    expectations: [ContractExpectation; 5],
+    method: &'static str,
+    name: &'static str,
+    phase: ContractPhase,
+    request: ContractRequest,
+    side_effect: ContractSideEffect,
+    success_content_type: Option<&'static str>,
+    success_status: u16,
+    path: &'static str,
+}
+
+fn configured_contract_expectations(
+    success_status: u16,
+    ordinary_user_status: u16,
+) -> [ContractExpectation; 5] {
+    [
+        contract_expectation(503, Some("setup_required")),
+        contract_expectation(401, Some("unauthorized")),
+        contract_expectation(
+            ordinary_user_status,
+            (ordinary_user_status == 403).then_some("forbidden"),
+        ),
+        contract_expectation(success_status, None),
+        contract_expectation(success_status, None),
+    ]
+}
+
+fn contract_config_bytes(proxy: &support::Proxy) -> Option<Vec<u8>> {
+    std::fs::read(proxy.data_dir.join("config.json")).ok()
+}
+
+fn contract_upstream_calls(mock: &support::MockNim) -> usize {
+    mock.state.hit_count() + mock.state.models_hits.load(Ordering::SeqCst)
+}
+
+fn contract_body(
+    row: &RouteBehavior,
+    actor: ContractActor,
+    mock: &support::MockNim,
+) -> Option<String> {
+    let suffix = match actor {
+        ContractActor::BeforeSetup => "before",
+        ContractActor::Anonymous => "anonymous",
+        ContractActor::User => "user",
+        ContractActor::Admin => "admin",
+        ContractActor::Superuser => "superuser",
+    };
+    let value = match row.name {
+        "api-settings-nim-keys" => {
+            serde_json::json!({"add": {"key": format!("matrix-nim-{suffix}"), "rpm": 41}})
+        }
+        "api-settings-clients" => {
+            serde_json::json!({"add": {"name": format!("matrix-client-{suffix}")}})
+        }
+        "api-settings-limits" => serde_json::json!({
+            "heartbeat_secs": 1,
+            "max_inflight": 513,
+            "max_wait_secs": 31,
+            "models_ttl_secs": 300,
+            "request_timeout_secs": 300,
+            "stream_idle_secs": 300,
+            "strict_passthrough": false
+        }),
+        "api-settings-history" => serde_json::json!({
+            "days": 60,
+            "default_window_days": 30,
+            "slo_target_percent": 99.8
+        }),
+        "api-settings-governor" => serde_json::json!({"enabled": false}),
+        "api-settings-users" => serde_json::json!({
+            "add": {
+                "password": "matrix-password-1",
+                "role": "user",
+                "username": format!("created-{suffix}")
+            }
+        }),
+        "api-settings-validate-key" => serde_json::json!({"key": "probe-key"}),
+        "api-settings-upstream" => {
+            serde_json::json!({"base_url": format!("{}/matrix-{suffix}", mock.url)})
+        }
+        "api-settings-account" => serde_json::json!({
+            "current_password": TEST_PASSWORD,
+            "new_password": format!("matrix-new-password-{suffix}")
+        }),
+        "v1-wildcard" => serde_json::json!({
+            "messages": [{"content": format!("route contract {suffix}"), "role": "user"}],
+            "model": "mock/model-a",
+            "stream": false
+        }),
+        "login-post" => {
+            return Some(format!(
+                "username={}&password={}",
+                actor.username(),
+                TEST_PASSWORD
+            ));
+        }
+        "setup-post" => serde_json::json!({
+            "base_url": mock.url,
+            "nim_keys": [{"key": "matrix-setup-key", "rpm": 40}],
+            "password": "matrix-setup-password",
+            "username": "matrix-root"
+        }),
+        "setup-validate-key" => {
+            serde_json::json!({"base_url": mock.url, "key": "probe-key"})
+        }
+        _ => return None,
+    };
+    Some(serde_json::to_string(&value).unwrap())
+}
+
+async fn send_contract_request(
+    row: &RouteBehavior,
+    actor: ContractActor,
+    proxy: &support::Proxy,
+    cookie: Option<&str>,
+    mock: &support::MockNim,
+) -> reqwest::Response {
+    let mut request = match row.method {
+        "GET" => client().get(proxy.url(row.path)),
+        "POST" => client().post(proxy.url(row.path)),
+        other => panic!("route-contract:request: unsupported method {other}"),
+    };
+    if row.accept_html {
+        request = request.header("accept", "text/html");
+    }
+    if let Some(cookie) = cookie {
+        request = request.header("cookie", cookie);
+    }
+    if let Some(body) = contract_body(row, actor, mock) {
+        request = match row.request {
+            ContractRequest::Json => request.header(CONTENT_TYPE, "application/json"),
+            ContractRequest::Form => {
+                request.header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+            }
+            ContractRequest::None => {
+                panic!(
+                    "route-contract:request: {} unexpectedly has a body",
+                    row.name
+                )
+            }
+        }
+        .body(body);
+    }
+    request.send().await.unwrap()
+}
+
+#[tokio::test]
+async fn route_contract_behavior_matrix() {
+    let rows = vec![
+        RouteBehavior {
+            access: ContractAccess::Public,
+            accept_html: false,
+            // Intentionally wrong for the committed red proof. /health is
+            // phase-independent and really returns 200 before setup.
+            expectations: [
+                contract_expectation(503, Some("setup_required")),
+                contract_expectation(200, None),
+                contract_expectation(200, None),
+                contract_expectation(200, None),
+                contract_expectation(200, None),
+            ],
+            method: "GET",
+            name: "health",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::None,
+            side_effect: ContractSideEffect::None,
+            success_content_type: Some("text/plain; charset=utf-8"),
+            success_status: 200,
+            path: "/health",
+        },
+        RouteBehavior {
+            access: ContractAccess::OperatorAny,
+            accept_html: true,
+            expectations: [
+                contract_expectation(302, None),
+                contract_expectation(302, None),
+                contract_expectation(200, None),
+                contract_expectation(200, None),
+                contract_expectation(200, None),
+            ],
+            method: "GET",
+            name: "root-page",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::None,
+            side_effect: ContractSideEffect::None,
+            success_content_type: Some("text/html; charset=utf-8"),
+            success_status: 200,
+            path: "/",
+        },
+        RouteBehavior {
+            access: ContractAccess::OperatorAny,
+            accept_html: true,
+            expectations: [
+                contract_expectation(302, None),
+                contract_expectation(302, None),
+                contract_expectation(200, None),
+                contract_expectation(200, None),
+                contract_expectation(200, None),
+            ],
+            method: "GET",
+            name: "dash-page",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::None,
+            side_effect: ContractSideEffect::None,
+            success_content_type: Some("text/html; charset=utf-8"),
+            success_status: 200,
+            path: "/dash",
+        },
+        RouteBehavior {
+            access: ContractAccess::OperatorAny,
+            accept_html: false,
+            expectations: configured_contract_expectations(200, 200),
+            method: "GET",
+            name: "metrics",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::None,
+            side_effect: ContractSideEffect::None,
+            success_content_type: Some("text/plain; charset=utf-8"),
+            success_status: 200,
+            path: "/metrics",
+        },
+        RouteBehavior {
+            access: ContractAccess::OperatorAny,
+            accept_html: false,
+            expectations: configured_contract_expectations(200, 200),
+            method: "GET",
+            name: "api-dashboard",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::None,
+            side_effect: ContractSideEffect::None,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/api/dashboard",
+        },
+        RouteBehavior {
+            access: ContractAccess::OperatorAny,
+            accept_html: false,
+            expectations: configured_contract_expectations(200, 200),
+            method: "GET",
+            name: "api-dashboard-now",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::None,
+            side_effect: ContractSideEffect::None,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/api/dashboard/now",
+        },
+        RouteBehavior {
+            access: ContractAccess::OperatorAny,
+            accept_html: false,
+            expectations: configured_contract_expectations(200, 200),
+            method: "GET",
+            name: "api-config",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::None,
+            side_effect: ContractSideEffect::None,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/api/config",
+        },
+        RouteBehavior {
+            access: ContractAccess::OperatorAny,
+            accept_html: false,
+            expectations: configured_contract_expectations(200, 200),
+            method: "POST",
+            name: "api-settings-nim-keys",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::Json,
+            side_effect: ContractSideEffect::DurableConfig,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/api/settings/nim-keys",
+        },
+        RouteBehavior {
+            access: ContractAccess::OperatorAny,
+            accept_html: false,
+            expectations: configured_contract_expectations(200, 200),
+            method: "POST",
+            name: "api-settings-clients",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::Json,
+            side_effect: ContractSideEffect::DurableConfig,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/api/settings/clients",
+        },
+        RouteBehavior {
+            access: ContractAccess::OperatorAdmin,
+            accept_html: false,
+            expectations: configured_contract_expectations(200, 403),
+            method: "POST",
+            name: "api-settings-limits",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::Json,
+            side_effect: ContractSideEffect::DurableConfig,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/api/settings/limits",
+        },
+        RouteBehavior {
+            access: ContractAccess::OperatorAdmin,
+            accept_html: false,
+            expectations: configured_contract_expectations(200, 403),
+            method: "POST",
+            name: "api-settings-history",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::Json,
+            side_effect: ContractSideEffect::DurableConfig,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/api/settings/history",
+        },
+        RouteBehavior {
+            access: ContractAccess::OperatorAdmin,
+            accept_html: false,
+            expectations: configured_contract_expectations(200, 403),
+            method: "POST",
+            name: "api-settings-governor",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::Json,
+            side_effect: ContractSideEffect::DurableConfig,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/api/settings/governor",
+        },
+        RouteBehavior {
+            access: ContractAccess::OperatorAdmin,
+            accept_html: false,
+            expectations: configured_contract_expectations(200, 403),
+            method: "POST",
+            name: "api-settings-users",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::Json,
+            side_effect: ContractSideEffect::DurableConfig,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/api/settings/users",
+        },
+        RouteBehavior {
+            access: ContractAccess::OperatorAny,
+            accept_html: false,
+            expectations: configured_contract_expectations(200, 200),
+            method: "POST",
+            name: "api-settings-validate-key",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::Json,
+            side_effect: ContractSideEffect::Upstream,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/api/settings/validate-key",
+        },
+        RouteBehavior {
+            access: ContractAccess::Client,
+            accept_html: false,
+            expectations: [
+                contract_expectation(503, Some("setup_required")),
+                contract_expectation(200, None),
+                contract_expectation(200, None),
+                contract_expectation(200, None),
+                contract_expectation(200, None),
+            ],
+            method: "POST",
+            name: "v1-wildcard",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::Json,
+            side_effect: ContractSideEffect::Upstream,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/v1/chat/completions",
+        },
+        RouteBehavior {
+            access: ContractAccess::OperatorAdmin,
+            accept_html: false,
+            expectations: configured_contract_expectations(200, 403),
+            method: "POST",
+            name: "api-settings-upstream",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::Json,
+            side_effect: ContractSideEffect::DurableConfig,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/api/settings/upstream",
+        },
+        RouteBehavior {
+            access: ContractAccess::OperatorAny,
+            accept_html: false,
+            expectations: configured_contract_expectations(200, 200),
+            method: "POST",
+            name: "api-settings-account",
+            phase: ContractPhase::PostSetup,
+            request: ContractRequest::Json,
+            side_effect: ContractSideEffect::DurableConfigAndSession,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/api/settings/account",
+        },
+        RouteBehavior {
+            access: ContractAccess::Public,
+            accept_html: true,
+            expectations: [
+                contract_expectation(302, None),
+                contract_expectation(200, None),
+                contract_expectation(302, None),
+                contract_expectation(302, None),
+                contract_expectation(302, None),
+            ],
+            method: "GET",
+            name: "login-get",
+            phase: ContractPhase::Always,
+            request: ContractRequest::None,
+            side_effect: ContractSideEffect::None,
+            success_content_type: Some("text/html; charset=utf-8"),
+            success_status: 200,
+            path: "/login",
+        },
+        RouteBehavior {
+            access: ContractAccess::Public,
+            accept_html: true,
+            expectations: [
+                contract_expectation(302, None),
+                contract_expectation(303, None),
+                contract_expectation(303, None),
+                contract_expectation(303, None),
+                contract_expectation(303, None),
+            ],
+            method: "POST",
+            name: "login-post",
+            phase: ContractPhase::Always,
+            request: ContractRequest::Form,
+            side_effect: ContractSideEffect::SessionCookie,
+            success_content_type: None,
+            success_status: 303,
+            path: "/login",
+        },
+        RouteBehavior {
+            access: ContractAccess::Public,
+            accept_html: true,
+            expectations: [
+                contract_expectation(303, None),
+                contract_expectation(303, None),
+                contract_expectation(303, None),
+                contract_expectation(303, None),
+                contract_expectation(303, None),
+            ],
+            method: "POST",
+            name: "logout",
+            phase: ContractPhase::Always,
+            request: ContractRequest::None,
+            side_effect: ContractSideEffect::SessionCookie,
+            success_content_type: None,
+            success_status: 303,
+            path: "/logout",
+        },
+        RouteBehavior {
+            access: ContractAccess::Public,
+            accept_html: true,
+            expectations: [
+                contract_expectation(200, None),
+                contract_expectation(404, None),
+                contract_expectation(404, None),
+                contract_expectation(404, None),
+                contract_expectation(404, None),
+            ],
+            method: "GET",
+            name: "setup-get",
+            phase: ContractPhase::PreSetup,
+            request: ContractRequest::None,
+            side_effect: ContractSideEffect::None,
+            success_content_type: Some("text/html; charset=utf-8"),
+            success_status: 200,
+            path: "/setup",
+        },
+        RouteBehavior {
+            access: ContractAccess::Public,
+            accept_html: false,
+            expectations: [
+                contract_expectation(200, None),
+                contract_expectation(409, Some("setup_complete")),
+                contract_expectation(409, Some("setup_complete")),
+                contract_expectation(409, Some("setup_complete")),
+                contract_expectation(409, Some("setup_complete")),
+            ],
+            method: "POST",
+            name: "setup-validate-key",
+            phase: ContractPhase::PreSetup,
+            request: ContractRequest::Json,
+            side_effect: ContractSideEffect::Upstream,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/setup/validate-key",
+        },
+        // Keep the successful claim last: it intentionally closes the
+        // before-setup fixture for every subsequent request.
+        RouteBehavior {
+            access: ContractAccess::Public,
+            accept_html: false,
+            expectations: [
+                contract_expectation(200, None),
+                contract_expectation(409, Some("setup_complete")),
+                contract_expectation(409, Some("setup_complete")),
+                contract_expectation(409, Some("setup_complete")),
+                contract_expectation(409, Some("setup_complete")),
+            ],
+            method: "POST",
+            name: "setup-post",
+            phase: ContractPhase::PreSetup,
+            request: ContractRequest::Json,
+            side_effect: ContractSideEffect::DurableConfigAndSession,
+            success_content_type: Some("application/json"),
+            success_status: 200,
+            path: "/setup",
+        },
+    ];
+
+    assert_eq!(rows.len(), 23, "route-contract:inventory");
+
+    let mock = start_mock().await;
+    let before_setup = start_proxy_fresh().await;
+    let configured = start_proxy_with(
+        &mock.url,
+        StoreOpts {
+            extra_users: vec![
+                ("matrix-user".into(), "user".into()),
+                ("matrix-admin".into(), "admin".into()),
+            ],
+            ..Default::default()
+        },
+        &[],
+    )
+    .await;
+    let user_cookie = login_as(&configured, "matrix-user").await;
+    let admin_cookie = login_as(&configured, "matrix-admin").await;
+    let superuser_cookie = login(&configured).await;
+
+    for row in &rows {
+        for actor in ContractActor::ALL {
+            let (proxy, cookie) = match actor {
+                ContractActor::BeforeSetup => (&before_setup, None),
+                ContractActor::Anonymous => (&configured, None),
+                ContractActor::User => (&configured, Some(user_cookie.as_str())),
+                ContractActor::Admin => (&configured, Some(admin_cookie.as_str())),
+                ContractActor::Superuser => (&configured, Some(superuser_cookie.as_str())),
+            };
+            let expected = row.expectations[actor.index()];
+            let config_before = contract_config_bytes(proxy);
+            let upstream_before = contract_upstream_calls(&mock);
+            let response = send_contract_request(row, actor, proxy, cookie, &mock).await;
+            let actual_status = response.status().as_u16();
+            assert_eq!(
+                actual_status, expected.status,
+                "route-contract:phase/auth: {} {} actor={actor:?} access={:?} phase={:?}",
+                row.method, row.path, row.access, row.phase
+            );
+
+            let succeeded = actual_status == row.success_status;
+            if succeeded {
+                if let Some(content_type) = row.success_content_type {
+                    assert_eq!(
+                        response
+                            .headers()
+                            .get(CONTENT_TYPE)
+                            .and_then(|value| value.to_str().ok()),
+                        Some(content_type),
+                        "route-contract:success-content-type: {} {} actor={actor:?}",
+                        row.method,
+                        row.path
+                    );
+                }
+            }
+
+            let has_session_cookie = response.headers().contains_key("set-cookie");
+            let body = response.bytes().await.unwrap();
+            if let Some(error) = expected.error {
+                let value: serde_json::Value = serde_json::from_slice(&body).unwrap_or_else(|e| {
+                    panic!(
+                        "route-contract:error: {} {} actor={actor:?} was not JSON: {e}",
+                        row.method, row.path
+                    )
+                });
+                assert_eq!(
+                    value["error"]["code"], error,
+                    "route-contract:error: {} {} actor={actor:?}",
+                    row.method, row.path
+                );
+            }
+
+            let config_after = contract_config_bytes(proxy);
+            let upstream_after = contract_upstream_calls(&mock);
+            match row.side_effect {
+                ContractSideEffect::None => {
+                    assert_eq!(
+                        config_after, config_before,
+                        "route-contract:durable-bytes: {} {} actor={actor:?}",
+                        row.method, row.path
+                    );
+                    assert_eq!(
+                        upstream_after, upstream_before,
+                        "route-contract:side-effect: {} {} actor={actor:?}",
+                        row.method, row.path
+                    );
+                }
+                ContractSideEffect::SessionCookie => {
+                    assert_eq!(
+                        config_after, config_before,
+                        "route-contract:durable-bytes: {} {} actor={actor:?}",
+                        row.method, row.path
+                    );
+                    assert_eq!(
+                        has_session_cookie, succeeded,
+                        "route-contract:session: {} {} actor={actor:?}",
+                        row.method, row.path
+                    );
+                }
+                ContractSideEffect::DurableConfig => {
+                    if succeeded {
+                        assert_ne!(
+                            config_after, config_before,
+                            "route-contract:durable-bytes: {} {} actor={actor:?}",
+                            row.method, row.path
+                        );
+                    } else {
+                        assert_eq!(
+                            config_after, config_before,
+                            "route-contract:durable-bytes: rejected {} {} actor={actor:?}",
+                            row.method, row.path
+                        );
+                    }
+                }
+                ContractSideEffect::DurableConfigAndSession => {
+                    if succeeded {
+                        assert_ne!(
+                            config_after, config_before,
+                            "route-contract:durable-bytes: {} {} actor={actor:?}",
+                            row.method, row.path
+                        );
+                    } else {
+                        assert_eq!(
+                            config_after, config_before,
+                            "route-contract:durable-bytes: rejected {} {} actor={actor:?}",
+                            row.method, row.path
+                        );
+                    }
+                    assert_eq!(
+                        has_session_cookie, succeeded,
+                        "route-contract:session: {} {} actor={actor:?}",
+                        row.method, row.path
+                    );
+                }
+                ContractSideEffect::Upstream => {
+                    assert_eq!(
+                        upstream_after > upstream_before,
+                        succeeded,
+                        "route-contract:side-effect: {} {} actor={actor:?}",
+                        row.method,
+                        row.path
+                    );
+                    assert_eq!(
+                        config_after, config_before,
+                        "route-contract:durable-bytes: {} {} actor={actor:?}",
+                        row.method, row.path
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ContractOwnership {
+    Own,
+    Other,
+}
+
+#[derive(Debug)]
+struct OwnershipBehavior {
+    body: serde_json::Value,
+    durable_change: bool,
+    ownership: ContractOwnership,
+    path: &'static str,
+    status: u16,
+}
+
+#[tokio::test]
+async fn route_contract_ownership_matrix() {
+    let mock = start_mock().await;
+    let proxy = start_proxy_with(
+        &mock.url,
+        StoreOpts {
+            clients: vec![("root-client".into(), "root-secret".into())],
+            extra_users: vec![("matrix-user".into(), "user".into())],
+            ..Default::default()
+        },
+        &[],
+    )
+    .await;
+    let root_cookie = login(&proxy).await;
+    let user_cookie = login_as(&proxy, "matrix-user").await;
+
+    let root_nim_fingerprint = api_config(&proxy, &root_cookie).await["nim_keys"][0]["fingerprint"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let (status, body) = post_json(
+        &proxy,
+        &user_cookie,
+        "/api/settings/nim-keys",
+        serde_json::json!({"add": {"key": "matrix-user-nim", "rpm": 40}}),
+    )
+    .await;
+    assert_eq!(status, 200, "ownership fixture add failed: {body}");
+    let user_nim_fingerprint = api_config(&proxy, &user_cookie).await["nim_keys"][0]["fingerprint"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let (status, body) = post_json(
+        &proxy,
+        &user_cookie,
+        "/api/settings/clients",
+        serde_json::json!({"add": {"name": "user-client"}}),
+    )
+    .await;
+    assert_eq!(status, 200, "ownership fixture add failed: {body}");
+
+    let rows = vec![
+        OwnershipBehavior {
+            body: serde_json::json!({
+                "set": {"fingerprint": user_nim_fingerprint, "rpm": 42}
+            }),
+            durable_change: true,
+            ownership: ContractOwnership::Own,
+            path: "/api/settings/nim-keys",
+            status: 200,
+        },
+        OwnershipBehavior {
+            body: serde_json::json!({
+                "set": {"fingerprint": root_nim_fingerprint, "rpm": 42}
+            }),
+            durable_change: false,
+            ownership: ContractOwnership::Other,
+            path: "/api/settings/nim-keys",
+            status: 403,
+        },
+        OwnershipBehavior {
+            body: serde_json::json!({"remove": "user-client"}),
+            durable_change: true,
+            ownership: ContractOwnership::Own,
+            path: "/api/settings/clients",
+            status: 200,
+        },
+        OwnershipBehavior {
+            body: serde_json::json!({"remove": "root-client"}),
+            durable_change: false,
+            ownership: ContractOwnership::Other,
+            path: "/api/settings/clients",
+            status: 403,
+        },
+    ];
+
+    for row in rows {
+        let before = contract_config_bytes(&proxy);
+        let (status, body) = post_json(&proxy, &user_cookie, row.path, row.body).await;
+        assert_eq!(
+            status.as_u16(),
+            row.status,
+            "route-contract:ownership: {:?} {}: {body}",
+            row.ownership,
+            row.path
+        );
+        let after = contract_config_bytes(&proxy);
+        if row.durable_change {
+            assert_ne!(
+                after, before,
+                "route-contract:durable-bytes: {:?} {}",
+                row.ownership, row.path
+            );
+        } else {
+            assert_eq!(
+                after, before,
+                "route-contract:durable-bytes: {:?} {}",
+                row.ownership, row.path
+            );
+            assert_eq!(
+                body["error"]["code"], "forbidden",
+                "route-contract:ownership: {:?} {}",
+                row.ownership, row.path
+            );
+        }
+    }
 }
 
 /// Send only headers for an over-limit body. `Expect: 100-continue` keeps the

--- a/tests/openapi.rs
+++ b/tests/openapi.rs
@@ -14,6 +14,18 @@
 
 use std::path::PathBuf;
 
+fn assert_global_security(spec: &serde_json::Value) {
+    let global = spec["security"].as_array().expect("document security");
+    assert_eq!(
+        global,
+        &[
+            serde_json::json!({"session_cookie": []}),
+            serde_json::json!({"basic_auth": []}),
+        ],
+        "route-contract:openapi-security: the /api/* routes inherit exactly session-cookie or Basic credentials"
+    );
+}
+
 fn spec_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("openapi.json")
 }
@@ -53,6 +65,20 @@ fn spec_is_usable() {
 
     let paths = spec["paths"].as_object().expect("paths");
     assert_eq!(paths.len(), 14, "12 /api/* routes + the 2 setup routes");
+    for omitted in [
+        "/",
+        "/dash",
+        "/health",
+        "/login",
+        "/logout",
+        "/metrics",
+        "/v1/{*path}",
+    ] {
+        assert!(
+            !paths.contains_key(omitted),
+            "{omitted}: non-control-plane or upstream-owned route must stay outside this spec"
+        );
+    }
 
     for (path, item) in paths {
         for (method, op) in item.as_object().expect("path item") {
@@ -99,8 +125,7 @@ fn spec_is_usable() {
     }
 
     // The document-level requirement the /api/* routes inherit.
-    let global = spec["security"].as_array().expect("document security");
-    assert_eq!(global.len(), 2, "session cookie or header credentials");
+    assert_global_security(&spec);
 
     // Every schema a response references must actually be in components.
     let schemas = spec["components"]["schemas"]
@@ -117,5 +142,18 @@ fn spec_is_usable() {
     let security = spec["components"]["securitySchemes"]
         .as_object()
         .expect("securitySchemes");
-    assert!(security.contains_key("session_cookie") && security.contains_key("basic_auth"));
+    assert_eq!(security["session_cookie"]["type"], "apiKey");
+    assert_eq!(security["session_cookie"]["in"], "cookie");
+    assert_eq!(security["session_cookie"]["name"], "nimproxy_session");
+    assert_eq!(security["basic_auth"]["type"], "http");
+    assert_eq!(security["basic_auth"]["scheme"], "basic");
+}
+
+#[test]
+#[should_panic(expected = "route-contract:openapi-security")]
+fn global_security_self_test_names_wrong_requirement() {
+    let mut spec: serde_json::Value =
+        serde_json::from_str(&nim_proxy::openapi_json()).expect("generated OpenAPI");
+    spec["security"] = serde_json::json!([{"wrong_scheme": []}]);
+    assert_global_security(&spec);
 }


### PR DESCRIPTION
## Outcome

Establish one tested inventory for all 23 live HTTP method/path contracts and their setup, authentication, authorization, ownership, and OpenAPI boundaries.

## Proof

- 23 routes × 5 actor/setup states = 115 real-request behavior cases
- 4 ownership cases and 4 client-auth cases
- Exact status, error code, content type, durable-store bytes, and upstream-call deltas
- Three named negative self-tests prove registration, OpenAPI-security, and durable-byte checks can fail
- Red: a8f8c49
- Green: ce8fe31
- Fresh gate: 128 unit, 98 E2E, 3 OpenAPI, 4 auth-filtered tests; Clippy, formatting, guide, and diff checks pass
- Independent review: 0 blocking and 0 nonblocking findings

## Constraint

The metadata describes live handlers but never becomes a second router. `openapi.json` remains byte-identical.

## Ponytail

Rung 2: reuse live registration and the generated OpenAPI specification.

Refs #91
Parent #69

This PR targets `release/v0.6.6`; `main` remains untouched.