### PR TITLE
refactor: make catalog sinks context explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,11 +25,11 @@ Break any of these and the change is wrong regardless of whether it works:
    refuses to boot. This durable-store startup rule applies to the config/auth
    store; history recovery follows its own
    [documented format policy](knowledge/architecture/metrics-history.md).
-2. **Escape once.** The current
-   [escape-at-load decision](knowledge/decisions/message-catalog-and-escaping.md)
-   remains binding: catalog values are escaped at load, and no render helper
-   escapes its label argument again. Only the separately approved atomic
-   replacement may supersede it.
+2. **Context owns the sink.** Page code passes catalog ids to DOM text,
+   allowlisted text-attribute, and structured-node helpers. Fixed-markup HTML
+   receives inert catalog descriptors and resolves and escapes them at its one
+   HTML boundary. Raw lookup is confined to canonical sink bodies. Catalog
+   text never enters URL, style, event, script, CSS, or raw-SVG contexts.
 3. **Zero upstream rate violations.** Not "few". The proxy exists to never
    exceed the per-key limit.
 4. **The wire format does not move.** Protected machine contracts include API

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -647,6 +647,29 @@ git commit -m "test: enforce HTTP trust boundaries"
 
 ### Task 3: Replace escape-at-load with contextual sinks atomically
 
+#### Execution record
+
+**Outcome:** Plain catalogs with context-owned sinks. **Proof:** Every hostile
+catalog/sink fixture fires by its exact check id and both pages render hostile
+catalog text literally. **Constraint:** Policy, runtime, negative checks, sink
+inventory, knowledge, and the guide invariant move atomically; there is no
+escaped/plain compatibility layer. **Ponytail Rung:** 4 — use native DOM
+`textContent` and `setAttribute` primitives.
+
+- 2026-07-30: no scope delta. The committed red proof adds 38 source self-test
+  cases and 11 locale fixtures. The source cases independently cover element
+  text, all four allowed text attributes, `href`, `src`, `style`, `onclick`,
+  script text, CSS, raw SVG, an escaped fixed-markup HTML string, a raw HTML
+  string, and structured-message HTML. The exact new check ids are
+  `catalog-markup`, `catalog-entity-markup`,
+  `forbidden-catalog-context`, `sink-context`, and
+  `structured-message-html`.
+- 2026-07-30: the two self-test commands passed by observing every hostile
+  fixture fail under its named check. Both unchanged page runtimes then failed
+  their required browser probe as `[sink-context]`: `message is not
+  reachable`. This is the intended red state for the missing one-type plain
+  catalog runtime.
+
 **GitHub issue title:** `v0.6.6: make catalogs plain and enforce contextual sinks`
 
 **Files:**
@@ -685,7 +708,7 @@ function setMessageAttr(node, attr, id, params = {}) {
 - Structured messages use fixed caller-created nodes. Catalog values never
   enter URL, style, event, script, CSS, or raw-SVG contexts.
 
-- [ ] **Step 1: Extend negative self-tests before changing helpers**
+- [x] **Step 1: Extend negative self-tests before changing helpers**
 
 Add exact check ids:
 
@@ -701,7 +724,7 @@ Fixtures must independently send catalog probes to element text, each allowed
 attribute, `href`, `src`, `style`, `onclick`, script text, CSS, raw SVG, and an
 unavoidable HTML-string sink.
 
-- [ ] **Step 2: Observe the red proof**
+- [x] **Step 2: Observe the red proof**
 
 ```sh
 python3 scripts/check_i18n.py --selftest

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -59,8 +59,9 @@ GitHub Actions, GitHub issues/milestones/Projects.
 - Data from APIs stays data: model ids, client names, publisher names, metric
   names/labels, prompts, response content, upstream error content, and
   `nimproxy_*` series are never localized or title-cased.
-- The current escape-at-load invariant remains binding until Task 3 replaces
-  the guide, decision, runtime, sink inventory, and negative checks atomically.
+- The id/descriptor context-owned-sink invariant is binding after Task 3:
+  page code passes catalog ids to DOM sinks and inert descriptors to
+  fixed-markup HTML builders, which resolve and escape them at one boundary.
 - No frontend framework, package manifest, bundler, runtime translation,
   translation/CDN dependency, database, TSDB, compatibility reader for
   experimental history, or new scheduling/gateway behavior.
@@ -256,7 +257,7 @@ changing it.
 |---|---|---|---|---|
 | 1 | One typed JSON rejection boundary | Raw E2E error bytes and unchanged stores | Do not change HTML, login, health, metrics, or `/v1` errors | 5 — use Axum extractors/fallbacks |
 | 2 | One tested trust-boundary inventory | Real-request route matrix agrees with OpenAPI | Metadata describes handlers; it is not a second router | 2 — reuse live registration and generated spec |
-| 3 | Plain catalogs with context-owned sinks | Every hostile sink probe fires by id | Policy, runtime, checks, and guide change atomically | 4 — use DOM text/attribute primitives |
+| 3 | Catalog ids/descriptors with context-owned sinks | Every hostile sink probe fires by id | Policy, runtime, checks, and guide change atomically | 4 — use DOM text/attribute primitives |
 | 4 | Maintainable embedded presentation assets | Gating/CSP/asset checks against served bytes | One binary; no network or runtime asset dependency | 4/5 — browser primitives plus existing Axum |
 | 5 | Canonical operational English | Projection/vocabulary/catalog checks | No machine data is rewritten or localized | 2 — extend existing locale tools |
 | 6 | Frozen dormant locale contracts | Persistence/auth/raw-byte failure matrix | Only installed `en-US`; fail closed | 2 — extend existing stores and settings routes |
@@ -468,7 +469,7 @@ Update the typed-response decision and test strategy; add the newest log entry
 at the top. Give the reviewer the complete uncommitted task diff plus the raw
 wire and side-effect assertions.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```sh
 git add src/api.rs src/lib.rs src/settings.rs tests/e2e.rs tests/openapi.rs \
@@ -649,12 +650,12 @@ git commit -m "test: enforce HTTP trust boundaries"
 
 #### Execution record
 
-**Outcome:** Plain catalogs with context-owned sinks. **Proof:** Every hostile
-catalog/sink fixture fires by its exact check id and both pages render hostile
-catalog text literally. **Constraint:** Policy, runtime, negative checks, sink
-inventory, knowledge, and the guide invariant move atomically; there is no
-escaped/plain compatibility layer. **Ponytail Rung:** 4 — use native DOM
-`textContent` and `setAttribute` primitives.
+**Outcome:** Catalog ids and inert descriptors reach only context-owning sinks.
+**Proof:** Every hostile catalog/sink fixture fires by its exact check id and
+both pages render hostile catalog text literally. **Constraint:** Policy,
+runtime, negative checks, sink inventory, knowledge, and the guide invariant
+move atomically; there is no escaped/plain compatibility layer. **Ponytail
+Rung:** 4 — use native DOM `textContent` and `setAttribute` primitives.
 
 - 2026-07-30: no scope delta. The committed red proof adds 38 source self-test
   cases and 11 locale fixtures. The source cases independently cover element
@@ -669,6 +670,87 @@ escaped/plain compatibility layer. **Ponytail Rung:** 4 — use native DOM
   their required browser probe as `[sink-context]`: `message is not
   reachable`. This is the intended red state for the missing one-type plain
   catalog runtime.
+- 2026-07-30 scope delta: the atomic invariant replacement also modifies
+  `scripts/check_agent_guide.py` because that executable contract required the
+  retired `Escape once` heading; leaving it unchanged makes the new guide fail
+  its own mandatory check. It also modifies
+  `knowledge/decisions/render-gate.md` because that decision governs
+  `--escape-probe` and described the retired escape-at-load behavior; leaving
+  it unchanged gives the changed browser gate contradictory authority.
+  `knowledge/decisions/locale-guards.md` is updated for the new markup/entity
+  check ids, and `knowledge/index.md` is updated as required by the repository
+  ingest contract. These are consistency dependencies of the one atomic
+  cutover, not additional product behavior.
+- 2026-07-30: independent pre-commit review withheld approval on four valid
+  findings. Added red checks that proved unescaped concatenated and multiline
+  `innerHTML`, `insertAdjacentHTML`, direct `setAttribute`, dropped inline
+  markers, and repeated fixed-node placeholders all escaped the first gate.
+  The repaired source lint recognizes the approved fixed-markup sink
+  inventory and requires exactly one expected sink check id; the locale
+  validator requires source-equivalent inline structure; repeated value
+  placeholders clone fixed nodes; and the remaining pre-escaped `tcStr` caller
+  is plain. The initial reviewer must explicitly approve the corrected tree
+  before commit.
+- 2026-07-30: the first re-review verified all four repairs, then withheld
+  approval on a second fail-open scanner edge. New red mutations proved raw
+  SVG concatenation (escaped and unescaped), `innerHTML +=`, semicolon-free
+  HTML calls/assignments, and nested `message()` arguments in direct
+  `setAttribute` all bypassed the first repair. The scanner now reads complete
+  statement and balanced-call boundaries only to locate owners, enumerates
+  every catalog lookup, and fails closed unless it has an approved text,
+  attribute, HTML, or named plain-value owner. Raw SVG is categorically
+  forbidden; the exact-id matrix covers all six spellings plus unknown owner
+  and unknown binding controls. A second fresh re-review remains required
+  before commit.
+- 2026-07-30: the next re-review proved the enumerator still granted blanket
+  approval to unknown nested owners inside named functions and let direct text
+  aliases/ASI-separated statements inherit an earlier approved shape. Nine
+  added red controls cover unknown owners inside a returner, internal helper,
+  and approved binding; script/style/SVG aliases; two ASI boundaries; fake
+  canonical `setAttribute`; and direct-return/internal positive controls.
+  Approval now belongs to the individual call: unknown nested owners reject
+  before binding/function checks, named functions admit only direct return or
+  internal `text` assignment, direct catalog text writes are confined to the
+  canonical helper/mixed-text callback, and element-creation aliases are
+  classified. The page's remaining direct dynamic text calls now use
+  `setMessageText` or `createTextNode`. Another frozen-tree re-review is
+  required.
+- 2026-07-30: the frozen re-review found two further fail-open classes: a
+  string literal could spoof the inferred HTML owner, and text/structured
+  helpers accepted script/style/SVG targets. Continuing to extend partial
+  JavaScript owner inference violated the Ponytail ladder, so the redesign
+  removes it. Page code now passes ids to DOM sinks and frozen Symbol-branded
+  descriptors to fixed-markup HTML builders. Only `escapeHtml()` resolves a
+  descriptor, and resolves and escapes in one operation. The source gate
+  blanks the exact seven canonical raw lookup bodies (three dashboard, four
+  setup) and rejects every other lexical `message()` call. The mutation matrix
+  covers string spoofing, ASI, fake helpers, active text targets, and direct
+  descriptor use in text, URL, style, native-attribute, and raw-SVG contexts.
+  Browser proof independently requires descriptor inertness and stable target
+  refusal. Ordinary SVG `aria-label` remains an approved accessibility-text
+  attribute through the ID-taking helper; raw SVG markup/text remains
+  forbidden. Another frozen-tree re-review is required.
+- 2026-07-30: structural re-review correctly identified two remaining runtime
+  capabilities: indirect raw resolver references were not rejected, and
+  movable catalog-filled/replacement nodes could enter active text contexts.
+  The resolver is now a lexical `const` rather than a `window` property, and
+  the bounded gate rejects every remaining bare resolver identifier after
+  blanking the declaration and seven canonical calls. The movable text-node
+  helper was deleted; structured and emphasis helpers validate every
+  replacement and its descendants before lookup. Descriptors now throw on
+  ordinary coercion, so accidental URL/style/native-attribute writes fail at
+  runtime. The gate intentionally remains a direct-convention regression
+  guard, not a general verifier for trusted authors deliberately using
+  computed properties, `Object.assign`, or native-method `.call`; that limit
+  is recorded in the decision and test strategy. Fresh review must reassess
+  source-obfuscation findings against this stated threat model.
+- 2026-07-30: final threat-boundary review found one current runtime gap
+  independent of source obfuscation: callers could pass an already-parented
+  `Text` node, while the helper validated only the node and not its active
+  parent. Both pages now validate the effective parent/ancestor context before
+  lookup. Browser proof includes a positive ordinary parented text node and
+  direct script/style/SVG parent negatives. The descriptor snippets in this
+  plan and the decision now include frozen parameters and coercion refusal.
 
 **GitHub issue title:** `v0.6.6: make catalogs plain and enforce contextual sinks`
 
@@ -680,10 +762,14 @@ escaped/plain compatibility layer. **Ponytail Rung:** 4 — use native DOM
 - Modify: `scripts/check_i18n.py`
 - Modify: `scripts/locale_v1.py`
 - Modify: `scripts/render_check.js`
+- Modify: `scripts/check_agent_guide.py`
 - Modify: `tests/fixtures/locales/`
 - Modify: `tests/fixtures/api/`
 - Replace: `knowledge/decisions/message-catalog-and-escaping.md`
 - Modify: `knowledge/architecture/dashboard.md`
+- Modify: `knowledge/decisions/locale-guards.md`
+- Modify: `knowledge/decisions/render-gate.md`
+- Modify: `knowledge/index.md`
 - Modify: `knowledge/testing/test-strategy.md`
 - Modify: `knowledge/log.md`
 
@@ -691,20 +777,33 @@ escaped/plain compatibility layer. **Ponytail Rung:** 4 — use native DOM
 
 - Consumes: current `rawMsg`, `fill`, `tRaw`, `t`, `applyStatic`, and render
   probes while the old invariant remains binding.
-- Produces one plain-text runtime contract:
+- Produces ID-taking DOM sinks and a distinguishable fixed-HTML descriptor:
 
 ```js
-function message(id, params = {}) { /* returns plain Unicode text */ }
+const message = (id, params = {}) => { /* returns plain Unicode text */ };
 function setMessageText(node, id, params = {}) {
+  assertMessageTextTarget(node);
   node.textContent = message(id, params);
 }
 function setMessageAttr(node, attr, id, params = {}) {
   if (!I18N_TEXT_ATTRS.has(attr)) throw new Error(`forbidden catalog attribute: ${attr}`);
   node.setAttribute(attr, message(id, params));
 }
+const catalogMessage = (id, params = {}) =>
+  Object.freeze({
+    type: CATALOG_MESSAGE,
+    id,
+    params: Object.freeze({ ...params }),
+    [Symbol.toPrimitive]() {
+      throw new TypeError("catalog descriptor requires escapeHtml");
+    },
+  });
 ```
 
 - `I18N_TEXT_ATTRS` is exactly `title`, `placeholder`, `aria-label`, and `alt`.
+- Raw `message()` calls exist only inside the canonical sink bodies.
+- Fixed-markup HTML resolves and escapes branded descriptors with
+  `escapeHtml()`; ordinary string coercion never reveals their text.
 - Structured messages use fixed caller-created nodes. Catalog values never
   enter URL, style, event, script, CSS, or raw-SVG contexts.
 
@@ -736,26 +835,26 @@ node scripts/render_check.js --page setup --escape-probe
 Expected: each new self-test identifies its own check id; the current runtime
 either parses markup-shaped catalog text or double-escapes literal entities.
 
-- [ ] **Step 3: Inventory every sink**
+- [x] **Step 3: Inventory every sink**
 
 Record each current element-content, attribute, HTML string, URL, style, event,
 script, CSS, and SVG sink in the replacement decision. The inventory must name
 its accepted value class and primitive; it is not a count or a copy of source.
 
-- [ ] **Step 4: Perform the one-way runtime cutover**
+- [x] **Step 4: Perform the one-way runtime cutover**
 
-Delete the escaped/plain duality. Replace ordinary `innerHTML` message writes
-with `textContent`; retain HTML-string builders only for fixed markup and escape
-machine data once at their sink. Replace setup `{b}`/`{key}`/`{endpoint}`
-message HTML with DOM construction.
+Delete the escaped/plain duality. Pass ids to DOM sinks and inert catalog
+descriptors to fixed-markup HTML builders; resolve and escape descriptors only
+at their HTML boundary, and escape machine data there once. Replace setup
+`{b}`/`{key}`/`{endpoint}` message HTML with DOM construction.
 
-- [ ] **Step 5: Update the binding invariant in the same diff**
+- [x] **Step 5: Update the binding invariant in the same diff**
 
 Change `AGENTS.md` only after the replacement decision, negative checks, and
 runtime are present in the uncommitted diff. The new invariant states catalogs
 are plain and every sink owns its context.
 
-- [ ] **Step 6: Run proof**
+- [x] **Step 6: Run proof**
 
 ```sh
 python3 scripts/check_i18n.py --selftest
@@ -771,20 +870,72 @@ cargo fmt --check
 git diff --check
 ```
 
-- [ ] **Step 7: Review the atomic boundary before commit**
+Fresh proof before independent-review repairs: source self-test 39 cases;
+catalog scan 225 referenced ids; locale self-test 11 fixtures; both locales
+clean; pseudolocale 225 messages;
+agent-guide self-test 10 fixtures and normal contract check; syntax self-test
+4 cases and both embedded pages parse; hostile and normal dashboard renders
+exercise 5 tabs and 15 chart hovers; hostile and normal setup renders exercise
+all 5 steps; formatting and diff checks pass.
+
+Fresh first-review-repair proof: source self-test 44 cases, each sink fixture
+emitting exactly its expected id; catalog scan 225 referenced ids; locale
+self-test 12 fixtures; both locales clean; pseudolocale 225 messages;
+agent-guide self-test 10 fixtures and normal contract check; syntax self-test
+4 cases and both embedded pages parse; hostile and normal dashboard renders
+exercise 5 tabs and 15 chart hovers; hostile and normal setup renders exercise
+all 5 steps, including exact attribute membership and repeated fixed-node
+placeholders; formatting and diff checks pass.
+
+Fresh fail-closed-repair proof: source self-test 54 cases, including the six
+second-review bypasses plus approved/unknown owner and binding controls, each
+hostile sink fixture emitting exactly its expected id; catalog scan 225
+referenced ids; locale self-test 12 fixtures; both locales clean;
+pseudolocale 225 messages; agent-guide self-test 10 fixtures and normal
+contract check; syntax self-test 4 cases and both embedded pages parse;
+hostile and normal dashboard renders exercise 5 tabs and 15 chart hovers;
+hostile and normal setup renders exercise all 5 steps; formatting and diff
+checks pass.
+
+Fresh individual-owner proof: source self-test 65 cases, including the nine
+third-review mutations and both direct-return/internal positive controls, each
+hostile sink fixture emitting exactly its expected id; catalog scan 225
+referenced ids; locale self-test 12 fixtures; both locales clean;
+pseudolocale 225 messages; agent-guide self-test 10 fixtures and normal
+contract check; syntax self-test 4 cases and both embedded pages parse;
+hostile and normal dashboard renders exercise 5 tabs and 15 chart hovers;
+hostile and normal setup renders exercise all 5 steps; formatting and diff
+checks pass.
+
+Fresh bounded-convention proof: source self-test 89 cases, including the
+reviewer mutations and descriptor boundary controls; catalog scan 225
+referenced ids; locale self-test 12 fixtures; both locales clean;
+pseudolocale 225 messages; agent-guide self-test 10 fixtures and normal
+contract check; syntax self-test 4 cases and both embedded pages parse;
+hostile and normal dashboard renders exercise 5 tabs and 15 chart hovers;
+hostile and normal setup renders all 5 steps. Hostile browser proof includes
+lexical resolver isolation, descriptor coercion refusal, stable
+script/style/SVG destination and replacement refusal, and the approved SVG
+`aria-label` path. Formatting and diff checks pass.
+
+- [x] **Step 7: Review the atomic boundary before commit**
 
 Give the reviewer the old decision/guide, replacement decision/guide, all sink
-changes, and negative-test evidence. Any surviving helper that accepts both
-escaped and plain catalog text blocks the commit.
+changes, and negative-test evidence. Any ambiguous catalog string flow or raw
+lookup outside the canonical sink bodies blocks the commit. Review must assess
+the intentional distinction between forbidden raw-SVG markup/text and the
+allowlisted SVG `aria-label` accessibility-text path.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```sh
 git add AGENTS.md src/dashboard.html src/setup.html scripts/check_i18n.py \
-  scripts/locale_v1.py scripts/render_check.js tests/fixtures/locales \
-  tests/fixtures/api knowledge/decisions/message-catalog-and-escaping.md \
-  knowledge/architecture/dashboard.md knowledge/testing/test-strategy.md \
-  knowledge/log.md
+  scripts/locale_v1.py scripts/render_check.js scripts/check_agent_guide.py \
+  tests/fixtures/locales \
+  knowledge/decisions/message-catalog-and-escaping.md \
+  knowledge/decisions/locale-guards.md knowledge/decisions/render-gate.md \
+  knowledge/architecture/dashboard.md knowledge/index.md \
+  knowledge/testing/test-strategy.md knowledge/log.md
 git commit -m "refactor: make catalog sinks context explicit"
 ```
 
@@ -825,7 +976,7 @@ git commit -m "refactor: make catalog sinks context explicit"
 
 **Interfaces:**
 
-- Consumes: Task 2 route matrix and Task 3 plain-message runtime.
+- Consumes: Task 2 route matrix and Task 3 ID/descriptor sink runtime.
 - Produces:
 
 ```rust

--- a/knowledge/architecture/dashboard.md
+++ b/knowledge/architecture/dashboard.md
@@ -190,9 +190,17 @@ logo with brand-colored monogram fallback, ranked by completion tokens.
 
 ## Security invariant
 
-Every dynamic string that reaches `innerHTML` — model/client names, tooltip
-and legend labels, table cells — passes through the `esc()` HTML-escaper.
-The typed history adapter preserves that rule for labels received from both
-dashboard endpoints, and scope/status text uses `textContent`. No range,
-current, Settings, hover, or sort path introduces an unescaped sink. See
-[input-sanitizing-and-xss](../decisions/input-sanitizing-and-xss.md).
+Ordinary catalog writes pass ids to the canonical `textContent` helper;
+`title`, `placeholder`, `aria-label`, and `alt` pass ids to the allowlisted
+attribute helper. Setup emphasis and literals use fixed DOM nodes. Dashboard
+HTML builders carry frozen catalog descriptors and resolve and escape them only
+through `escapeHtml()` at interpolation. Raw lookup is confined to those
+canonical sink bodies. SVG geometry is fixed or machine-generated; catalog
+descriptors do not enter SVG.
+
+Model/client names, tooltip and legend data, table cells, and other API data
+remain plain machine data and follow the same sink-specific escaping rule; they
+are never localized. Catalog ids and descriptors never enter URL, style,
+event, executable script, CSS, or raw-SVG contexts. See
+[message-catalog-and-escaping](../decisions/message-catalog-and-escaping.md)
+and [input-sanitizing-and-xss](../decisions/input-sanitizing-and-xss.md).

--- a/knowledge/decisions/locale-guards.md
+++ b/knowledge/decisions/locale-guards.md
@@ -41,14 +41,33 @@ not substitute, which would make the pseudolocale test itself instead of the
 layout.
 
 **`locale-v1` validator.** Completeness, orphans, placeholder parity, formatter
-syntax, no raw markup, inline balance, source-hash freshness, opt-in length
-caps. The hash is what makes a regenerate-on-drift pipeline possible: it records
-which English text a translation was made from, so "still valid, no longer
-correct" is detectable.
+syntax, separate raw-markup and entity-encoded-markup checks, exact inline
+marker structure, source-hash freshness, opt-in length caps. Exact inline
+structure keeps the runtime and accepted locale shapes aligned: emphasis
+markers may surround translated text, but cannot be removed, duplicated, or
+reordered. The hash is what makes a
+regenerate-on-drift pipeline possible: it records which English text a
+translation was made from, so "still valid, no longer correct" is detectable.
 
-**Untagged-string lint.** Fails on a display literal that bypasses `t()`,
+**Untagged-string lint.** Fails on a display literal that bypasses `message()`,
 covering attributes as well as text. Without it, English creeps back within two
 PRs, because a hardcoded label looks exactly like the code beside it.
+
+**Contextual-sink lint.** Page code passes ids to native DOM helpers and inert
+descriptors to fixed-markup HTML builders. Named self-tests independently
+reject URL, style, event, script, CSS, raw-SVG, native-attribute, raw-HTML,
+alias, string-spoof, ASI, and structured-message-HTML mutations. Descriptor
+tests cover direct text, URL, style, native-attribute, and SVG sinks. Expected
+check ids must match exactly. See
+[message-catalog-and-escaping](message-catalog-and-escaping.md).
+The normal source pass blanks only the lexical resolver declaration and exact
+canonical raw-lookup helper bodies; every remaining bare `message` identifier
+fails. This bounded convention does not infer JavaScript owners. Text and
+structured helpers reject script/style/SVG destinations and replacements, and
+HTML builders must resolve descriptors through `escapeHtml()`. This is a
+direct-convention regression guard, not a verifier for deliberately obfuscated
+trusted JavaScript; runtime resolver isolation, descriptor coercion refusal,
+and replacement validation are the accidental-misuse boundary.
 
 **Every check has a negative fixture, and the fixtures came first.** They are
 committed in a separate commit before the validator exists, and `--selftest`

--- a/knowledge/decisions/message-catalog-and-escaping.md
+++ b/knowledge/decisions/message-catalog-and-escaping.md
@@ -1,161 +1,146 @@
 ---
 type: Decision
-title: Embed the message catalog and escape it once, at load
-description: Extraction routes every user-visible string through t(). Catalog values are plain text escaped once on load, because four render helpers interpolate their arguments into innerHTML without escaping.
+title: Route catalog ids and inert descriptors to context-owning sinks
+description: Page code passes catalog ids to DOM sinks and branded inert descriptors to fixed-markup HTML builders; raw lookup is confined to canonical sink bodies.
 tags: [i18n, dashboard, security, xss]
-timestamp: 2026-07-29T00:00:00Z
+timestamp: 2026-07-30T00:00:00Z
 ---
 
-# Embed the message catalog and escape it once, at load
+# Route catalog ids and inert descriptors to context-owning sinks
 
 ## Context
 
-Localizing the dashboard means every user-visible string has to come from a
-catalog rather than a literal. `src/dashboard.html` is one embedded file with
-no build step ([dashboard](../architecture/dashboard.md)), so the catalog has
-to ship inline and the runtime has to be a few lines, not a framework.
+The first catalog runtime escaped every message at lookup and exposed a second
+plain lookup for `textContent` and `setAttribute`. Callers had to remember which
+representation a helper accepted. One extra escape rendered entities; one
+missing escape parsed markup. Structured setup copy also made HTML strings from
+catalog placeholders.
 
-The hard part is not the lookup. It is that the dashboard builds HTML by string
-concatenation into `innerHTML` — 45 sites — and the escaping posture recorded in
-[input-sanitizing-and-xss](input-sanitizing-and-xss.md) assumes every *dynamic*
-value passes through `esc()`. Catalog values are a new class of dynamic value,
-and an inventory of the render path found four helpers that interpolate their
-arguments with no escaping at all:
+An attempted replacement made `message()` public throughout page code and
+tried to infer the eventual owner of every returned string. Independent review
+repeatedly found fail-open shapes: string literals that spoofed helper names,
+ASI-separated calls that inherited an earlier owner, blanket approval inside
+named functions, fake canonical attribute writes, and script/style/SVG aliases.
+Adding more partial JavaScript parsing failed the Ponytail ladder.
 
-| Helper | Argument |
-|---|---|
-| `metricRow` | label |
-| `perfBlock` | label |
-| `tile` | label |
-| `prow` | label |
-
-`kpiCards` escapes `k.label` but not `k.value` or `k.sub`, and the delta-chip
-`title=` attribute is interpolated raw. All six are safe *today* only because
-every argument is a hardcoded literal. The moment they read from a catalog,
-they are injection sinks — and a catalog is exactly the kind of file that later
-gets machine-generated, contributed, or edited by someone who is not reading
-this page.
-
-Separately, `chipHtml` built an `onerror="…"` attribute containing a JavaScript
-statement containing single-quoted JS string literals — three nested contexts,
-no escaping. It was safe only because `initialsOf()` strips its input to
-`[A-Za-z0-9 ]`, a helper written to build monograms, not to sanitize. One
-catalog candidate (`'unknown'`, the fallback publisher name) reached it.
-
-## Options
-
-1. **Escape at every call site.** Wrap each `t()` result in `esc()`. Correct if
-   done everywhere, and silently wrong the first time someone forgets. Six
-   sinks today, more as the file grows.
-2. **Fix the four helpers to escape their arguments.** Better, but it changes
-   the contract of helpers that also receive already-escaped HTML fragments
-   from other call sites, so it would double-escape those.
-3. **Convert `innerHTML` to `textContent`.** Explicitly out of scope — that is a
-   rewrite of the render path, not an extraction.
-4. **Escape once, at load.** The catalog stores plain text; the runtime escapes
-   every value as it is parsed. `t()` is then safe to interpolate anywhere a
-   literal was safe, which is the whole file.
+The owner approved a one-way replacement while the application is pre-1.0.
+Runtime, both pages, validators, browser probes, guide invariant, and this
+decision move atomically.
 
 ## Choice
 
-**Option 4.** Catalog values are plain text. `t(id, params)` returns an escaped
-string; `tRaw(id)` returns the plain one for `setAttribute` and `textContent`,
-neither of which parses entities. Placeholder values are escaped as they are
-substituted — substitution happens *after* the message is escaped, so an
-unescaped param would land raw in exactly the sinks this decision exists to
-protect.
+Page code does not exchange ambiguous “catalog strings.” It uses two explicit
+value flows:
 
-The corollary is that **helpers must not escape their label argument**.
-`sortTable` did, which double-encoded every catalog-supplied column header —
-invisible in en-US, where no header contains `&` or `'`, and wrong the first
-time a locale or a copy edit introduces one. Worse, one id fed both an escaping
-sink (`sortTable`) and a non-escaping one (`metricRow`), so a single message had
-two escaping regimes. `sortTable` no longer escapes; column labels come from a
-literal or the catalog, never from request data.
+1. DOM text, text-bearing attributes, and structured setup copy receive a
+   catalog id plus parameters. Their canonical helper performs the lookup and
+   immediately writes through its native DOM primitive.
+2. Fixed-markup dashboard builders receive a frozen, Symbol-branded descriptor
+   from `catalogMessage(id, params)`. Its `Symbol.toPrimitive` throws on normal
+   coercion, so a URL, style, or native attribute cannot silently stringify it.
+   `escapeHtml()` is the sole named descriptor resolver and resolves and
+   escapes in one operation.
 
-And `chipHtml`'s `onerror=` is gone before any extraction: a delegated
-capture-phase `error` listener reads the fallback from `data-*` attributes.
-The file now has no JavaScript-context interpolation at all.
+`message(id, params)` still returns plain Unicode internally, but raw calls are
+confined to the exact canonical sink bodies. There is no escaped/plain
+compatibility lookup and no general plain catalog value in page code.
 
-That alone did not make the rule "catalog values reach element content and
-quoted attributes only" *enforced* — `applyStatic` called `setAttribute` with
-whatever attribute name the markup supplied, so a markup edit could still route
-a catalog value into `onclick=` or `style=`, and the CSP permits inline
-handlers. It is enforced now: the runtime accepts only `title`, `placeholder`,
-`aria-label`, and `alt`, and `check_i18n.py` rejects any other target.
+```js
+function setMessageText(node, id, params = {}) {
+  assertMessageTextTarget(node);
+  node.textContent = message(id, params);
+}
 
-**On both pages** — which is worth spelling out, because this paragraph was
-written when it was true of only one. `dashboard.html` had the `I18N_ATTRS`
-guard; `setup.html` did not, and shipped that way while this page and a comment
-in `check_i18n.py` both asserted the runtime enforced it. An adversarial review
-found it by reading the two runtimes side by side rather than trusting either
-description. Demonstrated before fixing: with
-`data-i18n-attr="onclick:setup.step4.copy"` injected into the wizard's markup,
-the unguarded page rendered `onclick="Copy"` on the element and the guarded page
-left the attribute unset.
+function setMessageAttr(node, attr, id, params = {}) {
+  if (!I18N_TEXT_ATTRS.has(attr))
+    throw new Error(`forbidden catalog attribute: ${attr}`);
+  node.setAttribute(attr, message(id, params));
+}
 
-The lesson is not about this attribute. A knowledge page that says "enforced"
-describes intent until someone runs the two implementations against the same
-hostile input — so when a page claims a runtime invariant, it should say which
-runtimes were checked.
+const CATALOG_MESSAGE = Symbol("catalog-message");
+const catalogMessage = (id, params = {}) =>
+  Object.freeze({
+    type: CATALOG_MESSAGE,
+    id,
+    params: Object.freeze({ ...params }),
+    [Symbol.toPrimitive]() {
+      throw new TypeError("catalog descriptor requires escapeHtml");
+    },
+  });
+```
 
-Three tagging mechanisms, chosen so markup structure never changes:
+`I18N_TEXT_ATTRS` is exactly `title`, `placeholder`, `aria-label`, and `alt`.
+Text helpers validate the effective target before lookup, including a text
+node's parent and active ancestors, and reject script, style, and SVG contexts.
+Structured helpers also reject those node types, including descendants, in
+every replacement/emphasis node before they resolve catalog text.
 
-- `data-i18n` — replaces an element's content
-- `data-i18n-attr="attr:id"` — sets an attribute
-- `data-i18n-text` — replaces an element's *own first text node*, for headings
-  that mix an icon, a text node, and a `.note` span. Assigning to a text node
-  cannot introduce markup, so this path needs no escaping at all.
+Structured messages never contain translator-authored HTML. Setup creates fixed
+`<code>` or `<b>` nodes and splices them between catalog-owned text nodes with
+`replaceChildren`. A replacement node is cloned for every placeholder
+occurrence. The locale validator requires the source marker sequence, so a
+locale may move emphasis but cannot drop, duplicate, or reorder its markers.
 
-Inline emphasis inside a message (`{b}…{/b}`) and fixed literals (`{key}`,
-`{endpoint}`) are placeholders expanded from a table in code, never markup
-stored in a catalog value.
+## Sink inventory
+
+| Sink class | Accepted value | Owning primitive |
+|---|---|---|
+| Ordinary element or mixed text-node content | Catalog id + plain parameters | `setMessageText` → `textContent` |
+| `title`, `placeholder`, `aria-label`, `alt` | Catalog id + plain parameters; `aria-label` is allowed on an ordinary SVG element | `setMessageAttr` → `setAttribute` |
+| Structured setup copy | Catalog id + caller-created fixed nodes | text nodes + `replaceChildren` |
+| Fixed chart/table/card/list HTML | Branded catalog descriptor or plain machine data | `escapeHtml` → `innerHTML` |
+| SVG geometry or raw SVG markup | Fixed markup, numeric geometry, fixed colors, and machine-formatted axis values | fixed builder or SVG DOM; catalog ids/descriptors forbidden except an allowlisted accessibility-text attribute after creation |
+| URL-bearing values | Fixed URLs or validated machine/config data | catalog ids and descriptors forbidden |
+| Style-bearing values | Fixed CSS tokens or bounded numeric layout values | catalog ids and descriptors forbidden |
+| Event handlers | Repository functions | catalog ids and descriptors forbidden |
+| Script, stylesheet text, raw SVG, native attribute bypass | Repository source or approved machine data | catalog ids and descriptors forbidden |
+
+The inline `application/json` block is a transport container, not executable
+script. Validators reject raw and entity-encoded markup before a catalog ships.
+Task 5 may replace that transport without changing these value classes.
+
+## Enforcement
+
+- `locale_v1.py --selftest` distinguishes raw markup, entity-encoded markup,
+  and invalid inline marker structure.
+- `check_i18n.py --selftest` covers both allowed flows and hostile URL, style,
+  event, script, CSS, SVG, native-attribute, raw-HTML, alias, string-spoof, and
+  ASI mutations. It also sends descriptors directly to text, URL, style,
+  native-attribute, and raw-SVG sinks while retaining the explicit
+  `setMessageAttr(svg, "aria-label", id)` accessibility path.
+- The resolver is a lexical `const`, not a `window` property. The normal source
+  pass first blanks its declaration and the exact canonical raw-lookup bodies.
+  Any remaining bare `message` identifier—including alias, `call`, or `bind`
+  use—is `sink-context`. This intentionally bounded convention replaces owner
+  inference.
+- `render_check.js --escape-probe` mutates every value with hostile literal
+  entity and markup text. It verifies descriptor inertness and HTML
+  resolution, the four-attribute allowlist, literal text/attribute bytes,
+  stable refusal of forbidden attributes and script/style/SVG text targets,
+  repeated structured placeholders, and both pages' rendered DOM.
+
+The source lint is a regression guard for the repository's direct conventions,
+not a security verifier for an author deliberately obfuscating JavaScript with
+computed properties, `Object.assign`, or native-method `.call`. Trusted source
+can always route the plain string returned by `escapeHtml()` somewhere else.
+Review remains responsible for such deliberate code. Runtime boundaries still
+remove the accidental capability: the raw resolver is not global, descriptors
+throw on coercion, and structured helpers validate both destinations and
+replacement nodes.
+
+See the [render gate](render-gate.md) and
+[test strategy](../testing/test-strategy.md).
 
 ## Consequences
 
-- English rendering is unchanged. `scripts/check_i18n.py` is the proof: every
-  tagged element still holds exactly the text its id claims, no id is missing
-  or orphaned, no hash is stale. Verified non-vacuous against three broken
-  inputs.
-- **`cargo test` cannot validate any of this.** The e2e suite asserts on served
-  HTML text, so it passes on JavaScript that does not parse — and it did. An
-  extraction pass wrote `${…}` into single-quoted strings and only
-  `node --check` caught it. Treat the Rust suite as necessary, never sufficient,
-  for changes to the embedded pages.
-- A headless-Chromium render that mutates three catalog values and confirms the
-  DOM follows is the end-to-end check. It is the only way to prove the runtime
-  actually ran, since an unmutated en-US catalog renders identically whether
-  substitution happened or not.
-- Eight bindings named `t` shadowed the new global — two cursor timestamps,
-  four callback parameters, an error-rate denominator inside `renderModels`
-  (which is dense with `t()` calls), and one in the custom-range handler. All
-  renamed. None broke at the time, but each was a silent failure waiting for
-  the next `t()` call added in that scope. Renaming one of them *did* break
-  `applyRange` mid-edit — the old name was still referenced two lines down, so
-  `isFinite(t)` tested the function and the Apply button stopped working. It
-  was caught by re-reading, not by any test.
-- Ordering matters: `applyStatic` must run **before** the tab-restore loop.
-  Running it after meant deep-linking to `#models` displayed the Models section
-  under a topbar reading "Overview", because the loop sets `#pagetitle` and the
-  catalog pass then overwrote it. `cargo test` and `check_i18n.py` both passed
-  on that; only a headless render at `#models` showed it.
-- **Which helper escapes is not uniform, and the call site has to know.** The
-  Context inventory above is no longer current: `kpiCards` stopped escaping
-  `k.label` in `77421e2`, so it now matches `metricRow`/`perfBlock`/`tile`/
-  `prow`/`stat` and takes `t()`. The *opposite* contract holds for `ringGauge`
-  (escapes `label` in both the `aria-label` and `.rlabel`), `legend` and both
-  charts' hover tooltips (escape `s.name`), `barList`/`leaderList` (escape
-  `name`/`label`, and must keep escaping — those carry model ids), and any site
-  that wraps the value in `esc()` itself: the reliability error segbar's
-  `title=` and the non-success outcomes table. All of those take `tRaw()`, as
-  do `textContent` and `setAttribute`. Reading the sink is the only way to
-  choose, and `--escape-probe` is the only check that tells a wrong choice
-  apart from a right one — it fails on entity text in the DOM.
-- Message ids are always spelled out at the call site, never built by
-  concatenation. `tRaw('dashboard.nav.tab.' + tab)` is invisible to a static
-  linter, which is the one thing that stops English creeping back. The status
-  taxonomy is the case that most invites the shortcut: `REASONS` is keyed by
-  HTTP status, so `t('dashboard.common.status.' + s)` would work and would be
-  unlintable. Every entry is written out instead.
-- The settings surface (~79 strings) is deliberately not extracted; it lands in
-  0.6.7.
+- Callers cannot accidentally choose an escaped versus plain catalog variant.
+- Native DOM helpers own ordinary text and attributes.
+- HTML builders receive a distinguishable value class and resolve it only at
+  their escaping boundary.
+- Catalog text cannot become URL, style, event, script, CSS, raw-SVG, or
+  arbitrary native-attribute input.
+- Machine data remains unlocalized. When fixed HTML displays model ids, client
+  names, publisher names, metric values, API errors, endpoints, or credentials,
+  `escapeHtml()` escapes that plain data without treating it as a descriptor.
+- Adding another raw resolver reference or a helper that accepts an ambiguous
+  string violates this decision.

--- a/knowledge/decisions/render-gate.md
+++ b/knowledge/decisions/render-gate.md
@@ -112,24 +112,29 @@ faked.
 - The fixtures are a **snapshot of a wire format**. If `/api/dashboard` changes
   shape, they must be recaptured — the gate will fail loudly rather than
   silently drift, which is the intended failure mode.
-- `--escape-probe` gives the escape-once rule in
+- `--escape-probe` gives the contextual-sink rule in
   [message-catalog-and-escaping](message-catalog-and-escaping.md) an
-  enforcement mechanism instead of a paragraph.
+  enforcement mechanism instead of a paragraph. The probe requires inert
+  dashboard descriptors to resolve only through the HTML escape boundary, the
+  exact four-attribute allowlist, literal DOM text/attribute values, stable
+  script/style/SVG target refusal, repeated fixed-node placeholders, and
+  catches both entity leakage and markup parsing.
 
   It enforces **both directions**, and the second one was added only after an
   adversarial review proved the first was not enough. The probe appends
   `Ampersand & Quote' <b>Tag</b>` to every catalog value:
 
-  - *Double-escaped* — the `&` and `'` come back as literal `&amp;` / `&#39;`
-    in the rendered output.
-  - *Not escaped at all* — the `<b>` parses into a real element, so a catalog
-    value that reached a raw-HTML sink is a DOM node rather than text.
+  - *Wrong text/attribute context* — the `&` and `'` come back as literal
+    `&amp;` / `&#39;` in the rendered output.
+  - *Raw HTML context* — the `<b>` parses into a real element, so a catalog
+    value that reached an HTML parser without its sink escape is a DOM node
+    rather than text.
 
   The original probe carried no tag and scanned text nodes only, which made it
-  a double-escape detector that was structurally blind to the missing-escape
+  an entity-leak detector that was structurally blind to the markup-parsing
   direction — the XSS direction — and blind to every attribute sink
-  (`deltaChip`'s `title=`, `ringGauge`'s `aria-label=`, the taxonomy segbar's
-  `title=`, and all of `applyStatic`'s `setAttribute` path). Four deliberate
+  (`deltaChip`'s and the taxonomy segbar's `title=`, and all of
+  `applyStatic`'s `setAttribute` path). Four deliberate
   defects were injected to establish that: two the probe caught, two it passed
   green. It now scans `title`, `aria-label`, `placeholder` and `alt` as well as
   text, and both injected defects fail.
@@ -163,12 +168,10 @@ faked.
   never sends proves the page works against fiction.
 
 - **Both runtimes are asserted to refuse non-allowlisted attributes.** The gate
-  builds a synthetic element carrying `data-i18n-attr` for `title`, `onclick`
-  and `style`, runs the page's own `applyStatic` over it, and fails unless the
-  first is set and the other two are refused. This existed as prose in
-  [message-catalog-and-escaping](message-catalog-and-escaping.md) and as a
-  comment in `check_i18n.py` while only one of the two pages enforced it.
-  Proved non-vacuous by deleting the guard: `FAIL — src/setup.html attribute
-  allowlist: set onclick= from a catalog id; set style= from a catalog id`.
+  calls each page's own `setMessageAttr` for all four allowed attributes and
+  for `href`, `src`, `style`, and `onclick`. Allowed values must equal the
+  hostile plain message byte-for-byte; forbidden attributes must throw the
+  stable refusal and remain unset. Static self-tests separately cover URL
+  properties, script text, CSS, raw SVG, and HTML-string sinks.
 - It is not a screenshot test and takes no screenshots. Layout review stays
   human, per the plan's original and still-correct reasoning.

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -40,7 +40,7 @@ page describes a conclusion, a plan describes the live state.
 | [dependency-update-cooldown](decisions/dependency-update-cooldown.md) | Routine dependency updates wait seven days; security updates remain immediate |
 | [lane-cooldown-naming](decisions/lane-cooldown-naming.md) | `bench` → `cooldown`; renames the metric and accepts a bounded history gap over a permanent alias |
 | [no-estimated-savings-metric](decisions/no-estimated-savings-metric.md) | "Dollars saved" needed per-model published rates to be honest; deleted rather than faked |
-| [message-catalog-and-escaping](decisions/message-catalog-and-escaping.md) | Inline `en-US` catalog behind `t()`; values escaped once at load because four render helpers do not escape their arguments |
+| [message-catalog-and-escaping](decisions/message-catalog-and-escaping.md) | Catalog ids for DOM sinks; inert descriptors resolved only by fixed-markup HTML escaping |
 | [intl-formatting](decisions/intl-formatting.md) | Cached `Intl` formatters keyed to the catalog locale; CSS percentages deliberately excluded |
 | [locale-guards](decisions/locale-guards.md) | `en-XA` pseudolocale, `locale-v1` validator, untagged-string lint — every check with a negative fixture written first |
 | [plural-categories-not-ternaries](decisions/plural-categories-not-ternaries.md) | Counted labels select a CLDR category via `Intl.PluralRules`; all six forms live in the source catalog because `locale-v1` requires id parity |

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,32 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-30] decision — plain catalogs with context-owned DOM sinks
+
+Replaced the escaped/plain catalog duality atomically across the guide,
+decision, dashboard and setup runtimes, validators, hostile browser probes,
+sink inventory, and testing runbook. Recorded in
+[message-catalog-and-escaping](decisions/message-catalog-and-escaping.md).
+
+- Page code passes ids to native text/attribute/structured sinks. Fixed-markup
+  dashboard builders carry frozen branded descriptors that reveal catalog text
+  only when the HTML sink resolves and escapes them.
+- Setup emphasis and key/endpoint literals use caller-created fixed DOM nodes;
+  repeated value placeholders clone the fixed node and inline marker structure
+  must match the source. Remaining fixed-markup builders resolve and escape
+  catalog descriptors, and escape plain machine values, at interpolation.
+- The negative fixtures name raw and entity-encoded catalog markup, forbidden
+  URL/style/event/script/CSS/SVG contexts, direct/concatenated/multiline/
+  adjacent raw HTML sinks, direct attribute bypasses, structured-message HTML,
+  descriptor misuse, and compatibility helpers separately and require exact
+  sink check ids. The normal source gate blanks the lexical resolver declaration
+  and exact canonical raw-lookup bodies, then rejects every remaining bare
+  resolver identifier, avoiding partial JavaScript owner inference.
+- Both populated-page browser probes inject literal entity and markup-shaped
+  text into every message, then require literal DOM output, a non-global
+  resolver, descriptor coercion refusal, and stable forbidden attribute and
+  script/style/SVG destination/replacement/parented-text errors.
+
 ## [2026-07-30] ingest — map and enforce every HTTP trust boundary
 
 Added the [HTTP trust-boundary map](architecture/http-trust-boundary-map.md)

--- a/knowledge/testing/test-strategy.md
+++ b/knowledge/testing/test-strategy.md
@@ -40,6 +40,14 @@ that proof.
   `node scripts/render_check.js --escape-probe`,
   `node scripts/render_check.js --page setup`, and
   `node scripts/render_check.js --page setup --escape-probe`.
+  The escape probe enforces the id/descriptor context-owned-sink contract:
+  lexical resolver isolation, descriptor coercion refusal and one HTML
+  resolver, the exact four-attribute
+  allowlist, literal hostile text in element content and allowed attributes,
+  stable rejection of forbidden attributes and script/style/SVG destinations
+  and replacements, including parented text-node contexts, repeated fixed-node
+  placeholders, no compatibility lookup, no parsed markup, and no literal
+  entity leakage.
 - **Number, date, and duration formatting:**
   `TZ=UTC LC_ALL=en_US.UTF-8 node scripts/formatter_fixture.js --check`.
 - **Catalog and UI text:** `python3 scripts/check_i18n.py --selftest`, then
@@ -188,10 +196,28 @@ Dashboard changes get two more checks.
 **Automated — `node scripts/render_check.js`.** Renders the page against the
 captured payloads in `tests/fixtures/api/`, walks all five tabs, hovers every
 chart with real pointer input, and fails on any uncaught page error.
-`--escape-probe` additionally fails on a render helper escaping a catalog value
-that was already escaped at load. This is the only gate that proves the page
-*runs*: `cargo test` asserts on served HTML text and `node --check` proves only
-that it parses. See [render-gate](../decisions/render-gate.md).
+`--escape-probe` additionally mutates every catalog value with hostile literal
+text and fails if a page parses it as markup, renders entity text, permits a
+forbidden catalog attribute, or retains an escaped/plain compatibility helper.
+`check_i18n.py --selftest` carries the static forbidden-context matrix, while
+`locale_v1.py --selftest` distinguishes raw and entity-encoded catalog markup
+and rejects inline-marker structure the runtime cannot render.
+The source gate blanks only the lexical resolver declaration and exact
+canonical raw-lookup helper bodies, then fails on every remaining bare
+`message` identifier. Negative controls cover aliases, `call`, `bind`, global
+property access, string-spoofed owners, ASI-separated calls, fake canonical
+attribute writes, script/style/SVG element aliases and helper targets, plus
+descriptors sent directly to text, URL, style, native-attribute, or raw-SVG
+sinks.
+This direct-convention scan is a regression guard, not a general verifier for
+trusted source deliberately obfuscated with computed properties,
+`Object.assign`, or native-method `.call`. Runtime proof supplies the security
+boundary for accidental misuse: the resolver is not global, descriptors throw
+on coercion, and structured helpers validate destinations and replacements.
+This is the only gate that proves the page *runs*: `cargo test` asserts on
+served HTML text and `node --check` proves only that it parses. See
+[render-gate](../decisions/render-gate.md) and
+[message-catalog-and-escaping](../decisions/message-catalog-and-escaping.md).
 
 **Human — screenshots, still.** Real-browser screenshots under live traffic
 (the UI is dark-only since the operator-console redesign), inspected by eye —

--- a/scripts/check_agent_guide.py
+++ b/scripts/check_agent_guide.py
@@ -21,7 +21,7 @@ REQUIRED = {
     "contract:invariants": (
         "## Invariants",
         "Fail closed",
-        "Escape once",
+        "Context owns the sink",
         "Zero upstream rate violations",
         "The wire format does not move",
         "Data is never localized",
@@ -82,7 +82,10 @@ CASES = {
     ),
     "missing-start": ("contract:start", "AGENTS.md", "## Start here", "## Begin"),
     "missing-invariant": (
-        "contract:invariants", "AGENTS.md", "Escape once", "Escape differently"
+        "contract:invariants",
+        "AGENTS.md",
+        "Context owns the sink",
+        "Escape differently",
     ),
     "missing-memory": (
         "contract:memory",

--- a/scripts/check_i18n.py
+++ b/scripts/check_i18n.py
@@ -183,7 +183,8 @@ NOT_DISPLAY = re.compile(
     r"querySelector|getElementById|createElementNS|setAttribute\(|getAttribute\(|"
     r"classList|\.style|addEventListener|removeEventListener|localStorage|"
     r"nimproxy_|labels\[|dataset\.|\.dataset|JSON\.|console\.|new Intl|"
-    r"\.split\(|\.join\(|\.replace\(|padStart|toFixed|encodeURI|fetch\("
+    r"new (?:Error|TypeError)|\.split\(|\.join\(|\.replace\(|padStart|toFixed|"
+    r"encodeURI|fetch\("
 )
 
 
@@ -236,8 +237,8 @@ def lint_runtime_helpers(name: str, raw: str) -> list:
         return []
     js = strip_comments(body.group(1))
     helpers = (
-        r"message|setMessageText|setMessageAttr|applyStatic|"
-        r"t|tRaw|tHtml|rawMsg|fill"
+        r"message|setMessageText|setMessageAttr|setMessageWithNodes|"
+        r"setEmphasizedMessage|applyStatic|t|tRaw|tHtml|rawMsg"
     )
     called = set(re.findall(rf"\b({helpers})\s*\(", js))
     defined = set(
@@ -250,60 +251,228 @@ def lint_runtime_helpers(name: str, raw: str) -> list:
 
 
 I18N_TEXT_ATTRS = {"title", "placeholder", "aria-label", "alt"}
+CANONICAL_LOOKUPS = {
+    "src/dashboard.html": (
+        r"""function escapeHtml\(value\) \{
+  const text = value && value\.type === CATALOG_MESSAGE
+    \? message\(value\.id, value\.params\)
+    : String\(value\);
+  return text\.replace""",
+        r"""function setMessageText\(node, id, params = \{\}\) \{
+  assertMessageTextTarget\(node\);
+  node\.textContent = message\(id, params\);
+\}""",
+        r"""function setMessageAttr\(node, attr, id, params = \{\}\) \{
+  if \(!I18N_TEXT_ATTRS\.has\(attr\)\)
+    throw new Error\(`forbidden catalog attribute: \$\{attr\}`\);
+  node\.setAttribute\(attr, message\(id, params\)\);
+\}""",
+    ),
+    "src/setup.html": (
+        r"""function setMessageText\(node, id, params = \{\}\) \{
+  assertMessageTextTarget\(node\);
+  node\.textContent = message\(id, params\);
+\}""",
+        r"""function setMessageAttr\(node, attr, id, params = \{\}\) \{
+  if \(!I18N_TEXT_ATTRS\.has\(attr\)\)
+    throw new Error\(`forbidden catalog attribute: \$\{attr\}`\);
+  node\.setAttribute\(attr, message\(id, params\)\);
+\}""",
+        r"""function setMessageWithNodes\(node, id, replacements\) \{
+  assertMessageTextTarget\(node\);
+  for \(const \[, replacement\] of replacements\) \{
+    assertMessageTextTarget\(replacement\);
+    if \(replacement\.querySelector\?\.\("script,style,svg"\)\)
+      throw new Error\("forbidden catalog text target"\);
+  \}
+  let text = message\(id\);""",
+        r"""function setEmphasizedMessage\(node, id, emphasis\) \{
+  assertMessageTextTarget\(node\);
+  assertMessageTextTarget\(emphasis\);
+  if \(emphasis\.querySelector\?\.\("script,style,svg"\)\)
+    throw new Error\("forbidden catalog text target"\);
+  const text = message\(id\);""",
+    ),
+}
+
+
+def _consume_canonical_lookups(name: str, source: str, problems: list) -> str:
+    """Blank only the deliberately tiny set of raw catalog lookup bodies.
+
+    Page code passes ids or inert descriptors. A raw ``message()`` lookup is
+    legal only inside one canonical sink helper, whose complete opening shape
+    is fixed here. This is intentionally a bounded convention rather than a
+    partial JavaScript parser.
+    """
+    working = source
+    for pattern in CANONICAL_LOOKUPS.get(name, ()):
+        matches = list(re.finditer(pattern, working))
+        if len(matches) != 1:
+            problems.append((
+                "sink-context",
+                f"{name}: canonical catalog sink shape occurs {len(matches)} times",
+            ))
+            continue
+        match = matches[0]
+        replacement = match.group(0).replace("message(", "__catalog_lookup__(")
+        working = working[:match.start()] + replacement + working[match.end():]
+
+    declarations = list(
+        re.finditer(r"\bconst message\s*=\s*\(id, params = \{\}\)\s*=>", working)
+    )
+    if name in CANONICAL_LOOKUPS and len(declarations) != 1:
+        problems.append((
+            "sink-context",
+            f"{name}: raw catalog lookup declaration occurs {len(declarations)} times",
+        ))
+    working = re.sub(
+        r"\bconst message(\s*=\s*\(id, params = \{\}\)\s*=>)",
+        r"const __catalog_lookup__\1",
+        working,
+    )
+    return working
 
 
 def lint_catalog_sinks(name: str, raw: str) -> list:
-    """Return ``(check id, detail)`` for catalog values in unsafe contexts.
-
-    This is deliberately a narrow source contract, not a JavaScript parser.
-    The runtime exposes one plain ``message()`` value type, and every permitted
-    call shape is explicit enough to identify mechanically. Browser probes
-    separately prove the helpers' actual DOM behavior.
-    """
+    """Enforce the bounded ID/descriptor-to-sink convention."""
     problems = []
     source = strip_comments(raw)
 
+    def add(check: str, detail: str):
+        if not any(existing == check for existing, _ in problems):
+            problems.append((check, detail))
+
     if re.search(r'data-i18n-html=|\btHtml\s*\(', source):
-        problems.append((
+        add(
             "structured-message-html",
             f"{name}: structured catalog message uses an HTML-producing path",
-        ))
+        )
+
+    if re.search(r"\b(?:rawMsg|tRaw)\s*\(|\b(?:const|let|var)\s+t\s*=", source):
+        add(
+            "sink-context",
+            f"{name}: escaped/plain catalog compatibility helper survives",
+        )
 
     for match in re.finditer(
         r"\bsetMessageAttr\s*\([^,]+,\s*['\"]([^'\"]+)['\"]", source
     ):
         attr = match.group(1)
         if attr not in I18N_TEXT_ATTRS:
-            problems.append((
+            add(
                 "forbidden-catalog-context",
                 f"{name}: catalog value targets forbidden attribute {attr!r}",
-            ))
+            )
 
+    # Declarative and helper-owned text paths never target active text or SVG.
+    if re.search(r"<(?:script|style|svg)\b[^>]*\bdata-i18n", source, re.I):
+        add(
+            "forbidden-catalog-context",
+            f"{name}: declarative catalog text targets script, CSS, or SVG",
+        )
+    forbidden_names = {"script", "scriptNode", "style", "styleNode", "svg", "svgNode"}
+    created = {
+        match.group(1)
+        for match in re.finditer(
+            r"\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*"
+            r"document\.createElement(?:NS)?\([^;\n]*['\"](?:script|style|svg)['\"]",
+            source,
+        )
+    }
+    targets = "|".join(re.escape(target) for target in sorted(forbidden_names | created))
+    if targets and re.search(
+        rf"\b(?:setMessageText|setMessageWithNodes|setEmphasizedMessage)"
+        rf"\s*\(\s*(?:{targets})\b",
+        source,
+    ):
+        add(
+            "forbidden-catalog-context",
+            f"{name}: catalog text helper targets script, CSS, or SVG",
+        )
+
+    body = re.search(r"<script>(.*?)</script>", raw, re.S)
+    javascript = strip_comments(body.group(1)) if body else ""
+    working = _consume_canonical_lookups(name, javascript, problems)
+    catalog_value = r"(?:message|catalogMessage)\s*\("
+
+    # These contexts never accept repository-owned text, even when escaped.
     forbidden_patterns = (
-        r"\.(?:href|src|onclick)\s*=\s*message\s*\(",
-        r"\.style(?:\.[A-Za-z_$][\w$]*)?\s*=\s*message\s*\(",
-        r"\b(?:script|scriptNode)\.textContent\s*=\s*message\s*\(",
-        r"\b(?:style|styleNode)\.textContent\s*=\s*message\s*\(",
-        r"\b(?:svg|svgNode)\.(?:innerHTML|textContent)\s*=\s*message\s*\(",
-        r"(?:href|src|style|onclick)=[\"'][^\"']*\$\{message\s*\(",
+        rf"\.(?:href|src|onclick)\s*=\s*[^;\n]*{catalog_value}",
+        rf"\.style(?:\.[A-Za-z_$][\w$]*)?\s*=\s*[^;\n]*{catalog_value}",
+        rf"\.setAttribute\s*\([^;\n]*{catalog_value}",
+        rf"\b(?:script|scriptNode|style|styleNode)\.textContent\s*=\s*"
+        rf"[^;\n]*{catalog_value}",
+        rf"\b(?:svg|svgNode)\.(?:textContent|innerHTML)\s*=\s*"
+        rf"[^;\n]*{catalog_value}",
     )
-    for pattern in forbidden_patterns:
-        if re.search(pattern, source):
-            problems.append((
+    if any(re.search(pattern, working) for pattern in forbidden_patterns):
+        add(
+            "forbidden-catalog-context",
+            f"{name}: catalog value enters URL, style, event, script, CSS, SVG, "
+            "or native attribute context",
+        )
+    for alias in created:
+        if re.search(
+            rf"\b{re.escape(alias)}\.(?:textContent|innerHTML)\s*=\s*"
+            rf"[^;\n]*{catalog_value}",
+            working,
+        ):
+            add(
                 "forbidden-catalog-context",
-                f"{name}: catalog value enters URL/style/event/script/CSS/SVG context",
-            ))
+                f"{name}: catalog value enters script, CSS, or SVG alias",
+            )
 
-    if re.search(r"\.innerHTML\s*=\s*message\s*\(", source):
-        problems.append((
+    # Descriptors may be resolved only by escapeHtml; ID-taking DOM helpers
+    # resolve their own catalog values and reject a descriptor argument.
+    if re.search(
+        r"\b(?:setMessageText|setMessageAttr|setMessageWithNodes|"
+        r"setEmphasizedMessage)\s*\([^,]+,\s*(?:['\"][^'\"]+['\"]\s*,\s*)?"
+        r"catalogMessage\s*\(",
+        working,
+    ):
+        add(
             "sink-context",
-            f"{name}: plain catalog value reaches an HTML parser without escaping",
-        ))
-    if re.search(r"\$\{message\s*\(", source):
-        problems.append((
+            f"{name}: catalog descriptor bypasses its owning HTML sink",
+        )
+    for write in re.finditer(
+        r"\.(?:innerHTML\s*\+?=|insertAdjacentHTML\s*\()([^;\n]*)", working
+    ):
+        expression = write.group(1)
+        if (
+            re.search(r"\bcatalogMessage\s*\(", expression)
+            and not re.search(
+                r"\bescapeHtml\s*\([^;\n]*\bcatalogMessage\s*\(", expression
+            )
+        ):
+            add(
+                "sink-context",
+                f"{name}: inert catalog descriptor reaches HTML without escapeHtml",
+            )
+    if re.search(
+        r"(?:\.textContent\s*=|createTextNode\s*\()[^;\n]*"
+        r"\bcatalogMessage\s*\(",
+        working,
+    ):
+        add(
             "sink-context",
-            f"{name}: plain catalog value is interpolated into an HTML string",
-        ))
+            f"{name}: catalog descriptor bypasses an ID-taking text sink",
+        )
+
+    # After the exact canonical bodies and lexical declaration are blanked,
+    # any remaining bare resolver identifier is a convention violation. This
+    # catches aliases, bind/call access, and destructuring without inferring
+    # eventual JavaScript ownership.
+    if (
+        not any(check == "forbidden-catalog-context" for check, _ in problems)
+        and (
+            re.search(r"(?<![.\w$-])message\b", working)
+            or re.search(r"\[\s*['\"]message['\"]\s*\]", working)
+        )
+    ):
+        add(
+            "sink-context",
+            f"{name}: raw message resolver is referenced outside canonical sinks",
+        )
 
     return problems
 
@@ -329,7 +498,9 @@ def lint_untagged(name: str, raw: str) -> list:
         text = m.group(1)
         if frozen(text):
             continue
-        errors.append(f"{name}: untagged display string {text!r} — route it through t()")
+        errors.append(
+            f"{name}: untagged display string {text!r} — route it through message()"
+        )
 
     stripped = strip_comments(scanned)
     for line in stripped.splitlines():
@@ -352,7 +523,9 @@ def lint_untagged(name: str, raw: str) -> list:
             if ATTR_VALUE.search(before):
                 continue
             if looks_like_prose(text):
-                errors.append(f"{name}: untagged prose {text!r} — route it through t()")
+                errors.append(
+                    f"{name}: untagged prose {text!r} — route it through message()"
+                )
 
     # Bare prose sitting between tags inside a template literal.
     for m in TEMPLATE_LITERAL.finditer(stripped):
@@ -365,7 +538,7 @@ def lint_untagged(name: str, raw: str) -> list:
                 if piece and looks_like_prose(piece):
                     errors.append(
                         f"{name}: untagged prose {piece!r} in template markup"
-                        f" — route it through t()"
+                        f" — route it through message()"
                     )
 
     # Localizable attributes carrying prose, with no data-i18n-attr beside them.
@@ -519,6 +692,11 @@ SINK_SELFTEST_CASES = [
     ("attr-title", "setMessageAttr(el, 'title', 'probe');", None),
     ("attr-placeholder", "setMessageAttr(el, 'placeholder', 'probe');", None),
     ("attr-aria-label", "setMessageAttr(el, 'aria-label', 'probe');", None),
+    (
+        "attr-svg-aria-label",
+        "setMessageAttr(svgNode, 'aria-label', 'probe');",
+        None,
+    ),
     ("attr-alt", "setMessageAttr(el, 'alt', 'probe');", None),
     # Forbidden contexts are independent so a broad check cannot hide a hole.
     ("attr-href", "setMessageAttr(el, 'href', 'probe');", "forbidden-catalog-context"),
@@ -532,17 +710,231 @@ SINK_SELFTEST_CASES = [
     ("script-text", "scriptNode.textContent = message('probe');", "forbidden-catalog-context"),
     ("css-text", "styleNode.textContent = message('probe');", "forbidden-catalog-context"),
     ("raw-svg", "svgNode.innerHTML = message('probe');", "forbidden-catalog-context"),
+    (
+        "raw-svg-concat",
+        "svgNode.innerHTML = '<text>' + message('probe') + '</text>';",
+        "forbidden-catalog-context",
+    ),
+    (
+        "raw-svg-escaped",
+        "svgNode.innerHTML = '<text>' + esc(message('probe')) + '</text>';",
+        "forbidden-catalog-context",
+    ),
     ("html-string", "el.innerHTML = message('probe');", "sink-context"),
     (
         "escaped-html-string",
-        "el.innerHTML = '<span>' + esc(message('probe')) + '</span>';",
+        "el.innerHTML = '<span>' + escapeHtml(catalogMessage('probe')) + '</span>';",
         None,
+    ),
+    (
+        "html-owner-string-spoof",
+        "el.innerHTML = 'esc(' + message('probe');",
+        "sink-context",
+    ),
+    (
+        "adjacent-owner-string-spoof",
+        "el.insertAdjacentHTML('beforeend', 'esc(' + message('probe'));",
+        "sink-context",
+    ),
+    ("approved-html-owner", "metricRow(catalogMessage('probe'), '1');", None),
+    ("approved-plain-binding", "const windowLabel = catalogMessage('probe');", None),
+    (
+        "raw-html-concat",
+        "el.innerHTML = '<span>' + message('probe') + '</span>';",
+        "sink-context",
+    ),
+    (
+        "raw-html-multiline",
+        "el.innerHTML = `<span>\n${message('probe')}\n</span>`;",
+        "sink-context",
+    ),
+    (
+        "raw-insert-adjacent",
+        "el.insertAdjacentHTML('beforeend', message('probe'));",
+        "sink-context",
+    ),
+    (
+        "raw-html-plus-equals",
+        "el.innerHTML += message('probe');",
+        "sink-context",
+    ),
+    (
+        "raw-html-no-semicolon",
+        "el.innerHTML = message('probe')",
+        "sink-context",
+    ),
+    (
+        "raw-insert-no-semicolon",
+        "el.insertAdjacentHTML('beforeend', message('probe'))",
+        "sink-context",
+    ),
+    (
+        "direct-setattribute-href",
+        "el.setAttribute('href', message('probe'));",
+        "forbidden-catalog-context",
+    ),
+    (
+        "direct-setattribute-style",
+        "el.setAttribute('style', message('probe'));",
+        "forbidden-catalog-context",
+    ),
+    (
+        "direct-setattribute-nested",
+        "el.setAttribute('href', message('probe', {x: fn()}));",
+        "forbidden-catalog-context",
+    ),
+    (
+        "direct-setattribute-fake-canonical",
+        "function setMessageAttr() {} other.setAttribute(attr, message(id, params));",
+        "forbidden-catalog-context",
+    ),
+    (
+        "canonical-setattribute-forbidden",
+        "function setMessageAttr(node, attr, id, params) { node.setAttribute('href', message(id, params)); }",
+        "forbidden-catalog-context",
+    ),
+    ("unknown-owner", "unknownSink(message('probe'));", "sink-context"),
+    ("unknown-binding", "const surprise = message('probe');", "sink-context"),
+    ("resolver-alias", "const lookup = message; lookup('probe');", "sink-context"),
+    ("resolver-call", "message.call(null, 'probe');", "sink-context"),
+    ("resolver-bind", "const lookup = message.bind(null);", "sink-context"),
+    ("resolver-window", "window['message']('probe');", "sink-context"),
+    (
+        "unknown-in-returner",
+        "function apiAccessLine() { return unknownSink(message('probe')); }",
+        "sink-context",
+    ),
+    (
+        "unknown-in-approved-binding",
+        "const windowLabel = unknownSink(message('probe'));",
+        "sink-context",
+    ),
+    (
+        "unknown-in-internal",
+        "function setMessageWithNodes() { unknownSink(message('probe')); }",
+        "sink-context",
+    ),
+    (
+        "script-alias-text",
+        "const alias = document.createElement('script'); alias.textContent = message('probe');",
+        "forbidden-catalog-context",
+    ),
+    (
+        "style-alias-text",
+        "const alias = document.createElement('style'); alias.textContent = message('probe');",
+        "forbidden-catalog-context",
+    ),
+    (
+        "svg-alias-text",
+        "const alias = document.createElementNS('urn:x', 'svg'); alias.textContent = message('probe');",
+        "forbidden-catalog-context",
+    ),
+    (
+        "helper-script-target",
+        "setMessageText(scriptNode, 'probe');",
+        "forbidden-catalog-context",
+    ),
+    (
+        "helper-style-target",
+        "setMessageText(styleNode, 'probe');",
+        "forbidden-catalog-context",
+    ),
+    (
+        "helper-svg-target",
+        "setMessageText(svgNode, 'probe');",
+        "forbidden-catalog-context",
+    ),
+    (
+        "structured-script-target",
+        "setMessageWithNodes(scriptNode, 'probe', []);",
+        "forbidden-catalog-context",
+    ),
+    (
+        "emphasis-style-target",
+        "setEmphasizedMessage(styleNode, 'probe', document.createElement('b'));",
+        "forbidden-catalog-context",
+    ),
+    (
+        "text-asi-unknown",
+        "el.textContent = 'safe'\nunknownSink(message('probe'));",
+        "sink-context",
+    ),
+    (
+        "binding-asi-unknown",
+        "const windowLabel = 'safe'\nunknownSink(message('probe'));",
+        "sink-context",
+    ),
+    (
+        "return-asi-unknown",
+        "function apiAccessLine() { return 'safe'\nsurprise = message('probe') }",
+        "sink-context",
+    ),
+    (
+        "approved-returner",
+        "function apiAccessLine() { return message('probe'); }",
+        "sink-context",
+    ),
+    (
+        "approved-internal",
+        "function setMessageWithNodes() { let text = message('probe'); }",
+        "sink-context",
+    ),
+    (
+        "descriptor-property-href",
+        "el.href = catalogMessage('probe');",
+        "forbidden-catalog-context",
+    ),
+    (
+        "descriptor-property-style",
+        "el.style.cssText = catalogMessage('probe');",
+        "forbidden-catalog-context",
+    ),
+    (
+        "descriptor-native-attr",
+        "el.setAttribute('title', catalogMessage('probe'));",
+        "forbidden-catalog-context",
+    ),
+    (
+        "descriptor-raw-svg",
+        "svgNode.innerHTML = escapeHtml(catalogMessage('probe'));",
+        "forbidden-catalog-context",
+    ),
+    (
+        "descriptor-text-helper",
+        "setMessageText(el, catalogMessage('probe'));",
+        "sink-context",
+    ),
+    (
+        "descriptor-direct-text",
+        "el.textContent = catalogMessage('probe');",
+        "sink-context",
+    ),
+    (
+        "descriptor-text-node",
+        "document.createTextNode(catalogMessage('probe'));",
+        "sink-context",
+    ),
+    (
+        "declarative-script-target",
+        '<script data-i18n="probe"></script>',
+        "forbidden-catalog-context",
+    ),
+    (
+        "declarative-style-target",
+        '<style data-i18n="probe"></style>',
+        "forbidden-catalog-context",
+    ),
+    (
+        "declarative-svg-target",
+        '<svg data-i18n="probe"></svg>',
+        "forbidden-catalog-context",
     ),
     (
         "structured-html",
         '<span data-i18n-html="probe"></span>',
         "structured-message-html",
     ),
+    ("escaped-compat-helper", "const t = id => id;", "sink-context"),
 ]
 
 SELFTEST_PAGE = """<!doctype html><html><body>
@@ -584,9 +976,9 @@ def selftest() -> int:
                 failures.append(f"{label}: expected to pass, tripped {sorted(found)}")
             else:
                 print(f"  ok  {label:24} passes")
-        elif want not in found:
+        elif found != {want}:
             failures.append(
-                f"{label}: expected {want!r}, tripped {sorted(found) or 'nothing'}"
+                f"{label}: expected only {want!r}, tripped {sorted(found) or 'nothing'}"
             )
         else:
             print(f"  ok  {label:24} trips {want}")
@@ -620,8 +1012,8 @@ def main() -> int:
             if mid not in catalog:
                 errors.append(f"{name}: data-i18n={mid} has no catalog entry")
                 continue
-            # catalog stores PLAIN text; the runtime escapes on load, so compare
-            # the markup with entities decoded
+            # Catalog values are plain text. Decode source-markup entities
+            # before comparing the authored fallback text with the catalog.
             want = catalog[mid]["en"]
             if htmlmod.unescape(inner).strip() != want.strip():
                 errors.append(
@@ -641,26 +1033,8 @@ def main() -> int:
                     f"{name}: {mid} text node {first[:50]!r} != catalog {want[:50]!r}"
                 )
 
-        # data-i18n-html carries inline markup as placeholders; the element is
-        # emptied in the markup, so there is no text to round-trip against.
-        # What must hold is that every placeholder is one the runtime expands.
-        known = {"{b}", "{/b}", "{key}", "{endpoint}"}
-        for m in re.finditer(r'data-i18n-html="([^"]+)"', source):
-            mid = m.group(1)
-            referenced.add(mid)
-            if mid not in catalog:
-                errors.append(f"{name}: data-i18n-html={mid} has no catalog entry")
-                continue
-            for ph in re.findall(r"\{[^}]*\}", catalog[mid]["en"]):
-                if ph not in known:
-                    errors.append(f"{name}: {mid} uses unknown placeholder {ph}")
-            if "<" in catalog[mid]["en"]:
-                errors.append(f"{name}: {mid} contains raw markup; use a placeholder")
-
-        # No value anywhere may carry markup or an HTML entity. Entities would
-        # double-encode (values are plain text, escaped once at load); markup
-        # would render literally through the escaping paths and inject through
-        # any that is added later.
+        # No value anywhere may carry raw or entity-encoded markup. Catalog
+        # values are plain text; an HTML parser never owns their meaning.
         for mid, msg in catalog.items():
             if "<" in msg["en"] or ">" in msg["en"]:
                 errors.append(f"[catalog-markup] {name}: {mid} contains raw markup")
@@ -700,15 +1074,15 @@ def main() -> int:
                     f"{name}: {mid} hash {msg.get('hash')} stale, text hashes to {got}"
                 )
 
-        # ids used from JavaScript: t('id') / tRaw('id') / tHtml('id').
-        # These must exist — an unknown id renders the raw id string to the
-        # operator rather than failing loudly.
-        # both quote styles: dashboard.html uses ', setup.html uses "
-        for m in re.finditer(r"""\bt(?:Raw|Html)?\(\s*['"]([a-z0-9_.]+)['"]""", strip_comments(raw)):
+        # Executable page code carries catalog ids as quoted values passed to
+        # ID-taking sinks or catalogMessage(). The application/json catalog is
+        # deliberately excluded, or every orphan would appear referenced.
+        js = strip_comments("".join(re.findall(r"<script>(.*?)</script>", raw, re.S)))
+        for m in re.finditer(r"""['"]((?:dashboard|setup)\.[a-z0-9_.]+)['"]""", js):
             mid = m.group(1)
             referenced.add(mid)
             if mid not in catalog:
-                errors.append(f"{name}: t('{mid}') has no catalog entry")
+                errors.append(f"{name}: message id {mid!r} has no catalog entry")
 
         for mid in catalog:
             if mid not in referenced:

--- a/scripts/check_i18n.py
+++ b/scripts/check_i18n.py
@@ -235,12 +235,77 @@ def lint_runtime_helpers(name: str, raw: str) -> list:
     if not body:
         return []
     js = strip_comments(body.group(1))
-    called = set(re.findall(r"\b(t|tRaw|tHtml|applyStatic|rawMsg|fill)\s*\(", js))
-    defined = set(re.findall(r"(?:const|let|var|function)\s+(t|tRaw|tHtml|applyStatic|rawMsg|fill)\b", js))
+    helpers = (
+        r"message|setMessageText|setMessageAttr|applyStatic|"
+        r"t|tRaw|tHtml|rawMsg|fill"
+    )
+    called = set(re.findall(rf"\b({helpers})\s*\(", js))
+    defined = set(
+        re.findall(rf"(?:const|let|var|function)\s+({helpers})\b", js)
+    )
     return [
         f"{name}: calls {fn}() but never defines it — the page will not localize"
         for fn in sorted(called - defined)
     ]
+
+
+I18N_TEXT_ATTRS = {"title", "placeholder", "aria-label", "alt"}
+
+
+def lint_catalog_sinks(name: str, raw: str) -> list:
+    """Return ``(check id, detail)`` for catalog values in unsafe contexts.
+
+    This is deliberately a narrow source contract, not a JavaScript parser.
+    The runtime exposes one plain ``message()`` value type, and every permitted
+    call shape is explicit enough to identify mechanically. Browser probes
+    separately prove the helpers' actual DOM behavior.
+    """
+    problems = []
+    source = strip_comments(raw)
+
+    if re.search(r'data-i18n-html=|\btHtml\s*\(', source):
+        problems.append((
+            "structured-message-html",
+            f"{name}: structured catalog message uses an HTML-producing path",
+        ))
+
+    for match in re.finditer(
+        r"\bsetMessageAttr\s*\([^,]+,\s*['\"]([^'\"]+)['\"]", source
+    ):
+        attr = match.group(1)
+        if attr not in I18N_TEXT_ATTRS:
+            problems.append((
+                "forbidden-catalog-context",
+                f"{name}: catalog value targets forbidden attribute {attr!r}",
+            ))
+
+    forbidden_patterns = (
+        r"\.(?:href|src|onclick)\s*=\s*message\s*\(",
+        r"\.style(?:\.[A-Za-z_$][\w$]*)?\s*=\s*message\s*\(",
+        r"\b(?:script|scriptNode)\.textContent\s*=\s*message\s*\(",
+        r"\b(?:style|styleNode)\.textContent\s*=\s*message\s*\(",
+        r"\b(?:svg|svgNode)\.(?:innerHTML|textContent)\s*=\s*message\s*\(",
+        r"(?:href|src|style|onclick)=[\"'][^\"']*\$\{message\s*\(",
+    )
+    for pattern in forbidden_patterns:
+        if re.search(pattern, source):
+            problems.append((
+                "forbidden-catalog-context",
+                f"{name}: catalog value enters URL/style/event/script/CSS/SVG context",
+            ))
+
+    if re.search(r"\.innerHTML\s*=\s*message\s*\(", source):
+        problems.append((
+            "sink-context",
+            f"{name}: plain catalog value reaches an HTML parser without escaping",
+        ))
+    if re.search(r"\$\{message\s*\(", source):
+        problems.append((
+            "sink-context",
+            f"{name}: plain catalog value is interpolated into an HTML string",
+        ))
+
+    return problems
 
 
 def lint_untagged(name: str, raw: str) -> list:
@@ -448,6 +513,38 @@ SELFTEST_CASES = [
     ("lowercase-token", "const z = 'sticky';", None),
 ]
 
+SINK_SELFTEST_CASES = [
+    # Allowed plain-text contexts.
+    ("element-text", "setMessageText(el, 'probe');", None),
+    ("attr-title", "setMessageAttr(el, 'title', 'probe');", None),
+    ("attr-placeholder", "setMessageAttr(el, 'placeholder', 'probe');", None),
+    ("attr-aria-label", "setMessageAttr(el, 'aria-label', 'probe');", None),
+    ("attr-alt", "setMessageAttr(el, 'alt', 'probe');", None),
+    # Forbidden contexts are independent so a broad check cannot hide a hole.
+    ("attr-href", "setMessageAttr(el, 'href', 'probe');", "forbidden-catalog-context"),
+    ("attr-src", "setMessageAttr(el, 'src', 'probe');", "forbidden-catalog-context"),
+    ("attr-style", "setMessageAttr(el, 'style', 'probe');", "forbidden-catalog-context"),
+    ("attr-onclick", "setMessageAttr(el, 'onclick', 'probe');", "forbidden-catalog-context"),
+    ("property-href", "el.href = message('probe');", "forbidden-catalog-context"),
+    ("property-src", "el.src = message('probe');", "forbidden-catalog-context"),
+    ("property-style", "el.style.cssText = message('probe');", "forbidden-catalog-context"),
+    ("property-onclick", "el.onclick = message('probe');", "forbidden-catalog-context"),
+    ("script-text", "scriptNode.textContent = message('probe');", "forbidden-catalog-context"),
+    ("css-text", "styleNode.textContent = message('probe');", "forbidden-catalog-context"),
+    ("raw-svg", "svgNode.innerHTML = message('probe');", "forbidden-catalog-context"),
+    ("html-string", "el.innerHTML = message('probe');", "sink-context"),
+    (
+        "escaped-html-string",
+        "el.innerHTML = '<span>' + esc(message('probe')) + '</span>';",
+        None,
+    ),
+    (
+        "structured-html",
+        '<span data-i18n-html="probe"></span>',
+        "structured-message-html",
+    ),
+]
+
 SELFTEST_PAGE = """<!doctype html><html><body>
 <script type="application/json" id="i18n-catalog">{"locale":"en-US","messages":{}}</script>
 <script>
@@ -479,12 +576,28 @@ def selftest() -> int:
         else:
             print(f"  ok  {label:24} trips {want}")
 
+    for label, snippet, want in SINK_SELFTEST_CASES:
+        page = SELFTEST_PAGE % snippet
+        found = {check for check, _ in lint_catalog_sinks("selftest", page)}
+        if want is None:
+            if found:
+                failures.append(f"{label}: expected to pass, tripped {sorted(found)}")
+            else:
+                print(f"  ok  {label:24} passes")
+        elif want not in found:
+            failures.append(
+                f"{label}: expected {want!r}, tripped {sorted(found) or 'nothing'}"
+            )
+        else:
+            print(f"  ok  {label:24} trips {want}")
+
     if failures:
         print("\nselftest FAILED:")
         for f in failures:
             print("  -", f)
         return 1
-    print(f"\nselftest ok — {len(SELFTEST_CASES)} cases, every check observed to fail")
+    total = len(SELFTEST_CASES) + len(SINK_SELFTEST_CASES)
+    print(f"\nselftest ok — {total} cases, every check observed to fail")
     return 0
 
 
@@ -550,9 +663,13 @@ def main() -> int:
         # any that is added later.
         for mid, msg in catalog.items():
             if "<" in msg["en"] or ">" in msg["en"]:
-                errors.append(f"{name}: {mid} contains raw markup")
-            if re.search(r"&(?:[a-zA-Z]+|#\d+);", msg["en"]):
-                errors.append(f"{name}: {mid} contains an HTML entity; store plain text")
+                errors.append(f"[catalog-markup] {name}: {mid} contains raw markup")
+            decoded = htmlmod.unescape(msg["en"])
+            if decoded != msg["en"] and ("<" in decoded or ">" in decoded):
+                errors.append(
+                    f"[catalog-entity-markup] {name}: {mid} contains "
+                    "entity-encoded markup"
+                )
 
         # Only text-bearing attributes are localizable; the runtime enforces
         # the same set, so a mismatch here is a bug in one of the two.
@@ -619,6 +736,10 @@ def main() -> int:
     for name in ("src/dashboard.html", "src/setup.html"):
         page = (ROOT / name).read_text()
         errors += lint_runtime_helpers(name, page)
+        errors += [
+            f"[{check}] {detail}"
+            for check, detail in lint_catalog_sinks(name, page)
+        ]
         errors += lint_untagged(name, page)
         if 'id="i18n-catalog"' in page:
             errors += lint_retired_vocabulary(name, page)

--- a/scripts/locale_v1.py
+++ b/scripts/locale_v1.py
@@ -27,8 +27,8 @@ The checks, and why each exists:
   and entity-encoded markup are rejected independently so neither can become
   executable or double-encoded when a value reaches the wrong sink.
   See knowledge/decisions/message-catalog-and-escaping.md.
-- **inline balance** — `{b}` without `{/b}` produces unclosed markup after the
-  runtime expands it.
+- **inline structure** — removed, duplicated, or reordered `{b}`/`{/b}`
+  markers describe a shape the fixed-node runtime does not accept.
 - **source-hash freshness** — the hash records which en-US text a translation
   was made from. When the source changes and the hash does not, the translation
   is stale: still valid, no longer correct. This is the check that makes a
@@ -52,6 +52,7 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 FIXTURES = ROOT / "tests/fixtures/locales"
 INLINE_OPEN = {"{b}"}
 INLINE_CLOSE = {"{/b}"}
+INLINE_TOKEN = re.compile(r"\{/?b\}")
 PLACEHOLDER = re.compile(r"\{[^{}]*\}")
 
 
@@ -109,10 +110,14 @@ def validate(source: dict, candidate: dict, name: str) -> list:
                 f"{name}: {mid} contains entity-encoded markup",
             ))
 
-        opens = sum(text.count(o) for o in INLINE_OPEN)
-        closes = sum(text.count(c2) for c2 in INLINE_CLOSE)
-        if opens != closes:
-            problems.append(("inline", f"{name}: {mid} has {opens} inline open vs {closes} close"))
+        source_inline = INLINE_TOKEN.findall(s["en"])
+        candidate_inline = INLINE_TOKEN.findall(text)
+        if candidate_inline != source_inline:
+            problems.append((
+                "inline",
+                f"{name}: {mid} inline structure {candidate_inline!r} "
+                f"does not match source {source_inline!r}",
+            ))
 
         if c.get("hash") != s["hash"]:
             problems.append((
@@ -158,6 +163,7 @@ def selftest() -> int:
         "entity-html.json": "catalog-entity-markup",
         "stale-hash.json": "stale",
         "too-long.json": "length",
+        "inline-dropped.json": "inline",
         "unbalanced-inline.json": "inline",
         "frozen-token-dropped.json": "frozen",
     }

--- a/scripts/locale_v1.py
+++ b/scripts/locale_v1.py
@@ -23,8 +23,9 @@ The checks, and why each exists:
   dropped placeholder leaves `{count}` visible in the interface.
 - **formatter syntax** — an unbalanced brace parses as literal text and ships
   as literal text.
-- **no raw markup** — values are escaped once at load. Markup in a value
-  renders literally today, and injects the moment a non-escaping path is added.
+- **no catalog markup** — catalog values are plain Unicode text. Raw markup
+  and entity-encoded markup are rejected independently so neither can become
+  executable or double-encoded when a value reaches the wrong sink.
   See knowledge/decisions/message-catalog-and-escaping.md.
 - **inline balance** — `{b}` without `{/b}` produces unclosed markup after the
   runtime expands it.
@@ -36,6 +37,7 @@ The checks, and why each exists:
 """
 import argparse
 import hashlib
+import html
 import json
 import pathlib
 import re
@@ -99,7 +101,13 @@ def validate(source: dict, candidate: dict, name: str) -> list:
                 ))
 
         if "<" in text or ">" in text:
-            problems.append(("markup", f"{name}: {mid} contains raw markup"))
+            problems.append(("catalog-markup", f"{name}: {mid} contains raw markup"))
+        decoded = html.unescape(text)
+        if decoded != text and ("<" in decoded or ">" in decoded):
+            problems.append((
+                "catalog-entity-markup",
+                f"{name}: {mid} contains entity-encoded markup",
+            ))
 
         opens = sum(text.count(o) for o in INLINE_OPEN)
         closes = sum(text.count(c2) for c2 in INLINE_CLOSE)
@@ -146,7 +154,8 @@ def selftest() -> int:
         "orphan-key.json": "orphan",
         "placeholder-mismatch.json": "placeholders",
         "bad-formatter-syntax.json": "syntax",
-        "raw-html.json": "markup",
+        "raw-html.json": "catalog-markup",
+        "entity-html.json": "catalog-entity-markup",
         "stale-hash.json": "stale",
         "too-long.json": "length",
         "unbalanced-inline.json": "inline",

--- a/scripts/render_check.js
+++ b/scripts/render_check.js
@@ -252,9 +252,9 @@ function buildPage(tmpdir) {
   // In-page capture as well as CDP: the page boots from an async IIFE, so a
   // throw there surfaces as an unhandled rejection, which Runtime.exceptionThrown
   // does not reliably report. A gate blind to that is blind to boot failure.
-  // The probe string carries both directions of the escape-once rule:
-  //   `&` and `'`  — escaped twice, they surface as literal `&amp;` / `&#39;`
-  //   `<b>`        — not escaped at all, it becomes a real ELEMENT in the DOM
+  // The probe string carries both directions of the contextual-sink rule:
+  //   `&` and `'`  — escaped as text, they surface as literal entities
+  //   `<b>`        — parsed as HTML, it becomes a real ELEMENT in the DOM
   // Without the tag the probe was a double-escape detector only, structurally
   // blind to the missing-escape direction — which is the XSS direction.
   if (escapeProbe) {
@@ -417,10 +417,9 @@ const SETUP_STEPS = {
   step3: `(() => {
     $('to3').click();
     const reviewed = ($('review').textContent || '').length > 0;
-    // Toggle both ways: apiAccessLine() has two branches and they land in
-    // different sinks — esc() into innerHTML on first render, textContent on
-    // change. Leave it checked so step4 reaches showConnect rather than
-    // navigating to /.
+    // Toggle both ways: apiAccessMessageId() has two branches and both feed the
+    // ID-taking text sink. Leave it checked so step4 reaches showConnect
+    // rather than navigating to /.
     $('mintkey').checked = false;
     $('mintkey').dispatchEvent(new Event('change'));
     $('mintkey').checked = true;
@@ -571,18 +570,28 @@ async function main() {
     return r.result.value;
   };
 
-  /* Exercise the page's real plain-message runtime. Static self-tests cover
+  /* Exercise the page's real ID/descriptor runtime. Static self-tests cover
      source-level forbidden contexts; this probe proves the helpers use native
      DOM sinks, preserve literal Unicode/entities/markup, and reject every
      non-text attribute. */
-  const sinkContext = await evaluate(`
-    (() => {
-      const required = ['message', 'setMessageText', 'setMessageAttr'];
+  if (escapeProbe) {
+    const sinkContext = await evaluate(`
+      (() => {
+      const required = ['setMessageText', 'setMessageAttr'];
       for (const name of required) {
         if (typeof globalThis[name] !== 'function') return name + ' is not reachable';
       }
+      if (typeof message !== 'function') return 'lexical message resolver is not reachable';
+      if (typeof globalThis.message !== 'undefined')
+        return 'raw message resolver is exposed on globalThis';
+      if (!${JSON.stringify(IS_SETUP)} &&
+          (typeof catalogMessage !== 'function' || typeof escapeHtml !== 'function'))
+        return 'catalog descriptor or HTML sink is not reachable';
       if (typeof I18N_TEXT_ATTRS === 'undefined') return 'I18N_TEXT_ATTRS is not defined';
-      for (const old of ['rawMsg', 'tRaw', 'tHtml']) {
+      const allowedAttrs = [...I18N_TEXT_ATTRS].sort().join(',');
+      if (allowedAttrs !== 'alt,aria-label,placeholder,title')
+        return 'I18N_TEXT_ATTRS is not exactly the four approved attributes';
+      for (const old of ['rawMsg', 't', 'tRaw', 'tHtml']) {
         if (typeof globalThis[old] !== 'undefined') return old + ' escaped/plain compatibility helper survives';
       }
       const ids = Object.keys(MSG);
@@ -596,11 +605,68 @@ async function main() {
       document.body.appendChild(host);
       const problems = [];
 
+      if (!${JSON.stringify(IS_SETUP)}) {
+        const descriptor = catalogMessage(id);
+        if (!Object.isFrozen(descriptor)) problems.push('catalog descriptor is mutable');
+        let coercionError = '';
+        try { String(descriptor); } catch (e) { coercionError = e.message; }
+        if (coercionError !== 'catalog descriptor requires escapeHtml')
+          problems.push('catalog descriptor did not refuse ordinary coercion');
+        const escaped = expected.replace(/[&<>"']/g, c =>
+          ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+        if (escapeHtml(descriptor) !== escaped)
+          problems.push('HTML sink did not resolve and escape the catalog descriptor');
+        for (const attempt of [
+          d => { document.createElement('a').href = d; },
+          d => { document.createElement('div').style.cssText = d; },
+          d => { document.createElement('div').setAttribute('title', d); },
+        ]) {
+          let error = '';
+          try { attempt(descriptor); } catch (e) { error = e.message; }
+          if (error !== 'catalog descriptor requires escapeHtml')
+            problems.push('catalog descriptor did not refuse a coercive non-HTML sink');
+        }
+      }
+
       const text = document.createElement('span');
       host.appendChild(text);
       setMessageText(text, id);
       if (text.textContent !== expected) problems.push('element text changed catalog bytes');
       if (text.children.length) problems.push('element text parsed catalog markup');
+      const textHost = document.createElement('span');
+      const textNode = document.createTextNode('');
+      textHost.appendChild(textNode);
+      host.appendChild(textHost);
+      setMessageText(textNode, id);
+      if (textNode.textContent !== expected)
+        problems.push('ordinary parented text node changed catalog bytes');
+
+      for (const node of [
+        document.createElement('script'),
+        document.createElement('style'),
+        document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+      ]) {
+        let error = '';
+        try { setMessageText(node, id); }
+        catch (e) { error = e.message; }
+        if (error !== 'forbidden catalog text target')
+          problems.push(node.nodeName + ' did not throw the stable text-target refusal');
+        if (node.textContent) problems.push(node.nodeName + ' received catalog text');
+      }
+      for (const parent of [
+        document.createElement('script'),
+        document.createElement('style'),
+        document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+      ]) {
+        const textNode = document.createTextNode('');
+        parent.appendChild(textNode);
+        let error = '';
+        try { setMessageText(textNode, id); }
+        catch (e) { error = e.message; }
+        if (error !== 'forbidden catalog text target')
+          problems.push(parent.nodeName + ' parented text node was accepted');
+        if (textNode.textContent) problems.push(parent.nodeName + ' parent received catalog text');
+      }
 
       for (const attr of ['title', 'placeholder', 'aria-label', 'alt']) {
         const node = document.createElement(attr === 'alt' ? 'img' : 'input');
@@ -609,6 +675,10 @@ async function main() {
         catch (e) { problems.push('refused allowlisted attribute ' + attr + ': ' + e.message); continue; }
         if (node.getAttribute(attr) !== expected) problems.push(attr + ' changed catalog bytes');
       }
+      const accessibleSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      setMessageAttr(accessibleSvg, 'aria-label', id);
+      if (accessibleSvg.getAttribute('aria-label') !== expected)
+        problems.push('SVG aria-label changed catalog bytes');
 
       for (const attr of ['href', 'src', 'style', 'onclick']) {
         const node = document.createElement('a');
@@ -620,13 +690,89 @@ async function main() {
           problems.push(attr + ' did not throw the stable refusal');
         if (node.hasAttribute(attr)) problems.push(attr + ' was set from a catalog id');
       }
+      if (typeof setMessageWithNodes === 'function') {
+        const id = 'setup.step3.mintkey';
+        const original = MSG[id].en;
+        const key = document.createElement('code');
+        key.textContent = 'KEY';
+        try {
+          MSG[id].en = 'A {key} B {key}';
+          setMessageWithNodes(host, id, [['{key}', key]]);
+          if (host.textContent !== 'A KEY B KEY')
+            problems.push('structured replacement did not preserve repeated placeholders');
+          if (host.querySelectorAll('code').length !== 2)
+            problems.push('structured replacement did not create one fixed node per placeholder');
+        } finally {
+          MSG[id].en = original;
+        }
+        for (const node of [
+          document.createElement('script'),
+          document.createElement('style'),
+          document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+        ]) {
+          let error = '';
+          try { setMessageWithNodes(node, id, [['{key}', key]]); }
+          catch (e) { error = e.message; }
+          if (error !== 'forbidden catalog text target')
+            problems.push(node.nodeName + ' structured helper did not refuse its target');
+          if (node.textContent) problems.push(node.nodeName + ' received structured catalog text');
+        }
+        for (const replacement of [
+          document.createElement('script'),
+          document.createElement('style'),
+          document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+          (() => {
+            const wrapper = document.createElement('span');
+            wrapper.appendChild(document.createElement('script'));
+            return wrapper;
+          })(),
+        ]) {
+          let error = '';
+          try { setMessageWithNodes(host, id, [['{key}', replacement]]); }
+          catch (e) { error = e.message; }
+          if (error !== 'forbidden catalog text target')
+            problems.push(replacement.nodeName + ' structured replacement was accepted');
+        }
+      }
+      if (typeof setEmphasizedMessage === 'function') {
+        const id = 'setup.step3.mintwarn';
+        for (const node of [
+          document.createElement('script'),
+          document.createElement('style'),
+          document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+        ]) {
+          let error = '';
+          try { setEmphasizedMessage(node, id, document.createElement('b')); }
+          catch (e) { error = e.message; }
+          if (error !== 'forbidden catalog text target')
+            problems.push(node.nodeName + ' emphasis helper did not refuse its target');
+          if (node.textContent) problems.push(node.nodeName + ' received emphasized catalog text');
+        }
+        for (const emphasis of [
+          document.createElement('script'),
+          document.createElement('style'),
+          document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+          (() => {
+            const wrapper = document.createElement('b');
+            wrapper.appendChild(document.createElement('script'));
+            return wrapper;
+          })(),
+        ]) {
+          let error = '';
+          try { setEmphasizedMessage(host, id, emphasis); }
+          catch (e) { error = e.message; }
+          if (error !== 'forbidden catalog text target')
+            problems.push(emphasis.nodeName + ' emphasis replacement was accepted');
+        }
+      }
       host.remove();
       return problems.length ? problems.join('; ') : '';
-    })()`);
-  if (sinkContext) {
-    console.error(`[sink-context] FAIL — ${PAGE_REL}: ${sinkContext}`);
-    proc.kill('SIGKILL');
-    process.exit(1);
+      })()`);
+    if (sinkContext) {
+      console.error(`[sink-context] FAIL — ${PAGE_REL}: ${sinkContext}`);
+      proc.kill('SIGKILL');
+      process.exit(1);
+    }
   }
 
   const untranslatedByTab = new Map();
@@ -854,8 +1000,8 @@ async function main() {
   if (doubleEscaped.length) {
     const dbl = doubleEscaped.filter((d) => d.dir !== 'missing');
     const miss = doubleEscaped.filter((d) => d.dir === 'missing');
-    console.error(`\nFAIL — escape-once violated: ${dbl.length} double-escaped, ${miss.length} unescaped`);
-    if (dbl.length) console.error('  a helper escaped an already-escaped catalog value:');
+    console.error(`\nFAIL — contextual catalog sink violated: ${dbl.length} entity-escaped, ${miss.length} parsed as markup`);
+    if (dbl.length) console.error('  a text/attribute sink rendered escaped entities:');
     const seen = new Set();
     for (const d of dbl) {
       if (seen.has(d.el)) continue;

--- a/scripts/render_check.js
+++ b/scripts/render_check.js
@@ -115,10 +115,9 @@ const localeArg = (() => {
   const i = args.indexOf('--locale');
   return i >= 0 ? args[i + 1] : null;
 })();
-// Catalog values are escaped once at load, so no render helper may escape its
-// label argument again (knowledge/decisions/message-catalog-and-escaping.md).
-// English labels contain no escapable character, so a second escape is
-// invisible until a real locale ships. This makes it visible now.
+// Catalog values are plain Unicode text. The probe proves ordinary text and
+// allowed attributes render literally, while fixed-markup HTML builders
+// perform their one context-appropriate escape at the sink.
 const escapeProbe = args.includes('--escape-probe');
 // Appended to every catalog value under --escape-probe. See the mutation below.
 const PROBE_MARKER = 'Ampersand';
@@ -572,43 +571,60 @@ async function main() {
     return r.result.value;
   };
 
-  /* Both runtimes must refuse to localize an attribute outside the allowlist.
-     This was asserted by two knowledge pages and a lint comment while only ONE
-     of the two pages actually enforced it, and the wizard shipped without the
-     guard. Reasoning found that; nothing re-checks it, so assert it in-page on
-     a synthetic element rather than trusting either description. */
-  const attrGuard = await evaluate(`
+  /* Exercise the page's real plain-message runtime. Static self-tests cover
+     source-level forbidden contexts; this probe proves the helpers use native
+     DOM sinks, preserve literal Unicode/entities/markup, and reject every
+     non-text attribute. */
+  const sinkContext = await evaluate(`
     (() => {
-      if (typeof applyStatic !== 'function') return 'applyStatic is not reachable';
-      if (typeof I18N_ATTRS === 'undefined') return 'I18N_ATTRS is not defined';
+      const required = ['message', 'setMessageText', 'setMessageAttr'];
+      for (const name of required) {
+        if (typeof globalThis[name] !== 'function') return name + ' is not reachable';
+      }
+      if (typeof I18N_TEXT_ATTRS === 'undefined') return 'I18N_TEXT_ATTRS is not defined';
+      for (const old of ['rawMsg', 'tRaw', 'tHtml']) {
+        if (typeof globalThis[old] !== 'undefined') return old + ' escaped/plain compatibility helper survives';
+      }
+      const ids = Object.keys(MSG);
+      if (!ids.length) return 'catalog has no probe id';
+      const id = ids[0];
+      const expected = message(id);
+      if (!expected.includes(${JSON.stringify(PROBE_MARKER)})) return 'message() did not return the hostile probe';
+      if (!expected.includes('<b>${PROBE_TAG_TEXT}</b>')) return 'message() did not return literal markup text';
+
       const host = document.createElement('div');
-      // A localizable attribute must be set; a scripting one must be refused.
-      host.innerHTML =
-        '<span id="__probe_ok" data-i18n-attr="title:__missing_id"></span>' +
-        '<span id="__probe_bad" data-i18n-attr="onclick:__missing_id"></span>' +
-        '<span id="__probe_style" data-i18n-attr="style:__missing_id"></span>';
       document.body.appendChild(host);
-      // The guard reports refusals with console.error, which this gate treats
-      // as a failure — correctly, in general. Silence it for the duration of
-      // the probe only: those two refusals are the behaviour under test, and
-      // the page must keep logging them for real operators.
-      const realError = console.error;
-      console.error = () => {};
-      try { applyStatic(host); }
-      catch (e) { console.error = realError; return 'applyStatic threw: ' + e.message; }
-      finally { console.error = realError; }
-      const ok = host.querySelector('#__probe_ok');
-      const bad = host.querySelector('#__probe_bad');
-      const sty = host.querySelector('#__probe_style');
       const problems = [];
-      if (!ok.hasAttribute('title')) problems.push('refused an allowlisted attribute (title)');
-      if (bad.hasAttribute('onclick')) problems.push('set onclick= from a catalog id');
-      if (sty.hasAttribute('style')) problems.push('set style= from a catalog id');
+
+      const text = document.createElement('span');
+      host.appendChild(text);
+      setMessageText(text, id);
+      if (text.textContent !== expected) problems.push('element text changed catalog bytes');
+      if (text.children.length) problems.push('element text parsed catalog markup');
+
+      for (const attr of ['title', 'placeholder', 'aria-label', 'alt']) {
+        const node = document.createElement(attr === 'alt' ? 'img' : 'input');
+        host.appendChild(node);
+        try { setMessageAttr(node, attr, id); }
+        catch (e) { problems.push('refused allowlisted attribute ' + attr + ': ' + e.message); continue; }
+        if (node.getAttribute(attr) !== expected) problems.push(attr + ' changed catalog bytes');
+      }
+
+      for (const attr of ['href', 'src', 'style', 'onclick']) {
+        const node = document.createElement('a');
+        host.appendChild(node);
+        let error = '';
+        try { setMessageAttr(node, attr, id); }
+        catch (e) { error = e.message; }
+        if (error !== 'forbidden catalog attribute: ' + attr)
+          problems.push(attr + ' did not throw the stable refusal');
+        if (node.hasAttribute(attr)) problems.push(attr + ' was set from a catalog id');
+      }
       host.remove();
       return problems.length ? problems.join('; ') : '';
     })()`);
-  if (attrGuard) {
-    console.error(`FAIL — ${PAGE_REL} attribute allowlist: ${attrGuard}`);
+  if (sinkContext) {
+    console.error(`[sink-context] FAIL — ${PAGE_REL}: ${sinkContext}`);
     proc.kill('SIGKILL');
     process.exit(1);
   }

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -582,66 +582,77 @@ body.on-settings .tright, body.on-settings #custom { display: none; }
 "use strict";
 const $ = id => document.getElementById(id);
 const css = v => getComputedStyle(document.documentElement).getPropertyValue(v).trim();
-// HTML-escape any value that reaches innerHTML. Model ids and client names
-// originate from request data; the server sanitizes them, but escape here too
-// so a stray character can never become markup (defense in depth vs XSS).
-const esc = s => String(s).replace(/[&<>"']/g, c =>
-  ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 /* ---------- i18n ----------
-   The catalog ships inline as a JSON block (the CSP already permits inline).
-   Values are stored as PLAIN TEXT and escaped once, here, at load.
-
-   That is the whole safety contract. Every call site interpolates into
-   innerHTML, and metricRow/tile/prow/perfBlock do not escape their label
-   argument, nor does kpiCards escape k.value/k.sub. Escaping at load is what
-   keeps those sinks safe — do not escape at call sites, and do not skip it.
-
-   t()    -> escaped, for innerHTML and template literals
-   tRaw() -> plain, for setAttribute and textContent, neither of which
-             parses entities
-   Catalog values may reach element content and quoted attributes only. Never
-   style=, href=, src=, or on*=. */
+   Catalog values remain plain Unicode text. Native DOM sinks own ordinary
+   element and text-bearing attribute contexts. A branded catalog descriptor
+   is inert until the fixed-markup HTML sink resolves and escapes it. */
 const I18N = JSON.parse($('i18n-catalog').textContent);
 const MSG = I18N.messages;
-const rawMsg = id => (MSG[id] === undefined ? id : MSG[id].en);
-/* Substitution happens AFTER the message is escaped, so an unescaped param
-   would land raw in metricRow/tile/prow, none of which escape their argument.
-   The escaper is a PARAMETER, matching setup.html, because the two helpers need
-   opposite ones: t() lands in innerHTML and must escape its params, while
-   tRaw() lands in textContent and setAttribute, which parse no entities and
-   would render an escaped param as a visible "&amp;". Hardcoding esc() here
-   was latent rather than wrong — no tRaw() call site passes params today — but
-   two same-named functions with different contracts across two files is the
-   trap, not the bug. */
-function fill(s, p, e) {
-  if (!p) return s;
-  for (const k in p) s = s.split('{' + k + '}').join(e(p[k]));
-  return s;
+const message = (id, params = {}) => {
+  let text = MSG[id] === undefined ? id : MSG[id].en;
+  for (const key in params)
+    text = text.split('{' + key + '}').join(String(params[key]));
+  return text;
+};
+const CATALOG_MESSAGE = Symbol('catalog-message');
+const catalogMessage = (id, params = {}) =>
+  Object.freeze({
+    type: CATALOG_MESSAGE,
+    id,
+    params: Object.freeze({ ...params }),
+    [Symbol.toPrimitive]() {
+      throw new TypeError('catalog descriptor requires escapeHtml');
+    },
+  });
+function escapeHtml(value) {
+  const text = value && value.type === CATALOG_MESSAGE
+    ? message(value.id, value.params)
+    : String(value);
+  return text.replace(/[&<>"']/g, c =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 }
-const I18N_ATTRS = new Set(['title', 'placeholder', 'aria-label', 'alt']);
-const t = (id, p) => fill(esc(rawMsg(id)), p, esc);
-const tRaw = (id, p) => fill(rawMsg(id), p, String);
+function assertMessageTextTarget(node) {
+  const context = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+  if (!context ||
+      context instanceof HTMLScriptElement ||
+      context instanceof HTMLStyleElement ||
+      context instanceof SVGElement ||
+      context.closest?.('script,style,svg'))
+    throw new Error('forbidden catalog text target');
+}
+const I18N_TEXT_ATTRS = new Set(['title', 'placeholder', 'aria-label', 'alt']);
+function setMessageText(node, id, params = {}) {
+  assertMessageTextTarget(node);
+  node.textContent = message(id, params);
+}
+function setMessageAttr(node, attr, id, params = {}) {
+  if (!I18N_TEXT_ATTRS.has(attr))
+    throw new Error(`forbidden catalog attribute: ${attr}`);
+  node.setAttribute(attr, message(id, params));
+}
 /* Static markup carries data-i18n="<id>" for content and
    data-i18n-attr="<attr>:<id>[,<attr>:<id>]" for attributes. */
 function applyStatic(root) {
-  root.querySelectorAll('[data-i18n]').forEach(el => { el.innerHTML = t(el.dataset.i18n); });
+  root.querySelectorAll('[data-i18n]').forEach(el => {
+    setMessageText(el, el.dataset.i18n);
+  });
   /* Replace an element's own first text node, leaving sibling markup alone.
      Assigning to a text node cannot introduce markup, so this path needs no
      escaping — and it keeps headings that mix a text node with an icon and a
      .note span structurally identical. */
   root.querySelectorAll('[data-i18n-text]').forEach(el => {
     for (const n of el.childNodes) {
-      if (n.nodeType === 3 && n.textContent.trim()) { n.textContent = tRaw(el.dataset.i18nText); break; }
+      if (n.nodeType === 3 && n.textContent.trim()) {
+        setMessageText(n, el.dataset.i18nText);
+        break;
+      }
     }
   });
   root.querySelectorAll('[data-i18n-attr]').forEach(el => {
     el.dataset.i18nAttr.split(',').forEach(pair => {
       const i = pair.indexOf(':');
       const attr = pair.slice(0, i);
-      // Only text-bearing attributes are localizable. Without this, a markup
-      // edit could route a catalog value into onclick= or style=.
-      if (!I18N_ATTRS.has(attr)) { console.error('refusing to localize attribute', attr); return; }
-      el.setAttribute(attr, tRaw(pair.slice(i + 1)));
+      setMessageAttr(el, attr, pair.slice(i + 1));
     });
   });
 }
@@ -796,7 +807,7 @@ const deltaBuckets = (cur, prev) => cur.map((b, i) => ({ le: b.le, count: b.coun
 
 /* ---------- state: one selected range plus a lightweight current snapshot ---------- */
 const POLL_MS = 3000;
-let samples = [];              // synthetic cumulative [{t(ms), rows}]
+let samples = [];              // synthetic cumulative [{t: milliseconds, rows}]
 let rangeData = null;
 let nowData = null;
 let nowRows = [];
@@ -933,7 +944,7 @@ function lineChart(el, series, unitFmt, opts = {}) {
   const H = opts.height || 190;
   el.classList.add('chart');
   const live = series.filter(s => s.pts.length > 1);
-  if (!live.length) { el.innerHTML = `<div class="empty">${t('dashboard.common.empty.no_data_in_range')}</div>`; return; }
+  if (!live.length) { el.innerHTML = `<div class="empty">${escapeHtml(catalogMessage('dashboard.common.empty.no_data_in_range'))}</div>`; return; }
   const W = el.clientWidth || 500, PT = 16, PB = 16;
   const t0 = Math.min(...live.map(s => s.pts[0].t));
   const t1 = Math.max(...live.map(s => s.pts[s.pts.length-1].t));
@@ -980,7 +991,7 @@ function lineChart(el, series, unitFmt, opts = {}) {
       let p = s.pts[0];
       for (const q of s.pts) if (Math.abs(q.t - best.t) < Math.abs(p.t - best.t)) p = q;
       dots += `<circle cx="${X(p.t)}" cy="${Y(p.v)}" r="4" fill="${s.color}" stroke="${css('--bg')}" stroke-width="1.5"/>`;
-      html += `<div class="row"><span><i class="sw" style="background:${s.color}"></i>${esc(s.name)}</span><b>${unitFmt(p.v)}</b></div>`;
+      html += `<div class="row"><span><i class="sw" style="background:${s.color}"></i>${escapeHtml(s.name)}</span><b>${unitFmt(p.v)}</b></div>`;
     }
     hoverg.innerHTML = xh.outerHTML + dots;
     hoverg.setAttribute('visibility', 'visible');
@@ -1009,7 +1020,7 @@ function stackChart(el, series, unitFmt, opts = {}) {
   const ts = (bands[0] || { pts: [] }).pts.map(p => p.t);
   const bandAt = (s, i) => Math.max(0, s.pts[i] ? s.pts[i].v : 0);
   const totals = ts.map((_, i) => bands.reduce((a, s) => a + bandAt(s, i), 0));
-  if (ts.length < 2 || !totals.some(v => v > 0)) { el.innerHTML = `<div class="empty">${t('dashboard.common.empty.no_data_in_range')}</div>`; return; }
+  if (ts.length < 2 || !totals.some(v => v > 0)) { el.innerHTML = `<div class="empty">${escapeHtml(catalogMessage('dashboard.common.empty.no_data_in_range'))}</div>`; return; }
   const W = el.clientWidth || 500, PT = 16, PB = 16;
   const t0 = ts[0], t1 = ts[ts.length-1];
   let vmax = Math.max(1e-6, ...totals);
@@ -1053,7 +1064,7 @@ function stackChart(el, series, unitFmt, opts = {}) {
       dots += `<circle cx="${mx}" cy="${Y(cum[k][bi])}" r="3" fill="${bands[k].color}" stroke="${css('--bg')}" stroke-width="1.5"/>`;
     let html = `<div class="t">${at(STAMP, ts[bi])}</div>`;
     for (const s of bands)
-      html += `<div class="row"><span><i class="sw" style="background:${s.color}"></i>${esc(s.name)}</span><b>${unitFmt(bandAt(s, bi))}</b></div>`;
+      html += `<div class="row"><span><i class="sw" style="background:${s.color}"></i>${escapeHtml(s.name)}</span><b>${unitFmt(bandAt(s, bi))}</b></div>`;
     html += `<div class="row" style="border-top:1px solid var(--hairline);margin-top:3px;padding-top:4px"><span>total</span><b>${unitFmt(totals[bi])}</b></div>`;
     hoverg.innerHTML = xh.outerHTML + dots;
     hoverg.setAttribute('visibility', 'visible');
@@ -1067,7 +1078,7 @@ function stackChart(el, series, unitFmt, opts = {}) {
 
 function legend(el, series) {
   el.innerHTML = series.length > 1
-    ? series.map(s => `<span><i style="background:${s.color}"></i>${esc(s.name)}</span>`).join('')
+    ? series.map(s => `<span><i style="background:${s.color}"></i>${escapeHtml(s.name)}</span>`).join('')
     : '';
 }
 
@@ -1078,7 +1089,10 @@ function legend(el, series) {
    saved/restored around the innerHTML swap so the 3s live poll doesn't jump. */
 const sortState = new Map();
 function sortTable(el, id, cols, rows, opts = {}) {
-  if (!rows.length) { el.innerHTML = `<div class="empty">${opts.empty || t('dashboard.common.empty.no_traffic')}</div>`; return; }
+  if (!rows.length) {
+    el.innerHTML = `<div class="empty">${escapeHtml(opts.empty || catalogMessage('dashboard.common.empty.no_traffic'))}</div>`;
+    return;
+  }
   const st = sortState.get(id) || { idx: opts.defaultIdx ?? 1, asc: opts.defaultAsc ?? false };
   sortState.set(id, st);
   const sorted = [...rows].sort((a, b) => {
@@ -1095,7 +1109,7 @@ function sortTable(el, id, cols, rows, opts = {}) {
   });
   let h = `<div class="scroll" style="max-height:${opts.maxH || 420}px"><table style="min-width:${opts.minW || 0}px"><thead><tr>` +
     cols.map((c, i) =>
-      `<th class="${c.align === 'l' ? 'l' : ''}${i === st.idx ? ' on' : ''}" data-i="${i}">${c.label}${i === st.idx ? (st.asc ? ' ↑' : ' ↓') : ''}</th>`
+      `<th class="${c.align === 'l' ? 'l' : ''}${i === st.idx ? ' on' : ''}" data-i="${i}">${escapeHtml(c.label)}${i === st.idx ? (st.asc ? ' ↑' : ' ↓') : ''}</th>`
     ).join('') + '</tr></thead><tbody>' +
     sorted.map(r => '<tr>' + r.cells.map((cell, i) => {
       const best = bests[i] !== null && r.vals[i] === bests[i];
@@ -1119,33 +1133,35 @@ function sortTable(el, id, cols, rows, opts = {}) {
    scale (percentages, utilization). */
 function barList(el, entries, fmtV, maxV) {
   const vals = entries.filter(e => isFinite(e.v));
-  if (!vals.length) { el.innerHTML = `<div class="empty">${t('dashboard.common.empty.no_data_yet')}</div>`; return; }
+  if (!vals.length) { el.innerHTML = `<div class="empty">${escapeHtml(catalogMessage('dashboard.common.empty.no_data_yet'))}</div>`; return; }
   const max = maxV || Math.max(1e-9, ...vals.map(e => e.v));
   el.innerHTML = entries.map(e =>
-    `<div class="brow"><span class="bname" title="${esc(e.name)}">${esc(e.label ?? e.name)}</span>` +
+    `<div class="brow"><span class="bname" title="${escapeHtml(e.name)}">${escapeHtml(e.label ?? e.name)}</span>` +
     `<span class="btrack">${isFinite(e.v) ? `<span style="width:${Math.max(2, e.v / max * 100).toFixed(0)}%;background:${e.color}"></span>` : ''}</span>` +
     `<span class="bval">${e.vtext ?? (isFinite(e.v) ? fmtV(e.v) : '–')}</span></div>`).join('');
 }
 
 /* leaderboard rows: chip square + name + value + thin progress bar */
 function leaderList(el, entries, fmtV) {
-  if (!entries.length) { el.innerHTML = `<div class="empty">${t('dashboard.common.empty.no_traffic')}</div>`; return; }
+  if (!entries.length) { el.innerHTML = `<div class="empty">${escapeHtml(catalogMessage('dashboard.common.empty.no_traffic'))}</div>`; return; }
   const max = Math.max(1e-9, ...entries.map(e => e.v));
   el.innerHTML = entries.map(e =>
     `<div class="lead">${e.chip}<div class="lbody">` +
-    `<div class="lrow"><span class="lname" title="${esc(e.name)}">${esc(e.label ?? e.name)}</span><span class="lval">${fmtV(e.v)}</span></div>` +
+    `<div class="lrow"><span class="lname" title="${escapeHtml(e.name)}">${escapeHtml(e.label ?? e.name)}</span><span class="lval">${fmtV(e.v)}</span></div>` +
     `<div class="ltrack"><span style="width:${Math.max(2, e.v / max * 100).toFixed(0)}%;background:${e.color}"></span></div>` +
     `</div></div>`).join('');
 }
 
 /* ---------- ring gauge ---------- */
-function ringGauge(el, ratio, text, color, label, sub) {
+function ringGauge(el, ratio, text, color, labelId, sub) {
   const C = 2 * Math.PI * 34, cl = Math.max(0, Math.min(1, ratio));
-  el.innerHTML = `<div class="ring"><svg width="76" height="76" viewBox="0 0 84 84" role="img" aria-label="${esc(label)} ${esc(text)}">
+  const label = catalogMessage(labelId);
+  el.innerHTML = `<div class="ring"><svg width="76" height="76" viewBox="0 0 84 84" role="img">
     <circle cx="42" cy="42" r="34" fill="none" stroke="rgba(255,255,255,0.08)" stroke-width="7"/>
     ${cl > 0.004 ? `<circle cx="42" cy="42" r="34" fill="none" stroke="${color}" stroke-width="7" stroke-linecap="round" stroke-dasharray="${(C*cl).toFixed(1)} ${C.toFixed(1)}" transform="rotate(-90 42 42)"/>` : ''}
-    </svg><span class="rtext">${text}</span></div>
-    <div class="rlabel">${esc(label)}</div><div class="rsub">${sub}</div>`;
+    </svg><span class="rtext">${escapeHtml(text)}</span></div>
+    <div class="rlabel">${escapeHtml(label)}</div><div class="rsub">${escapeHtml(sub)}</div>`;
+  setMessageAttr(el.querySelector('svg'), 'aria-label', labelId);
 }
 
 /* ---------- KPI metric cards ---------- */
@@ -1177,27 +1193,27 @@ function deltaChip(pts, downIsGood) {
   const d = (b - a) / a * 100;
   if (!isFinite(d) || Math.abs(d) < 0.05) return '';
   const good = downIsGood ? d <= 0 : d >= 0;
-  return `<span class="chip ${good ? 'good' : 'bad'}" title="${t('dashboard.common.kpi.delta_tooltip')}">${(Math.abs(d) >= 10 ? PCT_SIGNED_0 : PCT_SIGNED_1).format(d / 100)}</span>`;
+  return `<span class="chip ${good ? 'good' : 'bad'}" title="${escapeHtml(catalogMessage('dashboard.common.kpi.delta_tooltip'))}">${(Math.abs(d) >= 10 ? PCT_SIGNED_0 : PCT_SIGNED_1).format(d / 100)}</span>`;
 }
 /* k: {icon, label, value, sub, delta?, pts?} */
 function kpiCards(el, defs, hero) {
   el.innerHTML = defs.map(k =>
     `<div class="kpi${hero ? ' hero' : ''}">` +
-    `<div class="kpihead"><span class="kpilabel"><svg viewBox="0 0 16 16">${ICONS[k.icon] || ''}</svg>${k.label}</span>${k.delta || ''}</div>` +
-    `<div class="kpival">${k.value}</div>` +
-    `<div class="kpisub">${k.sub || ''}</div>` +
+    `<div class="kpihead"><span class="kpilabel"><svg viewBox="0 0 16 16">${ICONS[k.icon] || ''}</svg>${escapeHtml(k.label)}</span>${k.delta || ''}</div>` +
+    `<div class="kpival">${escapeHtml(k.value)}</div>` +
+    `<div class="kpisub">${escapeHtml(k.sub || '')}</div>` +
     sparkSvg(k.pts, hero) + `</div>`).join('');
 }
 
 /* one metric-list row: label, right-aligned mono value, optional tone */
-const metricRow = (l, v, tone) => `<div class="kv${tone ? ' ' + tone : ''}"><span>${l}</span><b>${v}</b></div>`;
+const metricRow = (l, v, tone) => `<div class="kv${tone ? ' ' + tone : ''}"><span>${escapeHtml(l)}</span><b>${escapeHtml(v)}</b></div>`;
 
 /* ---------- activity heatmap: weekday x hour, sequential green ramp ---------- */
 /* 2024-01-01 was a Monday, so offset 0 of the reference week is ISO Monday. */
 const DAYS = Array.from({ length: 7 }, (_, i) =>
   WEEKDAY_SHORT.format(Date.UTC(2024, 0, 1 + ((FIRST_DAY - 1 + i) % 7))));
 function heatmap(el, matrix, vmax) {
-  if (!vmax) { el.innerHTML = `<div class="empty">${t('dashboard.common.empty.no_data_in_range')}</div>`; return; }
+  if (!vmax) { el.innerHTML = `<div class="empty">${escapeHtml(catalogMessage('dashboard.common.empty.no_data_in_range'))}</div>`; return; }
   const CW = 26, CH = 18, GAP = 3, PL = 36, PT = 18;
   const W = PL + 24*(CW+GAP), H = PT + 7*(CH+GAP);
   let g = '';
@@ -1216,7 +1232,7 @@ function heatmap(el, matrix, vmax) {
     if (!c) { hideTip(); return; }
     const d = +c.dataset.d, h = +c.dataset.h;
     showTip(ev.clientX, ev.clientY,
-      `<div class="t">${DAYS[d]} ${HOUR_ONLY.formatRange(Date.UTC(2024, 0, 1, h), Date.UTC(2024, 0, 1, h + 1))}</div><div class="row"><span>${t('dashboard.common.col.requests')}</span><b>${fmt(matrix[d][h])}</b></div>`);
+      `<div class="t">${DAYS[d]} ${HOUR_ONLY.formatRange(Date.UTC(2024, 0, 1, h), Date.UTC(2024, 0, 1, h + 1))}</div><div class="row"><span>${escapeHtml(catalogMessage('dashboard.common.col.requests'))}</span><b>${fmt(matrix[d][h])}</b></div>`);
   });
   el.querySelector('svg').addEventListener('mouseleave', hideTip);
 }
@@ -1264,7 +1280,7 @@ const initialsOf = name => name.replace(/[^A-Za-z0-9 ]/g, ' ').trim().split(/\s+
 function chipHtml(pub) {
   const initials = initialsOf(pub.name);
   if (!pub.slug) return `<span class="logo" style="background:${pub.color}">${initials}</span>`;
-  return `<span class="logo cdnchip" style="background:rgba(255,255,255,0.05)" data-fb-bg="${esc(pub.color)}" data-fb-text="${esc(initials)}"><img alt="" src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/${encodeURIComponent(pub.slug)}.svg"></span>`;
+  return `<span class="logo cdnchip" style="background:rgba(255,255,255,0.05)" data-fb-bg="${escapeHtml(pub.color)}" data-fb-text="${escapeHtml(initials)}"><img alt="" src="https://unpkg.com/@lobehub/icons-static-svg@latest/icons/${encodeURIComponent(pub.slug)}.svg"></span>`;
 }
 /* CDN logo failed: fall back to the brand monogram. Delegated in the capture
    phase because `error` on <img> does not bubble. Replaces an onerror="..."
@@ -1309,17 +1325,17 @@ let activeTab = 'overview';
    is invisible to the untagged-string linter, which is the one thing that
    stops English creeping back. */
 const TITLES = {
-  overview: tRaw('dashboard.nav.tab.overview'), models: tRaw('dashboard.nav.tab.models'),
-  clients: tRaw('dashboard.nav.tab.clients'), reliability: tRaw('dashboard.nav.tab.reliability'),
-  capacity: tRaw('dashboard.nav.tab.capacity'), settings: tRaw('dashboard.nav.tab.settings'),
+  overview: 'dashboard.nav.tab.overview', models: 'dashboard.nav.tab.models',
+  clients: 'dashboard.nav.tab.clients', reliability: 'dashboard.nav.tab.reliability',
+  capacity: 'dashboard.nav.tab.capacity', settings: 'dashboard.nav.tab.settings',
 };
 
 function render() {
   if (!samples.length) return;
   const last = samples[samples.length-1], rows = nowRows;
-  // t(), not tRaw(): every consumer interpolates this into innerHTML through a
-  // sink that does not escape (kpiCards' k.sub, the availability hero's note).
-  const windowLabel = t('dashboard.common.note.selected_time_range');
+  // Keep this plain. Consumers that place it in fixed markup escape it at
+  // their own HTML sink.
+  const windowLabel = catalogMessage('dashboard.common.note.selected_time_range');
 
   /* ----- shared per-model aggregates ----- */
   const ptok = wgroups('nimproxy_prompt_tokens_total', 'model');
@@ -1413,7 +1429,7 @@ function render() {
 
 /* client monogram chip (client leaderboards) */
 const clientChip = cl =>
-  `<span class="logo" style="background:${clientColor(cl)}">${esc(initialsOf(String(cl)))}</span>`;
+  `<span class="logo" style="background:${clientColor(cl)}">${escapeHtml(initialsOf(String(cl)))}</span>`;
 
 /* ===== overview ===== */
 function renderOverview(c) {
@@ -1427,9 +1443,9 @@ function renderOverview(c) {
     return dr > 0 ? { t: s.t, v: Math.max(0, Math.min(100, dok / dr * 100)) } : null;
   }).filter(Boolean);
   kpiCards($('o-kpis'), [
-    { icon: 'pulse', label: t('dashboard.common.col.requests'), value: fmt(wreq), sub: windowLabel, delta: deltaChip(reqPts), pts: reqPts },
-    { icon: 'stack', label: t('dashboard.common.col.tokens_out'), value: fmt(allC), sub: `${fmt(allP)} in`, delta: deltaChip(ctokPts), pts: ctokPts },
-    { icon: 'check', label: t('dashboard.common.kpi.success_rate'), value: wreq ? pctOf(okRatio, 2) : NO_VALUE,
+    { icon: 'pulse', label: catalogMessage('dashboard.common.col.requests'), value: fmt(wreq), sub: windowLabel, delta: deltaChip(reqPts), pts: reqPts },
+    { icon: 'stack', label: catalogMessage('dashboard.common.col.tokens_out'), value: fmt(allC), sub: `${fmt(allP)} in`, delta: deltaChip(ctokPts), pts: ctokPts },
+    { icon: 'check', label: catalogMessage('dashboard.common.kpi.success_rate'), value: wreq ? pctOf(okRatio, 2) : NO_VALUE,
       sub: `${fmt(wok)} of ${fmt(wreq)}`, delta: deltaChip(okPts), pts: okPts },
   ], true);
 
@@ -1437,26 +1453,25 @@ function renderOverview(c) {
   lineChart($('o-traffic'), [{ name: 'req/min', color: MED, pts: reqPts, area: true }], fmt, { height: 220 });
 
   $('o-rings').innerHTML = '<div class="ringwrap" id="o-ring-cap"></div><div class="ringwrap" id="o-ring-ok"></div>';
-  // tRaw for the ring LABEL: ringGauge escapes it itself, in both the
-  // aria-label and .rlabel. t() there would double-encode.
+  // ringGauge accepts an id and owns its separate HTML and attribute sinks.
   ringGauge($('o-ring-cap'), capRatio, pctOf(capRatio, 0), capColor,
-    tRaw('dashboard.overview.ring.capacity_used'), `${fmt(rpmNow)} / ${fmt(capacity)} rpm · ${cfg.lanes} key${cfg.lanes === 1 ? '' : 's'}`);
+    'dashboard.overview.ring.capacity_used', `${fmt(rpmNow)} / ${fmt(capacity)} rpm · ${cfg.lanes} key${cfg.lanes === 1 ? '' : 's'}`);
   const errShare = wreq ? (wreq - wok) / wreq * 100 : 0;
   ringGauge($('o-ring-ok'), okRatio, wreq ? pctOf(okRatio, 0) : NO_VALUE, okColor,
-    tRaw('dashboard.common.kpi.success_rate'), `errors ${pctOf(errShare / 100, errShare && errShare < 10 ? 1 : 0)} · ${fmt(cooldown429)} cooldowns`);
+    'dashboard.common.kpi.success_rate', `errors ${pctOf(errShare / 100, errShare && errShare < 10 ? 1 : 0)} · ${fmt(cooldown429)} cooldowns`);
   $('o-health').innerHTML =
-    metricRow(t('dashboard.common.row.active_now'), fmt(sum(rows, 'nimproxy_active_requests'))) +
-    metricRow(t('dashboard.common.row.queued'), fmt(sum(rows, 'nimproxy_queue_depth'))) +
-    metricRow(t('dashboard.common.row.rate_limit_cooldowns'), fmt(cooldown429), cooldown429 > 0 ? 'warn' : 'zero') +
-    metricRow(t('dashboard.common.row.dropped'), fmt(shed), shed > 0 ? 'crit' : 'zero') +
-    metricRow(t('dashboard.common.row.unauthorized'), fmt(unauth), unauth > 0 ? 'crit' : 'zero') +
-    metricRow(t('dashboard.common.row.failed_logins'), fmt(logins), logins > 0 ? 'crit' : 'zero');
+    metricRow(catalogMessage('dashboard.common.row.active_now'), fmt(sum(rows, 'nimproxy_active_requests'))) +
+    metricRow(catalogMessage('dashboard.common.row.queued'), fmt(sum(rows, 'nimproxy_queue_depth'))) +
+    metricRow(catalogMessage('dashboard.common.row.rate_limit_cooldowns'), fmt(cooldown429), cooldown429 > 0 ? 'warn' : 'zero') +
+    metricRow(catalogMessage('dashboard.common.row.dropped'), fmt(shed), shed > 0 ? 'crit' : 'zero') +
+    metricRow(catalogMessage('dashboard.common.row.unauthorized'), fmt(unauth), unauth > 0 ? 'crit' : 'zero') +
+    metricRow(catalogMessage('dashboard.common.row.failed_logins'), fmt(logins), logins > 0 ? 'crit' : 'zero');
 
   const perfBlock = (label, note, p50, p95, fmtV) => {
     const scale = Math.max(isFinite(p50) ? p50 : 0, isFinite(p95) ? p95 : 0, 1e-9) * 1.25;
     const pos = v => Math.min(96, v / scale * 100).toFixed(1) + '%';
     return `<div><div style="display:flex;justify-content:space-between;align-items:baseline;margin-bottom:14px">` +
-      `<span style="font-size:12.5px;color:var(--ink-2)">${label}</span><span style="font:400 10px var(--mono);color:var(--ink-3)">${note}</span></div>` +
+      `<span style="font-size:12.5px;color:var(--ink-2)">${escapeHtml(label)}</span><span style="font:400 10px var(--mono);color:var(--ink-3)">${escapeHtml(note)}</span></div>` +
       `<div class="ptrack">${isFinite(p50) ? `<div class="p50" style="left:${pos(p50)}"></div>` : ''}${isFinite(p95) ? `<div class="p95" style="left:${pos(p95)}"></div>` : ''}</div>` +
       `<div class="pvals"><div><div class="l">p50</div><div class="v" style="color:var(--green-lt)">${fmtV(p50)}</div></div>` +
       `<div style="text-align:right"><div class="l">p95</div><div class="v" style="color:var(--ink-2)">${fmtV(p95)}</div></div></div></div>`;
@@ -1466,9 +1481,9 @@ function renderOverview(c) {
   const [s50, s95] = q('nimproxy_tokens_per_second', l => l.source === 'usage');
   const [i50, i95] = q('nimproxy_tpot_seconds');
   $('o-perf').innerHTML =
-    perfBlock(t('dashboard.models.ttft.heading'), t('dashboard.overview.perf.lower_is_better'), t50, t95, secs) +
-    perfBlock(t('dashboard.models.genspeed.heading'), t('dashboard.overview.perf.higher_is_better'), s50, s95, v => isFinite(v) ? fmt(v) + ' tok/s' : '–') +
-    perfBlock(t('dashboard.models.itl.heading'), t('dashboard.overview.perf.lower_is_better'), i50, i95, secs);
+    perfBlock(catalogMessage('dashboard.models.ttft.heading'), catalogMessage('dashboard.overview.perf.lower_is_better'), t50, t95, secs) +
+    perfBlock(catalogMessage('dashboard.models.genspeed.heading'), catalogMessage('dashboard.overview.perf.higher_is_better'), s50, s95, v => isFinite(v) ? fmt(v) + ' tok/s' : '–') +
+    perfBlock(catalogMessage('dashboard.models.itl.heading'), catalogMessage('dashboard.overview.perf.lower_is_better'), i50, i95, secs);
 
   leaderList($('o-topmodels'), models.slice(0, 5).map(m => {
     const pub = publisher(m);
@@ -1487,16 +1502,16 @@ function renderModels(c) {
   const chatReqs = [...reqModels.values()].reduce((a, b) => a + b, 0);
   const qmed = (metric, f) => { const v = quantile(wbuckets(metric, f), 0.5); return isFinite(v) ? v : NaN; };
   kpiCards($('m-kpis'), [
-    { icon: 'pulse', label: t('dashboard.common.col.requests'), value: fmt(chatReqs), sub: `${models.length} model${models.length === 1 ? '' : 's'}`,
+    { icon: 'pulse', label: catalogMessage('dashboard.common.col.requests'), value: fmt(chatReqs), sub: `${models.length} model${models.length === 1 ? '' : 's'}`,
       pts: rateSeries(s => sum(s.rows, 'nimproxy_requests_total', l => l.path === '/v1/chat/completions')) },
-    { icon: 'stack', label: t('dashboard.models.kpi.completion_tokens'), value: fmt(allC), sub: windowLabel,
+    { icon: 'stack', label: catalogMessage('dashboard.models.kpi.completion_tokens'), value: fmt(allC), sub: windowLabel,
       pts: rateSeries(s => sum(s.rows, 'nimproxy_completion_tokens_total')) },
-    { icon: 'grid', label: t('dashboard.models.kpi.prompt_tokens'), value: fmt(allP), sub: windowLabel,
+    { icon: 'grid', label: catalogMessage('dashboard.models.kpi.prompt_tokens'), value: fmt(allP), sub: windowLabel,
       pts: rateSeries(s => sum(s.rows, 'nimproxy_prompt_tokens_total')) },
-    { icon: 'clock', label: t('dashboard.models.col.avg_ttft'), value: ttftN ? secs(ttftS / ttftN) : '–',
+    { icon: 'clock', label: catalogMessage('dashboard.models.col.avg_ttft'), value: ttftN ? secs(ttftS / ttftN) : '–',
       sub: `median ${secs(qmed('nimproxy_ttft_seconds'))}`,
       pts: avgSeries('nimproxy_ttft_seconds_sum', 'nimproxy_ttft_seconds_count') },
-    { icon: 'bolt', label: t('dashboard.models.kpi.avg_speed'), value: tpsN ? fmt(tpsS / tpsN) + ' tok/s' : '–',
+    { icon: 'bolt', label: catalogMessage('dashboard.models.kpi.avg_speed'), value: tpsN ? fmt(tpsS / tpsN) + ' tok/s' : '–',
       sub: `median ${isFinite(qmed('nimproxy_tokens_per_second', l => l.source === 'usage')) ? fmt(qmed('nimproxy_tokens_per_second', l => l.source === 'usage')) + ' tok/s' : '–'}`,
       pts: avgSeries('nimproxy_tokens_per_second_sum', 'nimproxy_tokens_per_second_count') },
   ]);
@@ -1525,28 +1540,28 @@ function renderModels(c) {
 
   /* how responses end */
   // enum key (persisted, never translated) · label · severity class
-  const FINISH = [['stop', t('dashboard.models.finish.completed'), ''],
-    ['length', t('dashboard.models.col.truncated'), 'critc'],
-    ['tool_calls', t('dashboard.models.finish.tool_call'), ''],
-    ['content_filter', t('dashboard.models.finish.filtered'), 'warnc'],
-    ['other', t('dashboard.models.finish.other'), '']];
+  const FINISH = [['stop', catalogMessage('dashboard.models.finish.completed'), ''],
+    ['length', catalogMessage('dashboard.models.col.truncated'), 'critc'],
+    ['tool_calls', catalogMessage('dashboard.models.finish.tool_call'), ''],
+    ['content_filter', catalogMessage('dashboard.models.finish.filtered'), 'warnc'],
+    ['other', catalogMessage('dashboard.models.finish.other'), '']];
   const finByReason = Object.fromEntries(FINISH.map(([r]) => [r, wgroups('nimproxy_finish_reason_total', 'model', l => l.reason === r)]));
   const finModels = models.filter(m => finTotal.get(m));
   $('m-fincount').textContent = finModels.length ? `${finModels.length} model${finModels.length === 1 ? '' : 's'}` : '';
   sortTable($('table-finish'), 'finish',
-    [{ label: t('dashboard.common.col.model'), align: 'l', str: true }, ...FINISH.map(([, l]) => ({ label: l }))],
+    [{ label: catalogMessage('dashboard.common.col.model'), align: 'l', str: true }, ...FINISH.map(([, l]) => ({ label: l }))],
     finModels.map(m => {
       const tot = finTotal.get(m) || 1;
       const shares = FINISH.map(([r]) => (finByReason[r].get(m) || 0) / tot * 100);
       return {
         vals: [prettyName(m), ...shares],
-        cells: [`<i class="sw" style="background:${publisher(m).color}"></i>${esc(prettyName(m))}`,
+        cells: [`<i class="sw" style="background:${publisher(m).color}"></i>${escapeHtml(prettyName(m))}`,
           ...shares.map((v, i) => `<span class="${v >= 0.5 ? FINISH[i][2] : 'dim'}">${pct(v)}</span>`)],
       };
-    }), { defaultIdx: 1, maxH: 300, minW: 460, empty: t('dashboard.common.empty.no_completed_requests') });
+    }), { defaultIdx: 1, maxH: 300, minW: 460, empty: catalogMessage('dashboard.common.empty.no_completed_requests') });
 
   const reasoningModels = models.filter(m => (reasoningByModel.get(m) || 0) > 0);
-  if (!reasoningModels.length) $('meters-reasoning').innerHTML = `<div class="empty">${t('dashboard.models.empty.no_reasoning')}</div>`;
+  if (!reasoningModels.length) $('meters-reasoning').innerHTML = `<div class="empty">${escapeHtml(catalogMessage('dashboard.models.empty.no_reasoning'))}</div>`;
   else barList($('meters-reasoning'),
     reasoningModels.map(m => ({ name: prettyName(m), v: reasonPct(m), color: publisher(m).color })), pct);
 
@@ -1568,13 +1583,13 @@ function renderModels(c) {
   const avgReply = m => okByModel.get(m) ? (ctok.get(m) || 0) / okByModel.get(m) : NaN;
   const cmp = models.slice(0, 8);
   sortTable($('compare-scorecard'), 'scorecard', [
-    { label: t('dashboard.common.col.model'), align: 'l', str: true },
-    { label: t('dashboard.common.col.requests'), best: 'max' }, { label: 'TTFT', best: 'min' }, { label: 'tok/s', best: 'max' },
-    { label: 'TPOT', best: 'min' }, { label: t('dashboard.models.col.avg_response'), best: 'max' }, { label: t('dashboard.models.col.truncated'), best: 'min' },
-    { label: t('dashboard.models.col.reasoning'), best: 'min' }, { label: t('dashboard.models.col.errors'), best: 'min' },
+    { label: catalogMessage('dashboard.common.col.model'), align: 'l', str: true },
+    { label: catalogMessage('dashboard.common.col.requests'), best: 'max' }, { label: 'TTFT', best: 'min' }, { label: 'tok/s', best: 'max' },
+    { label: 'TPOT', best: 'min' }, { label: catalogMessage('dashboard.models.col.avg_response'), best: 'max' }, { label: catalogMessage('dashboard.models.col.truncated'), best: 'min' },
+    { label: catalogMessage('dashboard.models.col.reasoning'), best: 'min' }, { label: catalogMessage('dashboard.models.col.errors'), best: 'min' },
   ], cmp.map(m => ({
     vals: [prettyName(m), reqModels.get(m) || 0, avgTtft(m), avgTps(m), tpotAvg(m), avgReply(m), truncPct(m), reasonPct(m), errRate(m)],
-    cells: [`<i class="sw" style="background:${publisher(m).color}"></i>${esc(prettyName(m))}`,
+    cells: [`<i class="sw" style="background:${publisher(m).color}"></i>${escapeHtml(prettyName(m))}`,
       fmt(reqModels.get(m) || 0), isFinite(avgTtft(m)) ? secs(avgTtft(m)) : '–', isFinite(avgTps(m)) ? fmt(avgTps(m)) : '–',
       isFinite(tpotAvg(m)) ? secs(tpotAvg(m)) : '–', isFinite(avgReply(m)) ? fmt(avgReply(m)) + ' tok' : '–',
       pct(truncPct(m)), pct(reasonPct(m)), pct(errRate(m))],
@@ -1583,39 +1598,42 @@ function renderModels(c) {
     v => fmt(v) + ' tok/s');
 
   /* leading model cards (top 4; the rest live in the table) */
-  // tRaw: textContent does not parse entities, so an escaped value would show
-  // its entities literally.
-  $('m-cardnote').textContent = models.length ? tRaw('dashboard.models.cards.note') : '';
+  if (models.length) setMessageText($('m-cardnote'), 'dashboard.models.cards.note');
+  else $('m-cardnote').textContent = '';
   $('modelcards').innerHTML = models.slice(0, 4).map((m, i) => {
     const pub = publisher(m), ct = ctok.get(m) || 0, e = errRate(m);
-    const stat = (l, v, cls) => `<div class="stat"><div class="l">${l}</div><div class="v${cls ? ' ' + cls : ''}">${v}</div></div>`;
+    const stat = (l, v, cls) => `<div class="stat"><div class="l">${escapeHtml(l)}</div><div class="v${cls ? ' ' + cls : ''}">${escapeHtml(v)}</div></div>`;
     return `<div class="mcard"><span class="rank">#${i + 1}</span>
       <div class="mbrand">${chipHtml(pub)}
-        <div><div class="mname" title="${esc(m)}">${esc(prettyName(m))}</div><div class="mpub">${esc(pub.name)}</div></div>
+        <div><div class="mname" title="${escapeHtml(m)}">${escapeHtml(prettyName(m))}</div><div class="mpub">${escapeHtml(pub.name)}</div></div>
       </div>
       <div class="mstats">
         ${stat('requests', fmt(reqModels.get(m) || 0))}
-        ${stat(t('dashboard.common.note.tokens_out'), fmt(ct))}
+        ${stat(catalogMessage('dashboard.common.note.tokens_out'), fmt(ct))}
         ${stat('TTFT', ttftMC.get(m) ? secs(avgTtft(m)) : '–')}
         ${stat('tok/s', tpsMC.get(m) ? fmt(avgTps(m)) : '–')}
         ${stat('errors', errPct(m), isFinite(e) && e > 0 ? 'critc' : 'dim')}
       </div></div>`;
-  }).join('') || `<div class="empty">${t('dashboard.common.empty.no_traffic')}</div>`;
+  }).join('') || `<div class="empty">${escapeHtml(catalogMessage('dashboard.common.empty.no_traffic'))}</div>`;
 
   /* per-model table */
-  // tRaw, not t: this lands in textContent, which does not parse entities, so
-  // an escaped value renders its entities literally.
-  $('m-tablecount').textContent = models.length ? `${models.length} model${models.length === 1 ? '' : 's'} · ${tRaw('dashboard.common.sort_hint')}` : '';
+  const modelCount = $('m-tablecount');
+  if (models.length) {
+    setMessageText(modelCount, 'dashboard.common.sort_hint');
+    modelCount.prepend(`${models.length} model${models.length === 1 ? '' : 's'} · `);
+  } else {
+    modelCount.replaceChildren();
+  }
   sortTable($('table-models'), 'models', [
-    { label: t('dashboard.common.col.model'), align: 'l', str: true }, { label: t('dashboard.common.col.requests') }, { label: t('dashboard.common.col.tokens_out') },
-    { label: t('dashboard.models.col.avg_ttft') }, { label: t('dashboard.models.col.avg_tps') }, { label: 'TPOT' }, { label: t('dashboard.models.col.avg_response') },
-    { label: t('dashboard.models.col.truncated') }, { label: t('dashboard.models.col.reasoning') }, { label: t('dashboard.models.col.errors') },
+    { label: catalogMessage('dashboard.common.col.model'), align: 'l', str: true }, { label: catalogMessage('dashboard.common.col.requests') }, { label: catalogMessage('dashboard.common.col.tokens_out') },
+    { label: catalogMessage('dashboard.models.col.avg_ttft') }, { label: catalogMessage('dashboard.models.col.avg_tps') }, { label: 'TPOT' }, { label: catalogMessage('dashboard.models.col.avg_response') },
+    { label: catalogMessage('dashboard.models.col.truncated') }, { label: catalogMessage('dashboard.models.col.reasoning') }, { label: catalogMessage('dashboard.models.col.errors') },
   ], models.map(m => {
     const ct = ctok.get(m) || 0, ok = okByModel.get(m) || 0, e = errRate(m);
     return {
       vals: [m, reqModels.get(m) || 0, ct, avgTtft(m), avgTps(m), tpotAvg(m), ok ? ct / ok : NaN,
         truncPct(m), reasonPct(m), e],
-      cells: [`<i class="sw" style="background:${publisher(m).color}"></i>${esc(m)}`,
+      cells: [`<i class="sw" style="background:${publisher(m).color}"></i>${escapeHtml(m)}`,
         fmt(reqModels.get(m) || 0), fmt(ct),
         ttftMC.get(m) ? secs(avgTtft(m)) : '–', tpsMC.get(m) ? fmt(avgTps(m)) : '–',
         isFinite(tpotAvg(m)) ? secs(tpotAvg(m)) : '–', ok ? fmt(ct / ok) + ' tok' : '–',
@@ -1640,13 +1658,13 @@ function renderClients(c) {
   const streamPct = cl => genReq(cl) ? (streamT.get(cl) || 0) / genReq(cl) * 100 : NaN;
   const oTools = wsum('nimproxy_request_tools_sum'), oToolsN = wsum('nimproxy_request_tools_count');
   const oMsgs = wsum('nimproxy_request_messages_sum'), oMsgsN = wsum('nimproxy_request_messages_count');
-  const tile = (label, v, unit) => `<div class="tile"><div class="tlabel">${label}</div><div class="tval">${v}${unit ? `<span class="unit">${unit}</span>` : ''}</div></div>`;
+  const tile = (label, v, unit) => `<div class="tile"><div class="tlabel">${escapeHtml(label)}</div><div class="tval">${escapeHtml(v)}${unit ? `<span class="unit">${escapeHtml(unit)}</span>` : ''}</div></div>`;
   $('h-kpis').innerHTML =
-    tile(t('dashboard.clients.tile.clients'), clients.length) +
-    tile(t('dashboard.clients.tile.streaming_share'), totGen ? pctOf(totStreamT / totGen, 0) : NO_VALUE) +
-    tile(t('dashboard.clients.tile.avg_tools'), oToolsN ? fmt(oTools / oToolsN) : '–') +
-    tile(t('dashboard.clients.tile.avg_messages'), oMsgsN ? fmt(oMsgs / oMsgsN) : '–') +
-    tile(t('dashboard.clients.tile.requests_using_tools'), totGen ? pctOf(totToolReq / totGen, 0) : NO_VALUE);
+    tile(catalogMessage('dashboard.clients.tile.clients'), clients.length) +
+    tile(catalogMessage('dashboard.clients.tile.streaming_share'), totGen ? pctOf(totStreamT / totGen, 0) : NO_VALUE) +
+    tile(catalogMessage('dashboard.clients.tile.avg_tools'), oToolsN ? fmt(oTools / oToolsN) : '–') +
+    tile(catalogMessage('dashboard.clients.tile.avg_messages'), oMsgsN ? fmt(oMsgs / oMsgsN) : '–') +
+    tile(catalogMessage('dashboard.clients.tile.requests_using_tools'), totGen ? pctOf(totToolReq / totGen, 0) : NO_VALUE);
   barList($('h-toolint'), clients.map(cl => ({ name: cl, v: toolsAvg(cl), color: clientColor(cl) })), fmt);
   barList($('h-depth'), clients.map(cl => ({ name: cl, v: msgsAvg(cl), color: clientColor(cl) })), fmt);
   barList($('h-temp'), clients.map(cl => ({ name: cl, v: tempAvg(cl), color: clientColor(cl) })), v => NUM_2DP.format(v));
@@ -1660,11 +1678,11 @@ function renderClients(c) {
   if (maxTokClients.length)
     barList($('h-maxtok'), maxTokClients.map(cl => ({ name: cl, v: maxTokAvg(cl), color: clientColor(cl) })), fmt);
   sortTable($('table-harness'), 'harness', [
-    { label: t('dashboard.common.col.client'), align: 'l', str: true }, { label: t('dashboard.common.col.requests') }, { label: t('dashboard.common.col.tokens_out') },
-    { label: 'Tools/req' }, { label: 'Msgs/req' }, { label: t('dashboard.common.col.streaming') },
+    { label: catalogMessage('dashboard.common.col.client'), align: 'l', str: true }, { label: catalogMessage('dashboard.common.col.requests') }, { label: catalogMessage('dashboard.common.col.tokens_out') },
+    { label: 'Tools/req' }, { label: 'Msgs/req' }, { label: catalogMessage('dashboard.common.col.streaming') },
   ], clients.map(cl => ({
     vals: [cl, cReq.get(cl) || 0, cC.get(cl) || 0, toolsAvg(cl), msgsAvg(cl), streamPct(cl)],
-    cells: [`<i class="sw" style="background:${clientColor(cl)}"></i>${esc(cl)}`,
+    cells: [`<i class="sw" style="background:${clientColor(cl)}"></i>${escapeHtml(cl)}`,
       fmt(cReq.get(cl) || 0), fmt(cC.get(cl) || 0),
       isFinite(toolsAvg(cl)) ? fmt(toolsAvg(cl)) : '–', isFinite(msgsAvg(cl)) ? fmt(msgsAvg(cl)) : '–',
       isFinite(streamPct(cl)) ? Math.round(streamPct(cl)) + '%' : '–'],
@@ -1695,52 +1713,51 @@ function renderReliability(c) {
      translator nothing to move. 'SLO' is frozen. */
   const sloLine = (target, hasTraffic, isMet) => {
     const p = { target: (target * 100).toFixed(1) + '%' };
-    if (!hasTraffic) return t('dashboard.reliability.slo.no_traffic', p);
-    return isMet ? t('dashboard.reliability.slo.met', p)
-                 : t('dashboard.reliability.slo.missed', p);
+    if (!hasTraffic) return catalogMessage('dashboard.reliability.slo.no_traffic', p);
+    return isMet ? catalogMessage('dashboard.reliability.slo.met', p)
+                 : catalogMessage('dashboard.reliability.slo.missed', p);
   };
   const budget = !isFinite(availability) ? 0
     : slo >= 1 ? (availability >= 1 ? 0 : 100)
     : Math.min(100, (1 - availability) / (1 - slo) * 100);
   $('r-avail').innerHTML =
-    `<div class="hlabel">${t('dashboard.reliability.hero.availability')} <span class="note">${windowLabel}</span></div>
+    `<div class="hlabel">${escapeHtml(catalogMessage('dashboard.reliability.hero.availability'))} <span class="note">${escapeHtml(windowLabel)}</span></div>
     <div class="hbig" style="color:${met ? 'var(--green-lt)' : 'var(--red)'};margin-top:8px">${availTxt}</div>
-    <div style="font:400 11px var(--mono);color:var(--ink-3);margin-top:2px">${sloLine(slo, eligible, met)}</div>
-    <div style="display:flex;justify-content:space-between;font-size:11.5px;color:var(--ink-25);margin:16px 0 6px">${t('dashboard.reliability.hero.error_budget')}<span style="font:500 11px var(--mono);color:var(--ink-2)">${t('dashboard.reliability.hero.budget_used', { pct: budget.toFixed(0) + '%' })}</span></div>
+    <div style="font:400 11px var(--mono);color:var(--ink-3);margin-top:2px">${escapeHtml(sloLine(slo, eligible, met))}</div>
+    <div style="display:flex;justify-content:space-between;font-size:11.5px;color:var(--ink-25);margin:16px 0 6px">${escapeHtml(catalogMessage('dashboard.reliability.hero.error_budget'))}<span style="font:500 11px var(--mono);color:var(--ink-2)">${escapeHtml(catalogMessage('dashboard.reliability.hero.budget_used', { pct: budget.toFixed(0) + '%' }))}</span></div>
     <div class="htrack"><span style="width:${budget.toFixed(0)}%;background:${budget >= 100 ? 'var(--red)' : 'var(--amber)'}"></span></div>`;
 
   /* hero: where time goes (median-ish composition from windowed averages) */
   const qw = qwN ? qwS / qwN : 0, ttft = ttftN ? ttftS / ttftN : NaN, up = upN ? upS / upN : NaN;
   if (!upN) {
-    $('r-time').innerHTML = `<div class="hlabel">${t('dashboard.reliability.latency.title')} <span class="note">${t('dashboard.reliability.latency.note')}</span></div><div class="empty">${t('dashboard.common.empty.no_completed_requests')}</div>`;
+    $('r-time').innerHTML = `<div class="hlabel">${escapeHtml(catalogMessage('dashboard.reliability.latency.title'))} <span class="note">${escapeHtml(catalogMessage('dashboard.reliability.latency.note'))}</span></div><div class="empty">${escapeHtml(catalogMessage('dashboard.common.empty.no_completed_requests'))}</div>`;
   } else {
     const gen = Math.max(0, up - (isFinite(ttft) ? ttft : 0));
     const segs = [
-      { label: t('dashboard.reliability.col.queue_wait'), v: qw, color: 'var(--amber)' },
-      { label: t('dashboard.reliability.col.first_token'), v: isFinite(ttft) ? ttft : 0, color: 'var(--blue)' },
-      { label: t('dashboard.reliability.col.generation'), v: gen, color: 'var(--green)' },
+      { label: catalogMessage('dashboard.reliability.col.queue_wait'), v: qw, color: 'var(--amber)' },
+      { label: catalogMessage('dashboard.reliability.col.first_token'), v: isFinite(ttft) ? ttft : 0, color: 'var(--blue)' },
+      { label: catalogMessage('dashboard.reliability.col.generation'), v: gen, color: 'var(--green)' },
     ].filter(s => s.v > 0);
     const tot = segs.reduce((a, s) => a + s.v, 0) || 1;
     $('r-time').innerHTML =
-      `<div style="display:flex;align-items:baseline;gap:10px"><span class="hlabel">${t('dashboard.reliability.latency.title')}</span>
-      <span class="note" style="font:400 10px var(--mono);color:var(--ink-3)">${t('dashboard.reliability.latency.note')}</span>
+      `<div style="display:flex;align-items:baseline;gap:10px"><span class="hlabel">${escapeHtml(catalogMessage('dashboard.reliability.latency.title'))}</span>
+      <span class="note" style="font:400 10px var(--mono);color:var(--ink-3)">${escapeHtml(catalogMessage('dashboard.reliability.latency.note'))}</span>
       <span style="margin-left:auto;font-size:22px;font-weight:600;letter-spacing:-0.5px">${secs(tot)}</span></div>
       <div class="segbar" style="height:16px;margin:16px 0 12px">${segs.map(s => `<div style="width:${(s.v / tot * 100).toFixed(1)}%;background:${s.color}"></div>`).join('')}</div>
-      <div class="seglegend">${segs.map(s => `<div class="sl"><span class="sw" style="background:${s.color}"></span><div><div class="sll">${s.label}</div><div class="slv">${secs(s.v)}</div></div></div>`).join('')}</div>`;
+      <div class="seglegend">${segs.map(s => `<div class="sl"><span class="sw" style="background:${s.color}"></span><div><div class="sll">${escapeHtml(s.label)}</div><div class="slv">${secs(s.v)}</div></div></div>`).join('')}</div>`;
   }
 
   /* hero: live load + error taxonomy */
   const act = sum(rows, 'nimproxy_active_requests'), que = sum(rows, 'nimproxy_queue_depth');
   const errN = Math.max(0, wreq - wok);
-  // tRaw: these labels land in a title= attribute built with esc() below, so
-  // the escaping happens at that call site and must not happen twice.
+  // These labels remain plain until the title= HTML sink escapes them below.
   const TAX = [
-    [tRaw('dashboard.common.status.rate_limited'), s => s === '429', 'var(--amber)'],
-    [tRaw('dashboard.common.status.disconnect'), s => s === 'disconnect', 'var(--blue)'],
-    [tRaw('dashboard.common.status.timeout_stall'), s => s === '504' || s === 'stall', 'var(--red)'],
-    [tRaw('dashboard.common.status.client_error_4xx'), s => /^4\d\d$/.test(s) && s !== '429', 'var(--violet, #8B7BB8)'],
+    [catalogMessage('dashboard.common.status.rate_limited'), s => s === '429', 'var(--amber)'],
+    [catalogMessage('dashboard.common.status.disconnect'), s => s === 'disconnect', 'var(--blue)'],
+    [catalogMessage('dashboard.common.status.timeout_stall'), s => s === '504' || s === 'stall', 'var(--red)'],
+    [catalogMessage('dashboard.common.status.client_error_4xx'), s => /^4\d\d$/.test(s) && s !== '429', 'var(--violet, #8B7BB8)'],
     ['5xx', s => /^5\d\d$/.test(s) && s !== '504', '#C15F3C'],
-    [tRaw('dashboard.models.finish.other'), () => true, 'var(--ink-3)'],
+    [catalogMessage('dashboard.models.finish.other'), () => true, 'var(--ink-3)'],
   ];
   const taxCounts = []; let seen = new Set([...statusG.keys()].filter(IS_2XX));
   for (const [label, match, color] of TAX) {
@@ -1751,12 +1768,12 @@ function renderReliability(c) {
   const taxTot = taxCounts.reduce((a, x) => a + x.n, 0) || 1;
   $('r-load').innerHTML =
     `<div style="display:flex;gap:20px">
-      <div><div class="tlabel">${t('dashboard.common.row.active_now')}</div><div style="font-size:26px;font-weight:600;color:var(--green)">${fmt(act)}</div></div>
-      <div><div class="tlabel">${t('dashboard.common.row.queued')}</div><div style="font-size:26px;font-weight:600;color:var(--amber)">${fmt(que)}</div></div>
+      <div><div class="tlabel">${escapeHtml(catalogMessage('dashboard.common.row.active_now'))}</div><div style="font-size:26px;font-weight:600;color:var(--green)">${fmt(act)}</div></div>
+      <div><div class="tlabel">${escapeHtml(catalogMessage('dashboard.common.row.queued'))}</div><div style="font-size:26px;font-weight:600;color:var(--amber)">${fmt(que)}</div></div>
     </div>
     <div class="segbar" style="height:8px;border-radius:99px;margin:12px 0">${act + que ? `<div style="width:${(act / (act + que) * 100)}%;background:var(--green)"></div><div style="width:${(que / (act + que) * 100)}%;background:var(--amber)"></div>` : '<div style="width:100%;background:var(--track)"></div>'}</div>
-    <div style="display:flex;justify-content:space-between;align-items:center;margin-top:14px;padding-top:12px;border-top:1px solid var(--hairline)"><span class="tlabel">${t('dashboard.common.row.error_rate')}</span><span style="font:600 15px var(--mono);color:${errN ? 'var(--red)' : 'var(--ink-3)'}">${wreq ? pctOf(errN / wreq, 1) : NO_VALUE}</span></div>
-    <div class="segbar" style="height:6px;border-radius:99px;margin-top:8px;gap:1px">${taxCounts.length ? taxCounts.map(x => `<div style="width:${(x.n / taxTot * 100).toFixed(1)}%;background:${x.color}" title="${esc(x.label)}: ${fmt(x.n)}"></div>`).join('') : '<div style="width:100%;background:var(--track)"></div>'}</div>`;
+    <div style="display:flex;justify-content:space-between;align-items:center;margin-top:14px;padding-top:12px;border-top:1px solid var(--hairline)"><span class="tlabel">${escapeHtml(catalogMessage('dashboard.common.row.error_rate'))}</span><span style="font:600 15px var(--mono);color:${errN ? 'var(--red)' : 'var(--ink-3)'}">${wreq ? pctOf(errN / wreq, 1) : NO_VALUE}</span></div>
+    <div class="segbar" style="height:6px;border-radius:99px;margin-top:8px;gap:1px">${taxCounts.length ? taxCounts.map(x => `<div style="width:${(x.n / taxTot * 100).toFixed(1)}%;background:${x.color}" title="${escapeHtml(x.label)}: ${fmt(x.n)}"></div>`).join('') : '<div style="width:100%;background:var(--track)"></div>'}</div>`;
 
   lineChart($('chart-reqrate'), [{ name: 'requests/min', color: MED, pts: reqPts, area: true }], fmt, { height: 150 });
   const outcomeSeries = [
@@ -1769,16 +1786,15 @@ function renderReliability(c) {
   /* stacked composition over time — the same taxonomy groups as the hero
      error breakdown above (success prepended), first match wins so each
      status lands in exactly one band. */
-  // tRaw for the same reason as TAX: these become series names, and both
-  // stackChart's hover tooltip and legend() run them through esc().
+  // These become series names; stackChart and legend escape them at HTML sinks.
   const OUTCOMES = [
-    [tRaw('dashboard.common.status.success'), css('--green'), IS_2XX],
-    [tRaw('dashboard.common.status.rate_limited'), css('--amber'), s => s === '429'],
-    [tRaw('dashboard.common.status.disconnect'), css('--blue'), s => s === 'disconnect'],
-    [tRaw('dashboard.common.status.timeout_stall'), css('--red'), s => s === '504' || s === 'stall'],
-    [tRaw('dashboard.common.status.client_error_4xx'), 'var(--violet, #8B7BB8)', s => /^4\d\d$/.test(s) && s !== '429'],
+    [catalogMessage('dashboard.common.status.success'), css('--green'), IS_2XX],
+    [catalogMessage('dashboard.common.status.rate_limited'), css('--amber'), s => s === '429'],
+    [catalogMessage('dashboard.common.status.disconnect'), css('--blue'), s => s === 'disconnect'],
+    [catalogMessage('dashboard.common.status.timeout_stall'), css('--red'), s => s === '504' || s === 'stall'],
+    [catalogMessage('dashboard.common.status.client_error_4xx'), 'var(--violet, #8B7BB8)', s => /^4\d\d$/.test(s) && s !== '429'],
     ['5xx', '#C15F3C', s => /^5\d\d$/.test(s) && s !== '504'],
-    [tRaw('dashboard.models.finish.other'), css('--ink-3'), () => true],
+    [catalogMessage('dashboard.models.finish.other'), css('--ink-3'), () => true],
   ];
   const outcomeIdx = s => OUTCOMES.findIndex(([, , m]) => m(s));
   const stackSeries = OUTCOMES
@@ -1816,8 +1832,8 @@ function renderReliability(c) {
   const pcard = $('card-pressure');
   pcard.hidden = !(exhausted > 0 || govLimits.length);
   if (!pcard.hidden) {
-    // tRaw: lineChart's hover tooltip escapes s.name itself.
-    lineChart($('chart-exhaust'), [{ name: tRaw('dashboard.reliability.pressure.series'), color: css('--amber'),
+    // lineChart's hover tooltip escapes the plain series name itself.
+    lineChart($('chart-exhaust'), [{ name: catalogMessage('dashboard.reliability.pressure.series'), color: css('--amber'),
       pts: rateSeries(s => sum(s.rows, 'nimproxy_worker_exhausted_total')), area: 'url(#gMuted)' }], fmt, { height: 130 });
     const inflight = groups(rows, 'nimproxy_model_inflight', 'model');
     barList($('pressure-bars'), govLimits.map(([m, cap]) => ({
@@ -1827,56 +1843,56 @@ function renderReliability(c) {
   }
 
   /* non-success outcomes ranked by count */
-  // tRaw throughout: reason() feeds both a sort key and a cell built with
-  // esc() below, so these must stay plain. Ids are spelled out rather than
+  // reason() feeds the escaped display cell; the stable status remains the
+  // sort key. Ids are spelled out rather than
   // built from the status, which would hide them from the untagged-string lint.
   const REASONS = {
-    'disconnect': tRaw('dashboard.common.status.client_disconnected'),
-    'stall': tRaw('dashboard.common.status.stream_stalled'),
-    'stream_error': tRaw('dashboard.common.status.stream_error'),
-    '504': tRaw('dashboard.common.status.upstream_timeout_504'),
-    '429': tRaw('dashboard.common.status.rate_limited_429'),
-    '400': tRaw('dashboard.common.status.bad_request_400'),
-    '401': tRaw('dashboard.common.status.unauthorized_401'),
-    '403': tRaw('dashboard.common.status.forbidden_403'),
-    '404': tRaw('dashboard.common.status.not_found_404'),
-    '502': tRaw('dashboard.common.status.bad_gateway_502'),
-    '503': tRaw('dashboard.common.status.unavailable_503'),
+    'disconnect': catalogMessage('dashboard.common.status.client_disconnected'),
+    'stall': catalogMessage('dashboard.common.status.stream_stalled'),
+    'stream_error': catalogMessage('dashboard.common.status.stream_error'),
+    '504': catalogMessage('dashboard.common.status.upstream_timeout_504'),
+    '429': catalogMessage('dashboard.common.status.rate_limited_429'),
+    '400': catalogMessage('dashboard.common.status.bad_request_400'),
+    '401': catalogMessage('dashboard.common.status.unauthorized_401'),
+    '403': catalogMessage('dashboard.common.status.forbidden_403'),
+    '404': catalogMessage('dashboard.common.status.not_found_404'),
+    '502': catalogMessage('dashboard.common.status.bad_gateway_502'),
+    '503': catalogMessage('dashboard.common.status.unavailable_503'),
   };
   const reason = s => REASONS[s] || (/^\d+$/.test(s) ? `HTTP ${s}` : s);
   const totReq = [...statusG.values()].reduce((a, b) => a + b, 0) || 1;
   const bad = [...statusG.entries()].filter(([s]) => !IS_2XX(s));
   sortTable($('table-outcomes'), 'outcomes',
-    [{ label: t('dashboard.common.col.reason'), align: 'l', str: true }, { label: t('dashboard.common.col.count') }, { label: t('dashboard.common.col.share') }],
+    [{ label: catalogMessage('dashboard.common.col.reason'), align: 'l', str: true }, { label: catalogMessage('dashboard.common.col.count') }, { label: catalogMessage('dashboard.common.col.share') }],
     bad.map(([s, n]) => ({
-      vals: [reason(s), n, n / totReq * 100],
-      cells: [esc(reason(s)), fmt(n), pctOf(n / totReq, 1)],
-    })), { defaultIdx: 1, maxH: 240, empty: t('dashboard.reliability.empty.no_errors') });
+      vals: [s, n, n / totReq * 100],
+      cells: [escapeHtml(reason(s)), fmt(n), pctOf(n / totReq, 1)],
+    })), { defaultIdx: 1, maxH: 240, empty: catalogMessage('dashboard.reliability.empty.no_errors') });
 
   $('table-reliability').innerHTML =
-    metricRow(t('dashboard.common.row.active_now'), fmt(act)) +
-    metricRow(t('dashboard.common.row.queued'), fmt(que)) +
-    metricRow(t('dashboard.reliability.row.dropped_503'), fmt(shed), shed > 0 ? 'crit' : 'zero') +
-    metricRow(t('dashboard.common.row.rate_limit_cooldowns'), fmt(cooldown429), cooldown429 > 0 ? 'warn' : 'zero') +
-    metricRow(t('dashboard.common.status.upstream_error_cooldowns'), fmt(cooldownOther), cooldownOther > 0 ? 'warn' : 'zero') +
-    metricRow(t('dashboard.common.status.unauthorized_401'), fmt(unauth), unauth > 0 ? 'crit' : 'zero') +
-    metricRow(t('dashboard.common.row.failed_logins'), fmt(logins), logins > 0 ? 'crit' : 'zero');
+    metricRow(catalogMessage('dashboard.common.row.active_now'), fmt(act)) +
+    metricRow(catalogMessage('dashboard.common.row.queued'), fmt(que)) +
+    metricRow(catalogMessage('dashboard.reliability.row.dropped_503'), fmt(shed), shed > 0 ? 'crit' : 'zero') +
+    metricRow(catalogMessage('dashboard.common.row.rate_limit_cooldowns'), fmt(cooldown429), cooldown429 > 0 ? 'warn' : 'zero') +
+    metricRow(catalogMessage('dashboard.common.status.upstream_error_cooldowns'), fmt(cooldownOther), cooldownOther > 0 ? 'warn' : 'zero') +
+    metricRow(catalogMessage('dashboard.common.status.unauthorized_401'), fmt(unauth), unauth > 0 ? 'crit' : 'zero') +
+    metricRow(catalogMessage('dashboard.common.row.failed_logins'), fmt(logins), logins > 0 ? 'crit' : 'zero');
   const jsonMode = windowed(s => sum(s.rows, 'nimproxy_json_mode_total'));
   const tcModes = wgroups('nimproxy_tool_choice_total', 'mode');
-  const tcStr = [...tcModes.entries()].sort((a, b) => b[1] - a[1]).map(([m, n]) => `${esc(m)} ${fmt(n)}`).join(', ') || '–';
+  const tcStr = [...tcModes.entries()].sort((a, b) => b[1] - a[1]).map(([m, n]) => `${m} ${fmt(n)}`).join(', ') || '–';
   $('table-reqtypes').innerHTML =
-    metricRow(t('dashboard.common.row.streaming'), `${fmt(totStreamT)}${totGen ? ` (${Math.round(totStreamT / totGen * 100)}%)` : ''}`) +
-    metricRow(t('dashboard.reliability.row.buffered'), `${fmt(totStreamF)}${totGen ? ` (${Math.round(totStreamF / totGen * 100)}%)` : ''}`) +
-    metricRow(t('dashboard.reliability.row.requests_with_tools'), `${fmt(totToolReq)}${totGen ? ` (${Math.round(totToolReq / totGen * 100)}%)` : ''}`) +
-    metricRow(t('dashboard.reliability.row.json_mode'), fmt(jsonMode)) +
-    metricRow(t('dashboard.reliability.row.tool_choice'), tcStr);
+    metricRow(catalogMessage('dashboard.common.row.streaming'), `${fmt(totStreamT)}${totGen ? ` (${Math.round(totStreamT / totGen * 100)}%)` : ''}`) +
+    metricRow(catalogMessage('dashboard.reliability.row.buffered'), `${fmt(totStreamF)}${totGen ? ` (${Math.round(totStreamF / totGen * 100)}%)` : ''}`) +
+    metricRow(catalogMessage('dashboard.reliability.row.requests_with_tools'), `${fmt(totToolReq)}${totGen ? ` (${Math.round(totToolReq / totGen * 100)}%)` : ''}`) +
+    metricRow(catalogMessage('dashboard.reliability.row.json_mode'), fmt(jsonMode)) +
+    metricRow(catalogMessage('dashboard.reliability.row.tool_choice'), tcStr);
 
   sortTable($('table-clients'), 'clients', [
-    { label: t('dashboard.common.col.client'), align: 'l', str: true }, { label: t('dashboard.common.col.requests') }, { label: t('dashboard.common.col.tokens_in') },
-    { label: t('dashboard.common.col.tokens_out') },
+    { label: catalogMessage('dashboard.common.col.client'), align: 'l', str: true }, { label: catalogMessage('dashboard.common.col.requests') }, { label: catalogMessage('dashboard.common.col.tokens_in') },
+    { label: catalogMessage('dashboard.common.col.tokens_out') },
   ], clients.map(cl => ({
     vals: [cl, cReq.get(cl) || 0, cP.get(cl) || 0, cC.get(cl) || 0],
-    cells: [`<i class="sw" style="background:${clientColor(cl)}"></i>${esc(cl)}`,
+    cells: [`<i class="sw" style="background:${clientColor(cl)}"></i>${escapeHtml(cl)}`,
       fmt(cReq.get(cl) || 0), fmt(cP.get(cl) || 0), fmt(cC.get(cl) || 0)],
   })), { defaultIdx: 3, maxH: 420, minW: 560 });
 }
@@ -1894,12 +1910,12 @@ const KEY_PLURALS = new Intl.PluralRules(LOCALE);
 const enabledKeys = n => {
   const p = { n: fmt(n) };
   switch (KEY_PLURALS.select(n)) {
-    case 'zero': return t('dashboard.capacity.note.enabled_keys.zero', p);
-    case 'one': return t('dashboard.capacity.note.enabled_keys.one', p);
-    case 'two': return t('dashboard.capacity.note.enabled_keys.two', p);
-    case 'few': return t('dashboard.capacity.note.enabled_keys.few', p);
-    case 'many': return t('dashboard.capacity.note.enabled_keys.many', p);
-    default: return t('dashboard.capacity.note.enabled_keys.other', p);
+    case 'zero': return catalogMessage('dashboard.capacity.note.enabled_keys.zero', p);
+    case 'one': return catalogMessage('dashboard.capacity.note.enabled_keys.one', p);
+    case 'two': return catalogMessage('dashboard.capacity.note.enabled_keys.two', p);
+    case 'few': return catalogMessage('dashboard.capacity.note.enabled_keys.few', p);
+    case 'many': return catalogMessage('dashboard.capacity.note.enabled_keys.many', p);
+    default: return catalogMessage('dashboard.capacity.note.enabled_keys.other', p);
   }
 };
 /* Same reasoning as enabledKeys above: `interval${n === 1 ? '' : 's'}` was a
@@ -1907,12 +1923,12 @@ const enabledKeys = n => {
 const unknownIntervals = n => {
   const p = { n: fmt(n) };
   switch (KEY_PLURALS.select(n)) {
-    case 'zero': return t('dashboard.capacity.history.no_data.zero', p);
-    case 'one': return t('dashboard.capacity.history.no_data.one', p);
-    case 'two': return t('dashboard.capacity.history.no_data.two', p);
-    case 'few': return t('dashboard.capacity.history.no_data.few', p);
-    case 'many': return t('dashboard.capacity.history.no_data.many', p);
-    default: return t('dashboard.capacity.history.no_data.other', p);
+    case 'zero': return catalogMessage('dashboard.capacity.history.no_data.zero', p);
+    case 'one': return catalogMessage('dashboard.capacity.history.no_data.one', p);
+    case 'two': return catalogMessage('dashboard.capacity.history.no_data.two', p);
+    case 'few': return catalogMessage('dashboard.capacity.history.no_data.few', p);
+    case 'many': return catalogMessage('dashboard.capacity.history.no_data.many', p);
+    default: return catalogMessage('dashboard.capacity.history.no_data.other', p);
   }
 };
 function renderCapacity(c) {
@@ -1922,16 +1938,16 @@ function renderCapacity(c) {
   const satPct = Math.min(1, capRatio);
   const headroom = Math.max(0, capacity - rpmNow);
   $('k-sat').innerHTML =
-    `<div style="display:flex;align-items:baseline;gap:10px"><span class="hlabel">${t('dashboard.capacity.hero.saturation')}</span><span class="tag">${t('dashboard.common.tag.now')}</span>
-    <span class="note" style="font:400 10px var(--mono);color:var(--ink-3)">${t('dashboard.capacity.note.current_vs_capacity')}</span>
+    `<div style="display:flex;align-items:baseline;gap:10px"><span class="hlabel">${escapeHtml(catalogMessage('dashboard.capacity.hero.saturation'))}</span><span class="tag">${escapeHtml(catalogMessage('dashboard.common.tag.now'))}</span>
+    <span class="note" style="font:400 10px var(--mono);color:var(--ink-3)">${escapeHtml(catalogMessage('dashboard.capacity.note.current_vs_capacity'))}</span>
     <span style="margin-left:auto;font-size:30px;font-weight:600;letter-spacing:-1px;color:${capColor}">${Math.round(satPct * 100)}%</span></div>
     <div style="position:relative;height:20px;background:var(--track);border-radius:6px;overflow:hidden;margin:16px 0 8px">
       <div style="position:absolute;inset:0;width:${(satPct * 100).toFixed(1)}%;background:linear-gradient(90deg,var(--green-dk),var(--green));border-radius:6px"></div>
     </div>
     <div style="display:flex;justify-content:space-between;font:400 11px var(--mono);color:var(--ink-3)">
       <span style="color:var(--ink-2)">${fmt(rpmNow)} / ${fmt(capacity)} rpm</span>
-      <span>${enabledKeys(cfg.lanes)}</span>
-      <span style="color:var(--green-lt)">${fmt(headroom)} ${t('dashboard.capacity.note.rpm_available')}</span>
+      <span>${escapeHtml(enabledKeys(cfg.lanes))}</span>
+      <span style="color:var(--green-lt)">${fmt(headroom)} ${escapeHtml(catalogMessage('dashboard.capacity.note.rpm_available'))}</span>
     </div>`;
 
   /* Historical comparisons use each bucket's capacity at the time.
@@ -1940,8 +1956,8 @@ function renderCapacity(c) {
   const unknownCapacity = capacityPoints.length - knownCapacity.length;
   if (!knownCapacity.length) {
     $('k-prov').innerHTML =
-      `<div class="hlabel">${t('dashboard.capacity.history.title')}</div>
-      <div class="empty">${t('dashboard.capacity.empty.no_capacity_data')}</div>`;
+      `<div class="hlabel">${escapeHtml(catalogMessage('dashboard.capacity.history.title'))}</div>
+      <div class="empty">${escapeHtml(catalogMessage('dashboard.capacity.empty.no_capacity_data'))}</div>`;
   } else {
     const weightedSeconds = knownCapacity.reduce((n, point) => n + point.duration, 0);
     const averageUtil = weightedSeconds
@@ -1953,15 +1969,15 @@ function renderCapacity(c) {
       point.rpm - point.capacity > best.rpm - best.capacity ? point : best);
     const shortRpm = Math.max(0, Math.ceil(shortfall.rpm - shortfall.capacity));
     $('k-prov').innerHTML =
-      `<div class="hlabel">${t('dashboard.capacity.history.title')}</div>
+      `<div class="hlabel">${escapeHtml(catalogMessage('dashboard.capacity.history.title'))}</div>
       <div style="display:flex;align-items:baseline;gap:8px;margin-top:12px">
         <span style="font-size:34px;font-weight:600;letter-spacing:-1px;color:${shortRpm > 0 ? 'var(--amber)' : 'var(--ink-1)'}">${fmt(shortRpm)}</span>
-        <span style="font:400 12px var(--mono);color:var(--ink-3)">${t('dashboard.capacity.history.shortfall')}</span></div>
+        <span style="font:400 12px var(--mono);color:var(--ink-3)">${escapeHtml(catalogMessage('dashboard.capacity.history.shortfall'))}</span></div>
       <div style="font:400 11.5px var(--mono);color:var(--ink-25);margin-top:6px">
-        ${t('dashboard.capacity.history.utilization', {
+        ${escapeHtml(catalogMessage('dashboard.capacity.history.utilization', {
           avg: isFinite(averageUtil) ? pctOf(averageUtil, 0) : NO_VALUE,
           peak: pctOf(peak.rpm / peak.capacity, 0),
-        })}${unknownCapacity ? ' · ' + unknownIntervals(unknownCapacity) : ''}
+        }))}${unknownCapacity ? ' · ' + escapeHtml(unknownIntervals(unknownCapacity)) : ''}
       </div>`;
   }
 
@@ -1969,12 +1985,12 @@ function renderCapacity(c) {
   const sticky = windowed(s => sum(s.rows, 'nimproxy_affinity_total', l => l.result === 'sticky'));
   const spill = windowed(s => sum(s.rows, 'nimproxy_affinity_total', l => l.result === 'spill'));
   const stickyTxt = sticky + spill ? Math.round(sticky / (sticky + spill) * 100) + '%' : '–';
-  const prow = (l, v, color) => `<div style="display:flex;justify-content:space-between;align-items:center;padding:6px 0"><span style="font-size:12.5px;color:var(--ink-2)">${l}</span><span style="font:600 15px var(--mono);color:${color || 'var(--ink-1)'}">${v}</span></div>`;
+  const prow = (l, v, color) => `<div style="display:flex;justify-content:space-between;align-items:center;padding:6px 0"><span style="font-size:12.5px;color:var(--ink-2)">${escapeHtml(l)}</span><span style="font:600 15px var(--mono);color:${color || 'var(--ink-1)'}">${escapeHtml(v)}</span></div>`;
   $('k-pressure').innerHTML =
-    `<div class="hlabel" style="margin-bottom:12px">${t('dashboard.capacity.hero.throttling')}</div>` +
-    prow(t('dashboard.common.status.rate_limited_429'), fmt(cooldown429), cooldown429 > 0 ? 'var(--amber)' : 'var(--ink-3)') +
-    prow(t('dashboard.capacity.row.session_affinity'), stickyTxt) +
-    prow(t('dashboard.capacity.row.slots_in_use'), cfg.lanes);
+    `<div class="hlabel" style="margin-bottom:12px">${escapeHtml(catalogMessage('dashboard.capacity.hero.throttling'))}</div>` +
+    prow(catalogMessage('dashboard.common.status.rate_limited_429'), fmt(cooldown429), cooldown429 > 0 ? 'var(--amber)' : 'var(--ink-3)') +
+    prow(catalogMessage('dashboard.capacity.row.session_affinity'), stickyTxt) +
+    prow(catalogMessage('dashboard.capacity.row.slots_in_use'), cfg.lanes);
 
   /* Current per-slot utilization comes from adjacent `/now` polls. Selected
      window counts remain selected-window values; neither domain is subtracted
@@ -1991,7 +2007,7 @@ function renderCapacity(c) {
       util: Math.min(1, currentRpm / Math.max(1, laneRpm(i))),
       b429: lane429.get(k) || 0, bOther: laneOther.get(k) || 0 };
   });
-  if (!lanes.length) $('meters').innerHTML = `<div class="empty">${t('dashboard.common.empty.no_keys_configured')}</div>`;
+  if (!lanes.length) $('meters').innerHTML = `<div class="empty">${escapeHtml(catalogMessage('dashboard.common.empty.no_keys_configured'))}</div>`;
   else barList($('meters'), lanes.map(l => ({
     name: l.name, v: l.util * 100, color: l.util >= 0.9 ? css('--amber') : laneColor(l.i),
   })), v => Math.round(v) + '%', 100);
@@ -2004,15 +2020,15 @@ function renderCapacity(c) {
   legend($('legend-cooldowns'), cooldownSeries);
 
   sortTable($('table-lanes'), 'lanes', [
-    { label: t('dashboard.common.col.key'), align: 'l', str: true }, { label: t('dashboard.common.col.requests') }, { label: t('dashboard.common.col.share') },
-    { label: t('dashboard.capacity.col.current_rate') }, { label: t('dashboard.capacity.col.429s') }, { label: t('dashboard.common.status.upstream_error_cooldowns') },
+    { label: catalogMessage('dashboard.common.col.key'), align: 'l', str: true }, { label: catalogMessage('dashboard.common.col.requests') }, { label: catalogMessage('dashboard.common.col.share') },
+    { label: catalogMessage('dashboard.capacity.col.current_rate') }, { label: catalogMessage('dashboard.capacity.col.429s') }, { label: catalogMessage('dashboard.common.status.upstream_error_cooldowns') },
   ], lanes.map(l => ({
     vals: [l.name, l.cur, l.cur / totalLane * 100, l.currentRpm, l.b429, l.bOther],
-    cells: [`<i class="sw" style="background:${laneColor(l.i)}"></i>${esc(l.name)}`,
+    cells: [`<i class="sw" style="background:${laneColor(l.i)}"></i>${escapeHtml(l.name)}`,
       fmt(l.cur), pctOf(l.cur / totalLane, 0), `${fmt(l.currentRpm)} / ${laneRpm(l.i)}`,
       `<span class="${l.b429 ? 'warnc' : 'dim'}">${fmt(l.b429)}</span>`,
       `<span class="${l.bOther ? 'critc' : 'dim'}">${fmt(l.bOther)}</span>`],
-  })), { defaultIdx: 1, maxH: 360, minW: 560, empty: t('dashboard.common.empty.no_keys_configured') });
+  })), { defaultIdx: 1, maxH: 360, minW: 560, empty: catalogMessage('dashboard.common.empty.no_keys_configured') });
 }
 
 /* ===== settings — config-driven, not metrics-driven: fetched from
@@ -2053,7 +2069,7 @@ function renderSettings() {
     .filter(([id]) => id === 'access' || id === 'account' || (id === 'server' ? !!SET.server : !!SET.users));
   if (!subs.some(([id]) => id === setSub)) setSub = 'access';
   $('setnav').innerHTML = subs.map(([id, label]) =>
-    `<button role="tab" data-sub="${id}" aria-selected="${id === setSub}"><span class="nbar"></span>${SICONS[id]}<span>${esc(label)}</span></button>`).join('');
+    `<button role="tab" data-sub="${id}" aria-selected="${id === setSub}"><span class="nbar"></span>${SICONS[id]}<span>${escapeHtml(label)}</span></button>`).join('');
   for (const b of $('setnav').querySelectorAll('button'))
     b.addEventListener('click', () => { setSub = b.dataset.sub; renderSettings(); });
   ({ access: renderAccess, server: renderServer, users: renderUsers, account: renderAccount })[setSub]();
@@ -2080,8 +2096,8 @@ async function copyText(text, btn) {
    stray re-render can't eat the one chance to copy it */
 function showSecret(name, secret) {
   $('modal-body').innerHTML =
-    `<p style="margin:0 0 12px;color:var(--ink-2);font-size:13px">Client key <b>${esc(name)}</b> is ready. Copy it now — <b style="color:var(--amber-lt)">you won't see this again.</b></p>
-    <div class="secretbox">${esc(secret)}</div>
+    `<p style="margin:0 0 12px;color:var(--ink-2);font-size:13px">Client key <b>${escapeHtml(name)}</b> is ready. Copy it now — <b style="color:var(--amber-lt)">you won't see this again.</b></p>
+    <div class="secretbox">${escapeHtml(secret)}</div>
     <div style="display:flex;gap:10px;justify-content:flex-end;margin-top:16px">
       <button class="pbtn" id="modal-copy">Copy key</button>
       <button class="gbtn" id="modal-done">Done</button>
@@ -2093,15 +2109,15 @@ function showSecret(name, secret) {
 
 function renderAccess() {
   const admin = !!SET.users;
-  const ownerChip = o => admin ? ` <span class="tag">${esc(o)}</span>` : '';
+  const ownerChip = o => admin ? ` <span class="tag">${escapeHtml(o)}</span>` : '';
   const keyRows = SET.nim_keys.map((k, i) => {
     const st = keyState(k);
     return `<div class="krow${k.enabled ? '' : ' koff'}">
       <div style="min-width:0">
-        <div class="kmask">nvapi-••••${esc(k.last4)}${ownerChip(k.owner)}</div>
-        <div class="kmeta">fp ${esc(String(k.fingerprint).slice(0, 8))} · ${k.lane != null ? `slot ${+k.lane + 1}` : k.enabled ? 'unassigned' : 'off'}</div>
+        <div class="kmask">nvapi-••••${escapeHtml(k.last4)}${ownerChip(k.owner)}</div>
+        <div class="kmeta">fp ${escapeHtml(String(k.fingerprint).slice(0, 8))} · ${k.lane != null ? `slot ${+k.lane + 1}` : k.enabled ? 'unassigned' : 'off'}</div>
       </div>
-      <span class="${st.cls}" data-ksfp="${esc(k.fingerprint)}">${esc(st.text)}</span>
+      <span class="${st.cls}" data-ksfp="${escapeHtml(k.fingerprint)}">${escapeHtml(st.text)}</span>
       <span class="rpmwrap"><input class="sin num" type="number" min="1" max="10000" value="${+k.rpm}" data-rpm="${i}"><span class="unitl">rpm</span></span>
       <button class="tog" role="switch" aria-checked="${!!k.enabled}" data-tog="${i}" title="${k.enabled ? 'Disable — its rate window stays warm' : 'Enable'}"></button>
       ${k.guarded
@@ -2111,14 +2127,14 @@ function renderAccess() {
   }).join('');
   const ckRows = SET.client_keys.map((ck, i) =>
     `<div class="krow">
-      <span style="font-weight:600;flex:0 1 160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${esc(ck.name)}">${esc(ck.name)}</span>
-      <span class="kmask" style="color:var(--ink-25);font-weight:500">npk_••••••••${esc(ck.last4)}</span>
-      ${admin ? `<span class="tag">${esc(ck.owner)}</span>` : ''}
+      <span style="font-weight:600;flex:0 1 160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${escapeHtml(ck.name)}">${escapeHtml(ck.name)}</span>
+      <span class="kmask" style="color:var(--ink-25);font-weight:500">npk_••••••••${escapeHtml(ck.last4)}</span>
+      ${admin ? `<span class="tag">${escapeHtml(ck.owner)}</span>` : ''}
       <button class="dbtn" style="margin-left:auto" data-ckdel="${i}">Revoke</button>
     </div>`).join('');
   $('setbody').innerHTML = `
     <div class="card mb">
-      <h2>${admin ? 'NIM keys' : 'My NIM keys'} <span class="note" id="pool-note">${esc(poolNote())}</span></h2>
+      <h2>${admin ? 'NIM keys' : 'My NIM keys'} <span class="note" id="pool-note">${escapeHtml(poolNote())}</span></h2>
       <p class="shint">Keys you add join the shared pool as yours${admin ? '' : ' — only you and admins see they exist'}. Changes apply live: kept keys keep their rate windows, disabled keys re-enable warm.</p>
       <div>${keyRows || '<div class="empty">No NIM keys yet — add one below</div>'}</div>
       <div class="addrow">
@@ -2143,7 +2159,7 @@ function renderAccess() {
       <div class="congrid">
         <div class="conbox">
           <div class="slabel">Point your client's base URL at</div>
-          <div style="display:flex;align-items:center;gap:10px"><span class="kmask" style="flex:1;overflow:hidden;text-overflow:ellipsis">${esc(location.origin + '/v1')}</span><button class="gbtn" id="copy-base">copy</button></div>
+          <div style="display:flex;align-items:center;gap:10px"><span class="kmask" style="flex:1;overflow:hidden;text-overflow:ellipsis">${escapeHtml(location.origin + '/v1')}</span><button class="gbtn" id="copy-base">copy</button></div>
         </div>
         <div class="conbox">
           <div class="slabel">API access mode</div>
@@ -2238,7 +2254,7 @@ function renderServer() {
     <div class="card mb">
       <h2>Upstream &amp; limits <button class="pbtn" id="save-limits" style="margin-left:auto">Save</button></h2>
       <div class="slabel">Upstream base URL · saving clears the model-catalog cache</div>
-      <input id="sv-base" class="sin" style="width:100%" value="${esc(sv.base_url)}" spellcheck="false">
+      <input id="sv-base" class="sin" style="width:100%" value="${escapeHtml(sv.base_url)}" spellcheck="false">
       <div class="limgrid">
         ${num('sv-maxwait', 'Max wait', L.max_wait_secs, 's')}
         ${num('sv-heartbeat', 'Heartbeat', L.heartbeat_secs, 's')}
@@ -2259,7 +2275,7 @@ function renderServer() {
         <button class="tog" role="switch" id="gov-tog" aria-checked="${!!sv.governor.enabled}"></button></span></h2>
       <p class="shint">Absorbs NIM worker-exhaustion per model without cooling down keys. Each model self-tunes: engages on the first exhaustion, climbs while stable, dissolves after a long clean stretch. Set an override only if you know a model's ceiling.</p>
       <div>${ovr.map(([m, cap], i) =>
-        `<span class="ochip"><span title="${esc(m)}">${esc(m)}</span><b>${+cap} max</b><button data-govdel="${i}" title="Remove override">×</button></span>`).join('')
+        `<span class="ochip"><span title="${escapeHtml(m)}">${escapeHtml(m)}</span><b>${+cap} max</b><button data-govdel="${i}" title="Remove override">×</button></span>`).join('')
         || '<span class="kmeta">No overrides set</span>'}</div>
       <div class="addrow">
         <input id="gov-model" class="sin" style="flex:1;min-width:200px" placeholder="model id, e.g. moonshotai/kimi-k2.5" autocomplete="off" spellcheck="false">
@@ -2279,8 +2295,8 @@ function renderServer() {
           <span class="rpmwrap" style="display:flex"><input id="sv-slo" class="sin" style="width:100%;text-align:right" type="number" min="0.1" max="100" step="0.1" value="${+sv.dashboard.slo_target_percent}"><span class="unitl">%</span></span></div>
       </div>
       <div class="congrid" style="margin-top:16px">
-        <div class="conbox"><div class="slabel">Oldest data point</div><div class="kmeta" style="display:block">${esc(retainedFrom)}</div></div>
-        <div class="conbox"><div class="slabel">Data file</div><div class="kmeta" style="display:block">${esc(historyBytes)} bytes</div></div>
+        <div class="conbox"><div class="slabel">Oldest data point</div><div class="kmeta" style="display:block">${escapeHtml(retainedFrom)}</div></div>
+        <div class="conbox"><div class="slabel">Data file</div><div class="kmeta" style="display:block">${escapeHtml(historyBytes)} bytes</div></div>
       </div>
       ${sv.history.compaction_pending ? '<p class="shint" style="color:var(--amber-lt)">compaction pending</p>' : ''}
       <div class="serr" id="history-err"></div>
@@ -2350,12 +2366,12 @@ function renderServer() {
 function renderUsers() {
   const RCLS = { superuser: 'superuser', admin: 'admin', user: 'user' };
   const rows = SET.users.map((u, i) => `<div class="krow">
-    <span class="umono">${esc((u.username[0] || '?').toUpperCase())}</span>
+    <span class="umono">${escapeHtml((u.username[0] || '?').toUpperCase())}</span>
     <div style="min-width:0">
-      <div style="font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc(u.username)}</div>
+      <div style="font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${escapeHtml(u.username)}</div>
       <div class="kmeta">${+u.nim_keys} NIM · ${+u.client_keys} client</div>
     </div>
-    <span class="rbadge ${RCLS[u.role] || 'user'}" style="margin-left:auto">${esc(String(u.role).toUpperCase())}</span>
+    <span class="rbadge ${RCLS[u.role] || 'user'}" style="margin-left:auto">${escapeHtml(String(u.role).toUpperCase())}</span>
     ${u.role !== 'superuser' ? `<button class="gbtn" data-urp="${i}">Reset password</button>
       <select class="sin" data-urole="${i}" title="Role">
         <option value="admin"${u.role === 'admin' ? ' selected' : ''}>admin</option>
@@ -2415,7 +2431,7 @@ function renderAccount() {
   $('setbody').innerHTML = `<div class="card" style="max-width:560px">
     <h2>Account</h2>
     <div class="slabel">Username</div>
-    <input class="sin" style="width:100%" value="${esc(SET.username)}" disabled>
+    <input class="sin" style="width:100%" value="${escapeHtml(SET.username)}" disabled>
     <div class="slabel" style="margin-top:14px">Current password</div>
     <input id="a-cur" class="sin" style="width:100%" type="password" autocomplete="current-password">
     <div class="slabel" style="margin-top:14px">New password · at least 10 characters</div>
@@ -2540,12 +2556,13 @@ function updateScope() {
 function syncFollowControl(offline = false) {
   if (offline) {
     $('live').className = 'live down';
-    $('liveText').textContent = tRaw('dashboard.nav.live.disconnected');
+    setMessageText($('liveText'), 'dashboard.nav.live.disconnected');
     return;
   }
   const following = mode.kind === 'following' && !mode.paused;
   $('live').className = following ? 'live' : 'live idle';
-  $('liveText').textContent = following ? tRaw('dashboard.nav.live.following') : tRaw('dashboard.nav.live.frozen');
+  if (following) setMessageText($('liveText'), 'dashboard.nav.live.following');
+  else setMessageText($('liveText'), 'dashboard.nav.live.frozen');
 }
 
 function rebuildSamples() {
@@ -2679,7 +2696,7 @@ for (const b of document.querySelectorAll('#side nav button')) {
     for (const o of document.querySelectorAll('#side nav button')) o.setAttribute('aria-selected', o === b);
     for (const s of document.querySelectorAll('main > section')) s.hidden = s.id !== 'tab-' + b.dataset.tab;
     activeTab = b.dataset.tab;
-    $('pagetitle').textContent = TITLES[activeTab];
+    setMessageText($('pagetitle'), TITLES[activeTab]);
     // Settings is config-driven: hide the metrics range picker and (re)fetch.
     document.body.classList.toggle('on-settings', activeTab === 'settings');
     if (activeTab === 'settings') loadSettings();

--- a/src/setup.html
+++ b/src/setup.html
@@ -99,8 +99,8 @@ details input { margin-top:8px; }
   <section id="step3" hidden>
     <div class="review" id="review"></div>
     <label class="opt"><input type="checkbox" id="mintkey" checked>
-      <span data-i18n-html="setup.step3.mintkey"></span></label>
-    <p class="warn" id="mintwarn" hidden data-i18n-html="setup.step3.mintwarn"></p>
+      <span id="mintkey-label"></span></label>
+    <p class="warn" id="mintwarn" hidden></p>
     <div class="row">
       <button type="button" class="ghost" id="back2" data-i18n="setup.wizard.back">Back</button>
       <button type="submit" class="primary" id="finish" data-i18n="setup.step3.finish">Create &amp; open dashboard</button>
@@ -108,7 +108,7 @@ details input { margin-top:8px; }
   </section>
 
   <section id="step4" hidden>
-    <p class="sub" data-i18n-html="setup.step4.intro"></p>
+    <p class="sub" id="setup-complete-intro"></p>
     <label data-i18n="setup.step4.baseurl">Client base URL</label>
     <div class="copyrow"><code id="cbase"></code><button type="button" class="ghost" data-copy="cbase" data-i18n="setup.step4.copy">Copy</button></div>
     <label data-i18n="setup.step4.apikey">Client API key</label>
@@ -121,82 +121,156 @@ details input { margin-top:8px; }
 <script>
 "use strict";
 const $ = (id) => document.getElementById(id);
-const err = (m) => { $("err").textContent = m || ""; };
-const esc = (s) => String(s).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
+const setErrorText = (text) => { $("err").textContent = text || ""; };
 
 /* ---------- i18n ----------
-   Catalog values are PLAIN TEXT, escaped once here at load. Inline markup a
-   message needs is expressed as {b}...{/b} / {key} / {endpoint} placeholders
-   and expanded from the fixed table below — never stored as HTML in the
-   catalog, so a translator can move emphasis without being able to inject. */
+   Catalog values remain plain Unicode text. Native DOM sinks own ordinary
+   element and text-bearing attribute contexts. Structured messages splice
+   fixed caller-created nodes between text nodes; catalog text is never HTML. */
 const MSG = JSON.parse($("i18n-catalog").textContent).messages;
-const rawMsg = (id) => (MSG[id] === undefined ? id : MSG[id].en);
-/* Substitution happens AFTER the message is escaped, so the escaper is passed
-   in rather than hardcoded: t() lands in innerHTML and must escape its params,
-   tRaw() lands in textContent, which parses no entities and would render an
-   escaped param as visible "&amp;". Word order differs by language, so a
-   sentence is one message with a placeholder, never concatenated fragments. */
-function fill(s, p, e) {
-  if (!p) return s;
-  for (const k in p) s = s.split("{" + k + "}").join(e(p[k]));
-  return s;
+const message = (id, params = {}) => {
+  let text = MSG[id] === undefined ? id : MSG[id].en;
+  for (const key in params)
+    text = text.split("{" + key + "}").join(String(params[key]));
+  return text;
+};
+const I18N_TEXT_ATTRS = new Set(["title", "placeholder", "aria-label", "alt"]);
+function assertMessageTextTarget(node) {
+  const context = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+  if (!context ||
+      context instanceof HTMLScriptElement ||
+      context instanceof HTMLStyleElement ||
+      context instanceof SVGElement ||
+      context.closest?.("script,style,svg"))
+    throw new Error("forbidden catalog text target");
 }
-/* Same names as the dashboard's, so the two pages read alike and the
-   untagged-string linter recognises call sites on both. */
-const tRaw = (id, p) => fill(rawMsg(id), p, String);
-const t = (id, p) => fill(esc(rawMsg(id)), p, esc);
-const I18N_ATTRS = new Set(["title", "placeholder", "aria-label", "alt"]);
-const INLINE = { "{b}": "<b>", "{/b}": "</b>",
-                 "{key}": "<code>npk_\u2026</code>", "{endpoint}": "<code>/v1</code>" };
-function tHtml(id) {
-  let s = esc(rawMsg(id));
-  for (const k in INLINE) s = s.split(k).join(INLINE[k]);
-  return s;
+function setMessageText(node, id, params = {}) {
+  assertMessageTextTarget(node);
+  node.textContent = message(id, params);
+}
+function setMessageAttr(node, attr, id, params = {}) {
+  if (!I18N_TEXT_ATTRS.has(attr))
+    throw new Error(`forbidden catalog attribute: ${attr}`);
+  node.setAttribute(attr, message(id, params));
+}
+function setMessageWithNodes(node, id, replacements) {
+  assertMessageTextTarget(node);
+  for (const [, replacement] of replacements) {
+    assertMessageTextTarget(replacement);
+    if (replacement.querySelector?.("script,style,svg"))
+      throw new Error("forbidden catalog text target");
+  }
+  let text = message(id);
+  const children = [];
+  while (text) {
+    let next = null;
+    for (const [token, replacement] of replacements) {
+      const at = text.indexOf(token);
+      if (at >= 0 && (!next || at < next.at))
+        next = { at, replacement, token };
+    }
+    if (!next) {
+      children.push(document.createTextNode(text));
+      break;
+    }
+    if (next.at) children.push(document.createTextNode(text.slice(0, next.at)));
+    children.push(next.replacement.cloneNode(true));
+    text = text.slice(next.at + next.token.length);
+  }
+  node.replaceChildren(...children);
+}
+function setEmphasizedMessage(node, id, emphasis) {
+  assertMessageTextTarget(node);
+  assertMessageTextTarget(emphasis);
+  if (emphasis.querySelector?.("script,style,svg"))
+    throw new Error("forbidden catalog text target");
+  const text = message(id);
+  const open = text.indexOf("{b}");
+  const close = text.indexOf("{/b}", open + 3);
+  if (open < 0 || close < 0)
+    throw new Error(`invalid emphasis placeholders: ${id}`);
+  emphasis.textContent = text.slice(open + 3, close);
+  node.replaceChildren(
+    document.createTextNode(text.slice(0, open)),
+    emphasis,
+    document.createTextNode(text.slice(close + 4)),
+  );
 }
 function applyStatic(root) {
-  root.querySelectorAll("[data-i18n]").forEach(el => { el.innerHTML = t(el.dataset.i18n); });
-  root.querySelectorAll("[data-i18n-html]").forEach(el => { el.innerHTML = tHtml(el.dataset.i18nHtml); });
+  root.querySelectorAll("[data-i18n]").forEach(el => {
+    setMessageText(el, el.dataset.i18n);
+  });
   // Own first text node — used for <title>, whose content is plain text.
   root.querySelectorAll("[data-i18n-text]").forEach(el => {
     for (const n of el.childNodes) {
-      if (n.nodeType === 3 && n.textContent.trim()) { n.textContent = tRaw(el.dataset.i18nText); break; }
+      if (n.nodeType === 3 && n.textContent.trim()) { setMessageText(n, el.dataset.i18nText); break; }
     }
   });
   root.querySelectorAll("[data-i18n-attr]").forEach(el => {
     el.dataset.i18nAttr.split(",").forEach(pair => {
       const i = pair.indexOf(":");
       const attr = pair.slice(0, i);
-      // Only text-bearing attributes are localizable. Without this, a markup
-      // edit could route a catalog value into onclick= or style=, and the CSP
-      // permits inline handlers. Same set the dashboard enforces.
-      if (!I18N_ATTRS.has(attr)) { console.error("refusing to localize attribute", attr); return; }
-      el.setAttribute(attr, tRaw(pair.slice(i + 1)));
+      setMessageAttr(el, attr, pair.slice(i + 1));
     });
   });
 }
 applyStatic(document);
+const keyLiteral = document.createElement("code");
+keyLiteral.textContent = "npk_\u2026";
+const endpointLiteral = document.createElement("code");
+endpointLiteral.textContent = "/v1";
+setMessageWithNodes($("mintkey-label"), "setup.step3.mintkey", [
+  ["{key}", keyLiteral],
+  ["{endpoint}", endpointLiteral],
+]);
+setEmphasizedMessage(
+  $("mintwarn"),
+  "setup.step3.mintwarn",
+  document.createElement("b"),
+);
+setEmphasizedMessage(
+  $("setup-complete-intro"),
+  "setup.step4.intro",
+  document.createElement("b"),
+);
 let keys = []; // {key, rpm, models}
 
 function show(n) {
   [1,2,3].forEach(i => { $("step"+i).hidden = i !== n; $("s"+i).classList.toggle("on", i <= n); });
-  err("");
+  setErrorText("");
 }
 function mask(k) { return k.length > 8 ? k.slice(0,6) + "••••" + k.slice(-4) : "••••"; }
 function renderKeys() {
-  $("keylist").innerHTML = keys.map((k,i) =>
-    `<li><span class="ok">✓</span> <code>${esc(mask(k.key))}</code>` +
-    `<span class="meta">${t("setup.step2.key_meta", { models: k.models, rpm: k.rpm })}</span>` +
-    `<button type="button" class="ghost" data-i="${i}">×</button></li>`).join("");
-  $("keylist").querySelectorAll("button").forEach(b =>
-    b.onclick = () => { keys.splice(+b.dataset.i, 1); renderKeys(); });
+  const rows = keys.map((key, index) => {
+    const row = document.createElement("li");
+    const ok = document.createElement("span");
+    ok.className = "ok";
+    ok.textContent = "✓";
+    const masked = document.createElement("code");
+    masked.textContent = mask(key.key);
+    const meta = document.createElement("span");
+    meta.className = "meta";
+    setMessageText(meta, "setup.step2.key_meta", {
+      models: key.models,
+      rpm: key.rpm,
+    });
+    const remove = document.createElement("button");
+    remove.type = "button";
+    remove.className = "ghost";
+    remove.textContent = "×";
+    remove.onclick = () => { keys.splice(index, 1); renderKeys(); };
+    row.append(ok, " ", masked, meta, remove);
+    return row;
+  });
+  $("keylist").replaceChildren(...rows);
   $("to3").disabled = keys.length === 0;
 }
 
 $("to2").onclick = () => {
   const u = $("username").value.trim(), p = $("password").value;
-  if (!/^[A-Za-z0-9._-]{1,32}$/.test(u)) return err(tRaw("setup.step1.error.username_charset"));
-  if (p.length < 10) return err(tRaw("setup.step1.error.password_length"));
-  if (p !== $("confirm").value) return err(tRaw("setup.step1.error.password_mismatch"));
+  if (!/^[A-Za-z0-9._-]{1,32}$/.test(u)) return setMessageText($("err"), "setup.step1.error.username_charset");
+  if (p.length < 10) return setMessageText($("err"), "setup.step1.error.password_length");
+  if (p !== $("confirm").value) return setMessageText($("err"), "setup.step1.error.password_mismatch");
   show(2);
 };
 $("back1").onclick = () => show(1);
@@ -204,10 +278,10 @@ $("back2").onclick = () => show(2);
 
 $("addkey").onclick = async () => {
   const key = $("newkey").value.trim(), rpm = Math.max(1, Math.min(10000, +$("newrpm").value || 40));
-  if (!key) return err(tRaw("setup.step2.error.key_required"));
-  if (keys.some(k => k.key === key)) return err(tRaw("setup.step2.error.key_duplicate"));
-  err("");
-  $("addkey").disabled = true; $("addkey").textContent = tRaw("setup.step2.validating");
+  if (!key) return setMessageText($("err"), "setup.step2.error.key_required");
+  if (keys.some(k => k.key === key)) return setMessageText($("err"), "setup.step2.error.key_duplicate");
+  setErrorText("");
+  $("addkey").disabled = true; setMessageText($("addkey"), "setup.step2.validating");
   try {
     const body = { key };
     const base = $("baseurl").value.trim();
@@ -216,41 +290,69 @@ $("addkey").onclick = async () => {
       headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
     const v = await r.json();
     if (v.ok) { keys.push({ key, rpm, models: v.models }); $("newkey").value = ""; renderKeys(); }
-    else err(tRaw("setup.step2.error.validation_failed", { error: v.error || r.status }));
-  } catch (e) { err(tRaw("setup.step2.error.validation_request", { error: e })); }
-  $("addkey").disabled = false; $("addkey").textContent = tRaw("setup.step2.addkey");
+    else setMessageText($("err"), "setup.step2.error.validation_failed", { error: v.error || r.status });
+  } catch (e) { setMessageText($("err"), "setup.step2.error.validation_request", { error: e }); }
+  $("addkey").disabled = false; setMessageText($("addkey"), "setup.step2.addkey");
 };
 
-// tRaw: one caller wraps this in esc() for innerHTML, the other assigns it to
-// textContent. Both need the plain value.
-function apiAccessLine() {
+function apiAccessMessageId() {
   return $("mintkey").checked
-    ? tRaw("setup.step3.api_access_keyed")
-    : tRaw("setup.step3.api_access_open");
+    ? "setup.step3.api_access_keyed"
+    : "setup.step3.api_access_open";
 }
 $("to3").onclick = () => {
   const base = $("baseurl").value.trim();
   const poolRpm = keys.reduce((a,k)=>a+k.rpm,0);
-  // t(), not tRaw(): every value here is interpolated into innerHTML. The two
-  // user-controlled values keep their own esc(); catalog values are escaped by
-  // t() and must not be escaped a second time.
-  $("review").innerHTML =
-    `<div><span class="k">${t("setup.step3.review.superuser")}</span><span>${esc($("username").value.trim())}</span></div>` +
-    `<div><span class="k">${t("setup.step3.review.keys")}</span><span>${t("setup.step3.review.keys_value", { count: keys.length, rpm: poolRpm })}</span></div>` +
-    `<div><span class="k">${t("setup.step3.review.upstream")}</span><span>${esc(base || "https://integrate.api.nvidia.com")}</span></div>` +
-    `<div><span class="k">${t("setup.step3.review.api_access")}</span><span id="apiline">${esc(apiAccessLine())}</span></div>`;
+  const reviewRow = (labelId, value, valueId, messageId, params = {}) => {
+    const row = document.createElement("div");
+    const label = document.createElement("span");
+    label.className = "k";
+    setMessageText(label, labelId);
+    const display = document.createElement("span");
+    if (valueId) display.id = valueId;
+    if (messageId) setMessageText(display, messageId, params);
+    else display.textContent = value;
+    row.append(label, display);
+    return row;
+  };
+  $("review").replaceChildren(
+    reviewRow(
+      "setup.step3.review.superuser",
+      $("username").value.trim(),
+    ),
+    reviewRow(
+      "setup.step3.review.keys",
+      "",
+      "",
+      "setup.step3.review.keys_value",
+      {
+        count: keys.length,
+        rpm: poolRpm,
+      },
+    ),
+    reviewRow(
+      "setup.step3.review.upstream",
+      base || "https://integrate.api.nvidia.com",
+    ),
+    reviewRow(
+      "setup.step3.review.api_access",
+      "",
+      "apiline",
+      apiAccessMessageId(),
+    ),
+  );
   show(3);
 };
 $("mintkey").onchange = () => {
   $("mintwarn").hidden = $("mintkey").checked;
   const line = document.getElementById("apiline");
-  if (line) line.textContent = apiAccessLine();
+  if (line) setMessageText(line, apiAccessMessageId());
 };
 
 // Final screen: base URL + the once-only secret, with copy buttons.
 function showConnect(secret) {
   [1,2,3].forEach(i => { $("step"+i).hidden = true; $("s"+i).classList.add("on"); });
-  err("");
+  setErrorText("");
   $("cbase").textContent = window.location.origin + "/v1";
   $("csecret").textContent = secret;
   $("step4").hidden = false;
@@ -259,9 +361,9 @@ document.querySelectorAll("[data-copy]").forEach(b => {
   b.onclick = async () => {
     // Never claim "Copied" when the write failed (no clipboard API on a
     // plain-http remote) — this is a once-only secret.
-    try { await navigator.clipboard.writeText($(b.dataset.copy).textContent); b.textContent = tRaw("setup.step4.copied"); }
-    catch { b.textContent = tRaw("setup.step4.select_copy"); }
-    setTimeout(() => { b.textContent = tRaw("setup.step4.copy"); }, 1500);
+    try { await navigator.clipboard.writeText($(b.dataset.copy).textContent); setMessageText(b, "setup.step4.copied"); }
+    catch { setMessageText(b, "setup.step4.select_copy"); }
+    setTimeout(() => { setMessageText(b, "setup.step4.copy"); }, 1500);
   };
 });
 $("opendash").onclick = () => { window.location = "/"; };
@@ -287,8 +389,9 @@ $("wiz").onsubmit = async (ev) => {
       return;
     }
     const v = await r.json().catch(() => ({}));
-    err((v.error && v.error.message) || tRaw("setup.step3.error.failed", { status: r.status }));
-  } catch (e) { err(tRaw("setup.step3.error.request", { error: e })); }
+    if (v.error && v.error.message) setErrorText(v.error.message);
+    else setMessageText($("err"), "setup.step3.error.failed", { status: r.status });
+  } catch (e) { setMessageText($("err"), "setup.step3.error.request", { error: e }); }
   $("finish").disabled = false;
 };
 </script>

--- a/tests/fixtures/locales/entity-html.json
+++ b/tests/fixtures/locales/entity-html.json
@@ -1,0 +1,26 @@
+{
+  "locale": "xx-XX",
+  "state": "Machine",
+  "messages": {
+    "app.greeting": {
+      "en": "Hello &lt;script&gt;alert(1)&lt;/script&gt;",
+      "hash": "185f8db3"
+    },
+    "app.count": {
+      "en": "{count} of {total}",
+      "hash": "de344ba2"
+    },
+    "app.emphasis": {
+      "en": "Shown {b}once{/b} only",
+      "hash": "4723b13d"
+    },
+    "app.short_label": {
+      "en": "Keys",
+      "hash": "f0d66a79"
+    },
+    "app.rate": {
+      "en": "120 rpm · 429 retry",
+      "hash": "4b64f8c2"
+    }
+  }
+}

--- a/tests/fixtures/locales/inline-dropped.json
+++ b/tests/fixtures/locales/inline-dropped.json
@@ -1,0 +1,26 @@
+{
+  "locale": "xx-XX",
+  "state": "Machine",
+  "messages": {
+    "app.greeting": {
+      "en": "Hello",
+      "hash": "185f8db3"
+    },
+    "app.count": {
+      "en": "{count} of {total}",
+      "hash": "de344ba2"
+    },
+    "app.emphasis": {
+      "en": "Shown once only",
+      "hash": "4723b13d"
+    },
+    "app.short_label": {
+      "en": "Keys",
+      "hash": "f0d66a79"
+    },
+    "app.rate": {
+      "en": "120 rpm · 429 retry",
+      "hash": "4b64f8c2"
+    }
+  }
+}


### PR DESCRIPTION
## Outcome

Replace escape-at-load with one plain Unicode message runtime and context-owned DOM/HTML sinks across the dashboard and setup wizard.

## Proof

- Red `7d5243f`: validators recognize all five required hostile check IDs while both live page probes fail under the old runtime
- Green `8375ae8`: 89 exact-ID source cases, 225 catalog references, 12 locale fixtures across 2 catalogs, and a current 225-message pseudolocale
- Both embedded pages parse; hostile and normal dashboard renders cover 5 tabs and 15 chart hovers; hostile and normal setup renders cover all 5 steps
- Agent-guide checks, formatting, and commit diff checks pass
- Independent final review: approved with no material findings

## Constraint

Policy, runtime, negative checks, sink inventory, knowledge, and the agent-guide invariant move atomically. Raw catalog lookup is lexical and limited to seven canonical sink bodies. Frozen branded descriptors refuse coercion and resolve only at the HTML-owning escape boundary. URL, style, event, script, CSS, and raw-SVG contexts reject catalog data; the approved SVG `aria-label` accessibility path is preserved.

## Ponytail

Rung 4: native DOM text and attribute primitives. An attempted owner-inference scanner was rejected after growing too large; the final bounded convention removes that parser-like machinery.

Refs #92
Parent #69

This PR targets `release/v0.6.6`; `main` remains untouched.