### PR TITLE
v0.6.6: complete repository-owned UI extraction

### DIFF
--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -2163,6 +2163,16 @@ extracting the remaining English.
   plan/memory records approved frozen commit `2d6e346` with no Critical,
   Important, or Minor findings and confirmed the prior full approval remains
   valid. The subsequent change is this review record only.
+- 2026-07-30 PR #116 CI correction: both full-tests and coverage reached 103
+  passing e2e cases, then failed `dashboard_history_settings_markup` because
+  its pre-extraction assertion still required escaped English inside
+  `settings.js`. The local RED reproduced that exact assertion. The existing
+  test now proves Settings references `settings.server.history.heading` and
+  the authenticated operator catalog serves `History & dashboard`; the
+  targeted e2e proof is GREEN. This changes test ownership only, not Rust
+  product behavior or the catalog contract. Independent micro-review found no
+  Critical, Important, or Minor findings, and `cargo test --tests` is GREEN
+  with 135 library, 104 e2e, and seven OpenAPI tests.
 
 **GitHub issue title:** `v0.6.6: complete repository-owned UI extraction`
 

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -2081,7 +2081,7 @@ extracting the remaining English.
   40 rpm`. It now asserts the already-owned button/row state instead, and its
   input username joins the setup data exclusion. This repairs a
   locale-dependent observation only; no setup behavior or interface changed.
-- 2026-07-30 Phase 1 GREEN checkpoint (`6fb52ea`, amended before publish):
+- 2026-07-30 Phase 1 GREEN checkpoint (amended before publish):
   dashboard, shared/static, and setup-driver remnants reduce the production
   source report from 134 to 96 `unowned-ui-string` findings, all in
   `src/web/settings.js`. The dashboard `en-XA` run renders five tabs and 17
@@ -2095,6 +2095,8 @@ extracting the remaining English.
   layout change was added. The render scan now recognizes only the exact
   generated `p95` duration form lacking accentable prose and the three exact
   `secs()` Intl output shapes (integer `ms`, one-decimal `sec`, integer `min`).
+  Date exclusions are exact membership generated from `DAY_SHORT` over the
+  reference year, never a text-shaped regex.
   `node scripts/render_check.js --pseudolocale-selftest` proves an arbitrary
   bracketed English phrase and non-Intl duration shapes still fail. Settings
   extraction remains Step 3/4 work.

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -2030,6 +2030,42 @@ git commit -m "feat: add dormant locale preference contracts"
 
 ### Task 7: Complete catalog extraction across every page state
 
+#### Execution record
+
+**Outcome:** Every repository-owned UI string is catalog-owned across static,
+dynamic, validation, dialog, accessibility, plural, empty, loading, error, and
+Settings states. **Proof:** Source-class negative fixtures plus the complete
+Rust-owned `en-XA` state matrix. **Constraint:** Reconcile intent before
+wording; API/model/client/publisher/metric values remain untouched; no general
+message parser or visible locale selector. **Ponytail Rung:** 2/4 — extend the
+existing catalog/checker/state driver and use cached `Intl.PluralRules`.
+**Act:** Commit the attributable source/state coverage failures before
+extracting the remaining English.
+
+- 2026-07-30: Task 7 started from `release/v0.6.6` at `fe69e31` in the isolated
+  `work/v0.6.6-task-07-ui-catalog-extraction` worktree. Baseline proof passed
+  89 source negative cases, 232 referenced catalog ids, one production catalog
+  set, and 232 generated test-only pseudolocale messages. The served
+  `--all-states --pseudolocale` baseline rendered five tabs, hovered 17 charts,
+  observed all 52 Task 8 rows, and reported no uncaught page errors.
+- 2026-07-30 documentation scope delta:
+  `knowledge/decisions/plural-categories-not-ternaries.md` joins the task
+  because it explicitly records the four plural branches Task 7 now converts.
+  Leaving it unchanged would make the governing decision contradict the
+  completed extraction. This changes no product scope, dependency, or
+  interface.
+- 2026-07-30 RED proof adds the seven owned source classes to the existing
+  checker: static markup, JS toast, validation error, dialog fragment,
+  accessibility attribute, English plural suffix, and Settings label. Each
+  negative proves its exact source path and line under `unowned-ui-string`.
+  The former Settings cutoff is deleted, and `--pseudolocale` now selects the
+  existing in-memory `en-XA` catalog and fails on actionable bypasses. The
+  source self-test observed 96 cases; the production pass reports 134 owned
+  string violations, and the populated dashboard run reports 44 actionable
+  pseudo-localized bypasses. The setup state driver currently stops at its
+  pre-existing step-two reachability assertion, which is recorded as RED
+  state evidence to repair with the setup coverage rather than waive.
+
 **GitHub issue title:** `v0.6.6: complete repository-owned UI extraction`
 
 **Files:**
@@ -2050,6 +2086,7 @@ git commit -m "feat: add dormant locale preference contracts"
 - Modify: `tests/fixtures/locales/`
 - Modify: `knowledge/decisions/locale-guards.md`
 - Modify: `knowledge/decisions/intl-formatting.md`
+- Modify: `knowledge/decisions/plural-categories-not-ternaries.md`
 - Modify: `knowledge/decisions/standard-vocabulary.md`
 - Modify: `knowledge/architecture/dashboard.md`
 - Modify: `knowledge/testing/test-strategy.md`
@@ -2066,14 +2103,14 @@ git commit -m "feat: add dormant locale preference contracts"
   `Intl.PluralRules`; v0.6.6 does not implement a general message-language
   parser.
 
-- [ ] **Step 1: Add coverage failures for every source class**
+- [x] **Step 1: Add coverage failures for every source class**
 
 Extend the self-test fixture with one hard-coded label in HTML, one JS toast,
 one validation error, one dialog fragment, one accessibility attribute, one
 plural branch, and one Settings label. Each must report its own source path and
 line under the `unowned-ui-string` check.
 
-- [ ] **Step 2: Observe the red proof**
+- [x] **Step 2: Observe the red proof**
 
 ```sh
 python3 scripts/check_i18n.py --selftest

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -2081,6 +2081,23 @@ extracting the remaining English.
   40 rpm`. It now asserts the already-owned button/row state instead, and its
   input username joins the setup data exclusion. This repairs a
   locale-dependent observation only; no setup behavior or interface changed.
+- 2026-07-30 Phase 1 GREEN checkpoint (`6fb52ea`, amended before publish):
+  dashboard, shared/static, and setup-driver remnants reduce the production
+  source report from 134 to 96 `unowned-ui-string` findings, all in
+  `src/web/settings.js`. The dashboard `en-XA` run renders five tabs and 17
+  chart hovers with zero actionable bypasses. The source self-test observes 98
+  cases; `locale_v1 --all`, pseudolocale generation, `cargo fmt --check`, and
+  `git diff --check` pass. The capacity-table sort key and the branded
+  `<b>NIM</b>` markup remain unchanged. Explicit `KEY_PLURALS` selectors are
+  limited to the new capacity-key, cooldown, model-count, and API-mode/footer
+  whole messages because the existing ID-taking text sink cannot select a
+  count-dependent literal id. No parser, dependency, API, Rust behavior, or
+  layout change was added. The render scan now recognizes only the exact
+  generated `p95` duration form lacking accentable prose and the three exact
+  `secs()` Intl output shapes (integer `ms`, one-decimal `sec`, integer `min`).
+  `node scripts/render_check.js --pseudolocale-selftest` proves an arbitrary
+  bracketed English phrase and non-Intl duration shapes still fail. Settings
+  extraction remains Step 3/4 work.
 
 **GitHub issue title:** `v0.6.6: complete repository-owned UI extraction`
 

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -2065,6 +2065,22 @@ extracting the remaining English.
   pseudo-localized bypasses. The setup state driver currently stops at its
   pre-existing step-two reachability assertion, which is recorded as RED
   state evidence to repair with the setup coverage rather than waive.
+- 2026-07-30 Step 2 command record: `python3 scripts/check_i18n.py --selftest`
+  passed 96 negative cases; `python3 scripts/check_i18n.py` failed with 134
+  `unowned-ui-string` violations; `node scripts/render_check.js --pseudolocale`
+  reached the populated five-tab scan and failed with 44 actionable bypasses;
+  `node scripts/render_check.js --page setup --pseudolocale` failed exactly
+  `could not reach step2 in src/web/setup.html`; and `node
+  scripts/render_check.js --all-states --pseudolocale` reached the same
+  44-bypass assertion after its state matrix. The latter Node process did not
+  return after reporting, even though no task-worktree proxy remained, so its
+  exact PID was stopped. This is a render-driver lifecycle/reachability gap,
+  not a product semantic change; diagnose it through the existing driver.
+- 2026-07-30 driver diagnosis: setup's `step2` state was reached, but the
+  existing driver rejected it because it asserted the English text `3 models ·
+  40 rpm`. It now asserts the already-owned button/row state instead, and its
+  input username joins the setup data exclusion. This repairs a
+  locale-dependent observation only; no setup behavior or interface changed.
 
 **GitHub issue title:** `v0.6.6: complete repository-owned UI extraction`
 

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -2054,6 +2054,15 @@ extracting the remaining English.
   Leaving it unchanged would make the governing decision contradict the
   completed extraction. This changes no product scope, dependency, or
   interface.
+- 2026-07-30 documentation scope delta: the existing
+  `message-catalog-and-escaping` decision joins this task because Settings adds
+  the narrow canonical confirm/prompt text sinks and a catalog-owned fallback
+  for unusable API error bodies. The `locale-guards`, `intl-formatting`,
+  `standard-vocabulary`, Dashboard, and test-strategy records also join to
+  capture void-tag ownership, shared plural caching, exact Settings numbers,
+  approved Settings terminology, dynamic-sink ownership, and the expanded
+  state matrix. This documents existing implementation scope; it adds no
+  parser, dependency, Rust/API, or layout work.
 - 2026-07-30 RED proof adds the seven owned source classes to the existing
   checker: static markup, JS toast, validation error, dialog fragment,
   accessibility attribute, English plural suffix, and Settings label. Each
@@ -2088,7 +2097,7 @@ extracting the remaining English.
   chart hovers with zero actionable bypasses. The source self-test observes 98
   cases; `locale_v1 --all`, pseudolocale generation, `cargo fmt --check`, and
   `git diff --check` pass. The capacity-table sort key and the branded
-  `<b>NIM</b>` markup remain unchanged. Explicit `KEY_PLURALS` selectors are
+  `<b>NIM</b>` markup remain unchanged. Explicit `PLURALS` selectors are
   limited to the new capacity-key, cooldown, model-count, and API-mode/footer
   whole messages because the existing ID-taking text sink cannot select a
   count-dependent literal id. No parser, dependency, API, Rust behavior, or
@@ -2100,6 +2109,60 @@ extracting the remaining English.
   `node scripts/render_check.js --pseudolocale-selftest` proves an arbitrary
   bracketed English phrase and non-Intl duration shapes still fail. Settings
   extraction remains Step 3/4 work.
+- 2026-07-30 Phase 2 Settings extraction: all repository-owned Access,
+  Server, Users, and Account copy now uses the existing catalog text/attribute
+  sinks or escaped descriptors. Native confirm/prompt wrappers are narrow
+  canonical text sinks; server/API error bodies and persisted role values stay
+  byte-for-byte raw. Whole-message catalog entries cover dialogs, validation,
+  toasts, placeholders, titles, empty/loading states, and explicit six-way
+  CLDR forms for history bytes, validation model counts, and user key counts.
+  The existing plural cache moved to shared formatter initialization as
+  `PLURALS`, removing a Settings dependency on dashboard execution order.
+  The API-mode explanation intentionally becomes one plain whole catalog
+  sentence: retaining three bold literals would require a prohibited general
+  message parser. The validation-error state now explicitly proves an API
+  message clears any prior green success class. Parent review corrected
+  escaping at the history-date boundary, unit ownership, raw API-error
+  handling, persisted-role casing, vocabulary, and no-parser scope.
+- 2026-07-30 Phase 2 review correction: the markup ownership parser now treats
+  the complete HTML void-element set as self-closing, with negative controls
+  that prove a catalog-tagged input cannot own a following sibling and a normal
+  tagged ancestor still owns descendants. `sPost` preserves usable API errors
+  verbatim while catalog-owning only its no-message HTTP-status fallback.
+  Settings catalog parameters use exact `NUM_GROUPED` values instead of compact
+  dashboard formatting; new served-browser rows prove the fallback and values
+  above 10,000. The compact `s` unit and concurrency suffix retain existing
+  Settings density without importing English count grammar.
+- 2026-07-30 Phase 2 GREEN proof (refresh after review correction):
+  `check_i18n.py --selftest` observed 102 negative/control cases and the
+  production checker reports 427 referenced ids; `locale_v1.py --all`,
+  pseudolocale generation, dashboard/setup/login
+  pseudolocale renders, the complete 54-row `--all-states --pseudolocale`
+  matrix, formatter fixture, `cargo fmt --check`, and `git diff --check` all
+  pass.
+- 2026-07-30 independent re-review approved the frozen Task 7 diff with no
+  Critical, Important, or Minor findings (snapshot SHA-256
+  `78be1cacbd26745abeb9568d33dc21e54a3663600dbce52bd383566942e765cf`).
+- 2026-07-30 controller freeze correction: the fresh standalone Login proof
+  exposed a stale driver assertion after `--pseudolocale` began selecting the
+  real generated `en-XA` catalog. The page correctly rendered the selected
+  public-catalog values, but the driver still required en-US literals. The
+  observed RED was `catalog did not render the product name`; the minimal
+  driver-only correction compares the Login DOM with the selected public
+  catalog and retains the anonymous operator-asset boundary. The targeted
+  `--page login --pseudolocale` proof is GREEN. No product source, dependency,
+  route, layout, or wire contract changed.
+- 2026-07-30 controller matrix correction: the fresh 54-row run then timed out
+  at `mutation-user-role:fixture-user-admin` because its Task 8 expectation
+  still required derived `ADMIN`, while Task 7 deliberately preserves the
+  persisted API value `admin` byte-for-byte. The request and Rust-owned
+  before/after fixtures were already correct; only the row description and DOM
+  expectations changed. The complete `--all-states --pseudolocale` matrix is
+  GREEN with all 54 named rows observed.
+- 2026-07-30 independent micro-review of both controller corrections and their
+  plan/memory records approved frozen commit `2d6e346` with no Critical,
+  Important, or Minor findings and confirmed the prior full approval remains
+  valid. The subsequent change is this review record only.
 
 **GitHub issue title:** `v0.6.6: complete repository-owned UI extraction`
 
@@ -2121,6 +2184,7 @@ extracting the remaining English.
 - Modify: `tests/fixtures/locales/`
 - Modify: `knowledge/decisions/locale-guards.md`
 - Modify: `knowledge/decisions/intl-formatting.md`
+- Modify: `knowledge/decisions/message-catalog-and-escaping.md`
 - Modify: `knowledge/decisions/plural-categories-not-ternaries.md`
 - Modify: `knowledge/decisions/standard-vocabulary.md`
 - Modify: `knowledge/architecture/dashboard.md`
@@ -2158,20 +2222,20 @@ node scripts/render_check.js --all-states --pseudolocale
 Expected: production sources still contain repository-owned prose and one or
 more pseudo-localized page states expose fixed English or clipping.
 
-- [ ] **Step 3: Extract by intent and preserve machine data**
+- [x] **Step 3: Extract by intent and preserve machine data**
 
 Move each owned string to the catalog only after choosing its standard
 operational meaning. Feed API/model/client/publisher/metric values as
 parameters or text nodes without case conversion. Replace the setup API-key
 warning with standard protected-superuser language matching the actual rule.
 
-- [ ] **Step 4: Cover dynamic and accessibility states**
+- [x] **Step 4: Cover dynamic and accessibility states**
 
 Exercise every dialog, toast, validation path, empty state, loading state,
 auth error, title, placeholder, `aria-label`, and plural variant with `en-XA`.
 Catalog ids remain semantic and do not encode page layout.
 
-- [ ] **Step 5: Run proof**
+- [x] **Step 5: Run proof**
 
 ```sh
 python3 scripts/check_i18n.py --selftest
@@ -2187,19 +2251,22 @@ cargo fmt --check
 git diff --check
 ```
 
-- [ ] **Step 6: Ingest and review before commit**
+- [x] **Step 6: Ingest and review before commit**
 
 Record any approved terminology decision in the localization decision, not
 only the chronology log. Give the reviewer the intent inventory, all catalog
 diffs, and pseudo-locale screenshots/probes.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```sh
-git add src/web scripts/check_i18n.py scripts/locale_v1.py \
+git add docs/plans/v0.6.6-foundation-implementation.md src/web \
+  scripts/check_i18n.py scripts/locale_v1.py \
   scripts/gen_pseudolocale.py scripts/render_check.js tests/fixtures/locales \
   knowledge/decisions/locale-guards.md \
   knowledge/decisions/intl-formatting.md \
+  knowledge/decisions/message-catalog-and-escaping.md \
+  knowledge/decisions/plural-categories-not-ternaries.md \
   knowledge/decisions/standard-vocabulary.md \
   knowledge/architecture/dashboard.md knowledge/testing/test-strategy.md \
   knowledge/log.md

--- a/knowledge/architecture/dashboard.md
+++ b/knowledge/architecture/dashboard.md
@@ -148,9 +148,11 @@ The browser fixture authority is the 21 stable JSON files in
 production response types. Dashboard metric fixtures derive histogram bounds
 from the same `HISTOGRAM_BUCKETS` registry the recorder uses, with concrete
 samples producing their bucket counts and sums; the browser does not maintain
-another metric model. The 52-row served-app matrix consumes those files or
+another metric model. The 54-row served-app matrix consumes those files or
 `scenarios.json#scenario` at the HTTP boundary and records exact requests,
-DOM results, and clean-run observations. It proves named interactions, not
+DOM results, and clean-run observations. Its rows include Settings dialogs,
+validation/toast transitions, raw API errors, the catalog-owned status fallback,
+and exact grouped Settings values above 10,000. It proves named interactions, not
 layout or all dashboard paths.
 
 `rangeSamples()` adapts the normalized range contract back into the
@@ -214,3 +216,11 @@ are never localized. Catalog ids and descriptors never enter URL, style,
 event, executable script, CSS, or raw-SVG contexts. See
 [message-catalog-and-escaping](../decisions/message-catalog-and-escaping.md)
 and [input-sanitizing-and-xss](../decisions/input-sanitizing-and-xss.md).
+
+Settings renders dynamic Access, Server, Users, and Account markup through the
+same context-owned sinks: `applyStatic` owns declarative text/attribute ids,
+fixed-markup builders escape inert descriptors once, and the five-second Access
+refresh uses `setMessageText`. Confirm/prompt dialogs are exact catalog text
+sinks. Repository fallback errors are catalog messages; usable API error bodies
+remain raw text. Settings keeps API integers exact with locale grouping rather
+than dashboard compact-number formatting.

--- a/knowledge/decisions/intl-formatting.md
+++ b/knowledge/decisions/intl-formatting.md
@@ -39,6 +39,9 @@ as **`1000.0B`**, because there was no tier above `B`.
 **Option 3.** Formatters are constructed once at module scope — `Intl`
 constructors are expensive and these run inside render loops — and read
 `LOCALE` from the shipped catalog rather than the browser.
+`PLURALS` is cached in that same shared formatter layer, so dashboard and
+Settings counted messages select CLDR categories without either constructing a
+second `Intl.PluralRules` or depending on script load order.
 
 Thresholds are deliberately **unchanged**. `Intl`'s own compact notation begins
 at 1,000 (`1K`); this dashboard shows exact counts up to 10,000 because request
@@ -69,6 +72,11 @@ days of history.
 - `secs()` now reads `1.0 sec` rather than `1.0 s`. Slightly longer, but it is
   what `Intl` considers correct for en-US and it matches the `ms`/`min` forms,
   which already used a space and an abbreviation.
+- Settings numbers are a different contract from dashboard compact display:
+  catalog parameters for key slots, rate-window values, pool capacity,
+  validation model counts, and user key counts use `NUM_GROUPED` so every API
+  integer remains exact while adopting the catalog locale's grouping. A value
+  above 10,000 must never become dashboard-style `12K` in Settings.
 - The fixture harness reads formatter bodies straight out of
   `src/web/shared.js` and `src/web/dashboard.js`, plus the locale from the one
   canonical rich English catalog, so it cannot drift from the code and source

--- a/knowledge/decisions/locale-guards.md
+++ b/knowledge/decisions/locale-guards.md
@@ -69,6 +69,12 @@ and therefore rejected by the production preference APIs.
 **Untagged-string lint.** Fails on a display literal that bypasses `message()`,
 covering attributes as well as text. Without it, English creeps back within two
 PRs, because a hardcoded label looks exactly like the code beside it.
+Its standard-library HTML parser never pushes void elements (`input`, `img`,
+`br`, and the complete HTML void set) onto the owning-ancestor stack: HTMLParser
+does not emit their end tags, so treating a catalog-tagged input as open would
+hide later sibling prose. Negative controls prove both that void-element
+ownership ends immediately and that a normal catalog-tagged ancestor still
+owns its descendants.
 
 **Contextual-sink lint.** Page code passes ids to native DOM helpers and inert
 descriptors to fixed-markup HTML builders. Named self-tests independently
@@ -106,9 +112,8 @@ decoration: nothing establishes it can.
     `applyStatic` aborts on the first throw, one missing helper left the entire
     page untranslated rather than one string — and neither `node --check` nor
     `cargo test` can see it. A dedicated lint now catches that class.
-- The untagged-string lint is deliberately scoped: the settings surface is
-  excluded until foundation Task 7, and `chipHtml`'s interior is excluded
-  permanently.
+- The untagged-string lint covers Settings after foundation Task 7; `chipHtml`'s
+  interior remains excluded permanently.
   Flagging `chipHtml` would invite someone to "fix" it by routing a catalog
   value through the URL and script contexts PR 3 spent its effort removing.
 - `en-XA` proves layout mechanically but not **clipping**, which needs eyes.

--- a/knowledge/decisions/message-catalog-and-escaping.md
+++ b/knowledge/decisions/message-catalog-and-escaping.md
@@ -35,6 +35,9 @@ value flows:
 1. DOM text, text-bearing attributes, and structured setup copy receive a
    catalog id plus parameters. Their canonical helper performs the lookup and
    immediately writes through its native DOM primitive.
+   Native confirm/prompt dialogs are the one non-DOM text path: their exact
+   canonical wrappers resolve an id and immediately pass it to the browser's
+   text-only dialog primitive.
 2. Fixed-markup dashboard builders receive a frozen, Symbol-branded descriptor
    from `catalogMessage(id, params)`. Its `Symbol.toPrimitive` throws on normal
    coercion, so a URL, style, or native attribute cannot silently stringify it.
@@ -88,6 +91,7 @@ locale may move emphasis but cannot drop, duplicate, or reorder its markers.
 | Ordinary element or mixed text-node content | Catalog id + plain parameters | `setMessageText` → `textContent` |
 | `title`, `placeholder`, `aria-label`, `alt` | Catalog id + plain parameters; `aria-label` is allowed on an ordinary SVG element | `setMessageAttr` → `setAttribute` |
 | Structured setup copy | Catalog id + caller-created fixed nodes | text nodes + `replaceChildren` |
+| Native confirm/prompt dialog | Catalog id + plain parameters | `confirmMessage` / `promptMessage` → browser dialog text |
 | Fixed chart/table/card/list HTML | Branded catalog descriptor or plain machine data | `escapeHtml` → `innerHTML` |
 | SVG geometry or raw SVG markup | Fixed markup, numeric geometry, fixed colors, and machine-formatted axis values | fixed builder or SVG DOM; catalog ids/descriptors forbidden except an allowlisted accessibility-text attribute after creation |
 | URL-bearing values | Fixed URLs or validated machine/config data | catalog ids and descriptors forbidden |
@@ -113,6 +117,10 @@ Task 5 may replace that transport without changing these value classes.
   Any remaining bare `message` identifier—including alias, `call`, or `bind`
   use—is `sink-context`. This intentionally bounded convention replaces owner
   inference.
+- A settings request preserves a usable API `error` message verbatim. If an
+  error response has no usable message, the exact `sPost` canonical body
+  resolves the repository-owned `Request failed (HTTP {status}).` fallback;
+  this prevents a hidden English template literal without rewriting API text.
 - `render_check.js --escape-probe` mutates every value with hostile literal
   entity and markup text. It verifies descriptor inertness and HTML
   resolution, the four-attribute allowlist, literal text/attribute bytes,

--- a/knowledge/decisions/plural-categories-not-ternaries.md
+++ b/knowledge/decisions/plural-categories-not-ternaries.md
@@ -66,11 +66,15 @@ unreferenced, and the check would then demand their deletion. Writing
 
 ## Consequences
 
-- Six catalog ids per counted message. Two sets so far (`enabled_keys`,
-  `history.no_data`), 12 of the 181 dashboard messages.
-- A third counted label should reuse the `KEY_PLURALS` instance rather than
-  constructing another `Intl.PluralRules`; the formatter-caching reasoning in
-  [intl-formatting](intl-formatting.md) applies unchanged.
+- Six catalog ids per counted message. The Settings surface adds explicit sets
+  for history bytes, validated models, NIM API key counts, and client API key
+  counts; English repeats its `other` wording for the categories it does not
+  distinguish.
+- Every counted label reuses the shared cached `PLURALS` instance rather than
+  constructing another `Intl.PluralRules`. It is initialized with the catalog
+  locale alongside the number/date formatters in `shared.js`, so Settings does
+  not depend on `dashboard.js` execution order. The formatter-caching reasoning
+  in [intl-formatting](intl-formatting.md) applies unchanged.
 - English output is byte-identical to the ternaries **for every count either
   label can reach**, so this is invisible in the shipped locale — which means the
   pseudolocale run is the only check that observes it working.

--- a/knowledge/decisions/standard-vocabulary.md
+++ b/knowledge/decisions/standard-vocabulary.md
@@ -135,6 +135,14 @@ and “immediate access.” Login adds only the expected title, prompt, field
 labels/placeholders, submit label, and invalid-credentials message. These are
 repository-owned labels; model ids, client/publisher names, persisted values,
 and metric identifiers remain raw.
+Task 7 applies the same distinction to Settings: use **NIM API key**, **client
+API key**, **API key required**, **Open (no authentication)**, **Model limits**,
+**Model cache TTL**, **Stream idle timeout**, and **concurrent** for the
+governor cap. Settings status/validation/dialog copy is repository-owned;
+model ids, usernames, client names, API error messages, persisted role values,
+and numeric API values remain raw (with locale grouping only for numeric
+display). The pool note keeps the standard **Total** label rather than the
+retired `rpm total` run.
 
 ## Consequences
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,15 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-30] fix — align Rust asset proof with catalog ownership
+
+The history-settings asset e2e test now proves that Settings references its
+semantic catalog id and the authenticated operator catalog serves the owned
+heading. Its former assertion required the retired escaped English literal
+inside JavaScript, so full-tests and coverage correctly failed after Task 7
+extraction. See the [test strategy](testing/test-strategy.md) and
+[Task 7 plan](../docs/plans/v0.6.6-foundation-implementation.md).
+
 ## [2026-07-30] fix — align Login render proof with selected catalog
 
 The standalone Login render proof now compares repository-owned DOM text with

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,32 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-30] fix — align Login render proof with selected catalog
+
+The standalone Login render proof now compares repository-owned DOM text with
+the selected public catalog. Its former en-US literals became stale when
+`--pseudolocale` began selecting generated `en-XA`, causing the harness to
+reject correctly localized output before its untranslated-text scan. The
+anonymous Login/operator-asset boundary remains unchanged. See the
+[test strategy](testing/test-strategy.md) and
+[Task 7 plan](../docs/plans/v0.6.6-foundation-implementation.md).
+
+## [2026-07-30] decision — complete Settings catalog ownership and guard boundaries
+
+Task 7 extends catalog ownership through Settings Access, Server, Users, and
+Account states: repository copy, dialogs, validation/toasts, titles,
+placeholders, explicit CLDR count variants, and fallback HTTP-status errors are
+catalog-owned. API error bodies, model/client/user values, persisted roles, and
+exact numeric values remain raw; Settings applies locale grouping without
+dashboard compaction. Native confirm/prompt wrappers are exact canonical
+text-only sinks. The source guard now treats the full HTML void-element set as
+self-closing so a catalog-tagged input cannot suppress later prose. The
+served-browser matrix has 54 rows, including catalog fallback and >10,000
+Settings-value probes. See [message catalog and escaping](decisions/message-catalog-and-escaping.md),
+[locale guards](decisions/locale-guards.md), [Intl formatting](decisions/intl-formatting.md),
+[standard vocabulary](decisions/standard-vocabulary.md), [Dashboard](architecture/dashboard.md),
+and [test strategy](testing/test-strategy.md).
+
 ## [2026-07-30] component — Rust-owned browser fixtures and interaction matrix
 
 Task 8 makes `tests/fixtures/ui/` a 21-file, typed Rust serialization surface:

--- a/knowledge/testing/test-strategy.md
+++ b/knowledge/testing/test-strategy.md
@@ -301,6 +301,9 @@ Page-specific render assertions must compare rendered owned text with the
 selected catalog, not en-US literals; otherwise a real `en-XA` selection makes
 the harness reject correctly localized output before the untranslated-text
 scan runs.
+Rust asset e2e tests follow the same ownership boundary: assert the semantic
+catalog id in the application asset and the expected source text in the served
+catalog, never the retired English literal inside JavaScript.
 
 **Human — screenshots, still.** Real-browser screenshots under live traffic
 (the UI is dark-only since the operator-console redesign), inspected by eye —

--- a/knowledge/testing/test-strategy.md
+++ b/knowledge/testing/test-strategy.md
@@ -74,8 +74,10 @@ that proof.
   with `UPDATE_UI_FIXTURES=1 cargo test api::tests::ui_fixtures --lib`; verify
   without mutation with `cargo test api::tests::ui_fixtures --lib` and
   `git diff --exit-code -- tests/fixtures/ui`. Matrix recipes refer to a file
-  or `scenarios.json#scenario`, never a JavaScript wire body. `--all-states`
-  runs 52 named rows against the served application: exact ordered requests,
+  or `scenarios.json#scenario`, never a JavaScript wire body. Two explicitly
+  named resilience rows apply an in-memory transform to a generated body: one
+  removes an API error message and one raises Settings integers above 10,000.
+  `--all-states` runs 54 named rows against the served application: exact ordered requests,
   DOM observations, and clean page-error, console-error, promise-rejection,
   asset, unexpected-request, and fixture-consumption observations. Its loading
   row holds the real bootstrap response until the hidden-state assertion.
@@ -100,7 +102,9 @@ that proof.
 - **Number, date, and duration formatting:**
   `TZ=UTC LC_ALL=en_US.UTF-8 node scripts/formatter_fixture.js --check`.
 - **Catalog and UI text:** `python3 scripts/check_i18n.py --selftest`, then
-  `python3 scripts/check_i18n.py`; when English changes, also run
+  `python3 scripts/check_i18n.py`; the current selftest has 102 negative or
+  control cases, including void-element ownership and Settings source classes.
+  When English changes, also run
   `python3 scripts/gen_pseudolocale.py --check`.
 - **Locale files:** `python3 scripts/locale_v1.py --selftest` and
   `python3 scripts/locale_v1.py --all`. When the public English projection
@@ -257,9 +261,9 @@ cargo +nightly fuzz run sse_scan -- -max_total_time=60
 Dashboard changes get two more checks.
 
 **Automated — `node scripts/render_check.js`.** Starts the real binary, loads
-its served page/assets, and fulfills only the 21 Rust-generated typed JSON
+its served page/assets, and fulfills the 21 Rust-generated typed JSON
 fixtures in `tests/fixtures/ui/` at the API boundary. `--all-states` walks the
-52 named request/DOM/clean-run interactions (including loading via a held
+54 named request/DOM/clean-run interactions (including loading via a held
 bootstrap response), every dashboard tab, and chart hovers; it is not a layout
 test or a claim that every application path is covered. Regenerate deliberately
 with `UPDATE_UI_FIXTURES=1 cargo test api::tests::ui_fixtures --lib`, then
@@ -289,6 +293,14 @@ This is the only gate that proves the page *runs*: `cargo test` asserts on
 served HTML text and `node --check` proves only that it parses. See
 [render-gate](../decisions/render-gate.md) and
 [message-catalog-and-escaping](../decisions/message-catalog-and-escaping.md).
+Run the complete Settings matrix under `--all-states --pseudolocale` after
+catalog work: it covers accessibility text, dialogs, validation/toast state,
+raw API errors, the catalog fallback for an unusable error body, and exact
+grouped Settings values above 10,000.
+Page-specific render assertions must compare rendered owned text with the
+selected catalog, not en-US literals; otherwise a real `en-XA` selection makes
+the harness reject correctly localized output before the untranslated-text
+scan runs.
 
 **Human — screenshots, still.** Real-browser screenshots under live traffic
 (the UI is dark-only since the operator-console redesign), inspected by eye —

--- a/scripts/check_i18n.py
+++ b/scripts/check_i18n.py
@@ -150,7 +150,7 @@ def tagged(source: str, attr: str):
 # miss in review.
 #
 # Scoped deliberately:
-#   - the settings surface is excluded; its ~79 strings land in 0.6.7
+#   - Settings is included; its static and dynamic strings stay catalog-owned.
 #   - chipHtml's interior is excluded. It interpolates into a URL and (before
 #     this release) a JS context; routing a catalog value through it is the
 #     thing we spent PR 3 removing. Flagging it would invite someone to
@@ -302,6 +302,17 @@ CANONICAL_LOOKUPS = {
     throw new Error\(`forbidden catalog attribute: \$\{attr\}`\);
   node\.setAttribute\(attr, message\(id, params\)\);
 \}""",
+        r"""function confirmMessage\(id, params = \{\}\) \{
+  return confirm\(message\(id, params\)\);
+\}""",
+        r"""function promptMessage\(id, params = \{\}\) \{
+  return prompt\(message\(id, params\)\);
+\}""",
+        r"""const apiError = typeof j\.error === 'string'
+    \? j\.error
+    : \(j\.error && typeof j\.error\.message === 'string' \? j\.error\.message : ''\);
+  if \(!r\.ok \|\| j\.ok === false\)
+    throw new Error\(apiError \|\| message\('settings\.error\.request_failed', \{ status: r\.status \}\)\);""",
     ),
     "src/web/setup.html": (
         r"""function setMessageText\(node, id, params = \{\}\) \{
@@ -573,6 +584,11 @@ def lint_untagged(name: str, raw: str) -> list:
             # display string on the same source line.
             if re.search(r"\.className\s*=", before.rsplit(";", 1)[-1]):
                 continue
+            # `cls:` is the CSS-state field in a returned render descriptor,
+            # never operator copy. Keep the exemption to that exact field;
+            # a later object field remains scanned normally.
+            if re.search(r"\bcls\s*:\s*$", before):
+                continue
             # `class="logo cdnchip"` is an attribute value, not display text.
             if ATTR_VALUE.search(before):
                 continue
@@ -617,6 +633,14 @@ def unowned_ui_string(name: str, source: str, offset: int, detail: str) -> str:
 class _MarkupTextOwnership(HTMLParser):
     """Find ordinary visible markup text that has no catalog-owning ancestor."""
 
+    # HTMLParser emits ordinary ``handle_starttag`` calls for void HTML
+    # elements. They have no end tag to unwind the ownership stack, so pushing
+    # one would let a catalog attribute on an <input> hide every later sibling.
+    VOID_ELEMENTS = {
+        "area", "base", "br", "col", "embed", "hr", "img", "input",
+        "link", "meta", "param", "source", "track", "wbr",
+    }
+
     def __init__(self, name: str, source: str):
         super().__init__(convert_charrefs=True)
         self.name = name
@@ -625,7 +649,8 @@ class _MarkupTextOwnership(HTMLParser):
         self.errors = []
 
     def handle_starttag(self, tag, attrs):
-        self.stack.append((tag, dict(attrs)))
+        if tag not in self.VOID_ELEMENTS:
+            self.stack.append((tag, dict(attrs)))
 
     def handle_startendtag(self, tag, attrs):
         pass
@@ -804,6 +829,8 @@ SELFTEST_CASES = [
     ("class-attribute", 'const z = `<div class="logo cdnchip"></div>`;', None),
     ("class-assignment", "el.className = ready ? 'live' : 'live idle';", None),
     ("class-adjacent-display", "el.className = 'live idle'; el.textContent = 'Some fresh label here';", "unowned-ui-string"),
+    ("class-state-field", "const state = { cls: 'kstate dim' };", None),
+    ("class-field-display", "const state = { cls: 'kstate dim', label: 'Some fresh label here' };", "unowned-ui-string"),
     ("real-machinery", "document.querySelector('#tab-models');", None),
     ("frozen-unit", "const z = 'tok/s';", None),
     ("lowercase-token", "const z = 'sticky';", None),
@@ -824,6 +851,10 @@ SOURCE_CLASS_SELFTESTS = [
      "\nconst text = `${cfg.lanes} key${cfg.lanes === 1 ? '' : 's'}`;", lint_plural_suffixes, 2),
     ("settings-label", "src/web/settings.js",
      "\nfunction renderSettings() { const label = 'Unowned settings label'; }", lint_untagged, 2),
+    ("void-tag-does-not-own-following-label", "tests/fixtures/locales/unowned-void.html",
+     '\n<input data-i18n-attr="placeholder:probe"><span>Unowned following label</span>', lint_untagged_markup, 2),
+    ("tagged-ancestor-owns-descendant", "tests/fixtures/locales/owned-ancestor.html",
+     '\n<div data-i18n="probe"><span>Owned descendant label</span></div>', lint_untagged_markup, None),
 ]
 
 SINK_SELFTEST_CASES = [
@@ -1110,7 +1141,12 @@ def selftest() -> int:
 
     for label, name, snippet, check, line in SOURCE_CLASS_SELFTESTS:
         found = check(name, snippet)
-        if (len(found) != 1
+        if line is None:
+            if found:
+                failures.append(f"{label}: expected to pass, got {found!r}")
+            else:
+                print(f"  ok  {label:24} passes")
+        elif (len(found) != 1
                 or "[unowned-ui-string]" not in found[0]
                 or f"{name}:{line}:" not in found[0]):
             failures.append(
@@ -1243,11 +1279,19 @@ def main() -> int:
         # ID-taking sinks or catalogMessage(). The application/json catalog is
         # deliberately excluded, or every orphan would appear referenced.
         js = strip_comments("".join(re.findall(r"<script>(.*?)</script>", raw, re.S)))
-        for m in re.finditer(r"""['"]((?:dashboard|setup|login)\.[a-z0-9_.]+)['"]""", js):
+        for m in re.finditer(r"""['"]((?:dashboard|settings|setup|login)\.[a-z0-9_.]+)['"]""", js):
             mid = m.group(1)
             referenced.add(mid)
             if mid not in catalog:
                 errors.append(f"{name}: message id {mid!r} has no catalog entry")
+        for m in re.finditer(
+            r"""data-i18n(?:-attr)?=["'][^"']*?((?:dashboard|settings|setup|login)\.[a-z0-9_.]+)""",
+            js,
+        ):
+            mid = m.group(1)
+            referenced.add(mid)
+            if mid not in catalog:
+                errors.append(f"{name}: declarative message id {mid!r} has no catalog entry")
 
     for mid in catalog:
         if mid not in referenced:

--- a/scripts/check_i18n.py
+++ b/scripts/check_i18n.py
@@ -28,6 +28,7 @@ import json
 import pathlib
 import re
 import sys
+from html.parser import HTMLParser
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 EMERGENCY_TEXT = "NIM Proxy interface failed to load."
@@ -176,7 +177,6 @@ def frozen(text: str) -> bool:
 DISPLAY_CALLS = re.compile(
     r"(?:\{\s*label:\s*|metricRow\(\s*|tile\(\s*|prow\(\s*|empty:\s*)'([^']{2,})'"
 )
-SETTINGS_START = re.compile(r"function renderSettings\(")
 
 # The allowlist above only sees five call shapes, so every leak that survived
 # extraction lived in a shape it does not scan: `{name:'…'}` chart series,
@@ -526,11 +526,9 @@ def lint_catalog_sinks(name: str, raw: str) -> list:
 def lint_untagged(name: str, raw: str) -> list:
     errors = []
     body = re.search(r"<script>(.*?)</script>", raw, re.S)
-    js = body.group(1) if body else ""
+    js = body.group(1) if body else raw
 
-    # The settings surface is owned by foundation Task 7.
-    cut = SETTINGS_START.search(js)
-    scanned = js[: cut.start()] if cut else js
+    scanned = js
     # The startup failure has one deliberately unlocalized, dependency-free
     # string. It is useful precisely when no catalog is available.
     scanned = scanned.replace(repr(EMERGENCY_TEXT), "''")
@@ -544,16 +542,16 @@ def lint_untagged(name: str, raw: str) -> list:
     # chipHtml is excluded by design, not by oversight.
     scanned = re.sub(r"function chipHtml\(pub\) \{.*?\n\}", "", scanned, flags=re.S)
 
-    for m in DISPLAY_CALLS.finditer(strip_comments(scanned)):
+    for m in DISPLAY_CALLS.finditer(blank_comments(scanned)):
         text = m.group(1)
         if frozen(text):
             continue
-        errors.append(
-            f"{name}: untagged display string {text!r} — route it through message()"
-        )
+        errors.append(unowned_ui_string(name, scanned, m.start(1),
+            f"display string {text!r} — route it through message()"))
 
-    stripped = strip_comments(scanned)
-    for line in stripped.splitlines():
+    stripped = blank_comments(scanned)
+    line_start = 0
+    for line in stripped.splitlines(keepends=True):
         for m in QUOTED.finditer(line):
             text = m.group(1) if m.group(1) is not None else m.group(2)
             before = line[: m.start()]
@@ -573,9 +571,9 @@ def lint_untagged(name: str, raw: str) -> list:
             if ATTR_VALUE.search(before):
                 continue
             if looks_like_prose(text):
-                errors.append(
-                    f"{name}: untagged prose {text!r} — route it through message()"
-                )
+                errors.append(unowned_ui_string(name, scanned, line_start + m.start(),
+                    f"prose {text!r} — route it through message()"))
+        line_start += len(line)
 
     # Bare prose sitting between tags inside a template literal.
     for m in TEMPLATE_LITERAL.finditer(stripped):
@@ -586,10 +584,8 @@ def lint_untagged(name: str, raw: str) -> list:
             for piece in node.split("\x00"):
                 piece = piece.strip()
                 if piece and looks_like_prose(piece):
-                    errors.append(
-                        f"{name}: untagged prose {piece!r} in template markup"
-                        f" — route it through message()"
-                    )
+                    errors.append(unowned_ui_string(name, scanned, m.start(),
+                        f"prose {piece!r} in template markup — route it through message()"))
 
     # Localizable attributes carrying prose, with no data-i18n-attr beside them.
     markup = strip_scripts(raw)
@@ -599,8 +595,75 @@ def lint_untagged(name: str, raw: str) -> list:
             continue
         if frozen(text):
             continue
-        errors.append(f"{name}: untagged {attr}={text!r} — add data-i18n-attr")
+        errors.append(unowned_ui_string(name, raw, m.start(2),
+            f"{attr}={text!r} — add data-i18n-attr"))
     return errors
+
+
+def unowned_ui_string(name: str, source: str, offset: int, detail: str) -> str:
+    """Report prose in its real source, rather than a synthetic bundle line."""
+    return (
+        f"[unowned-ui-string] {name}:{source.count(chr(10), 0, offset) + 1}: "
+        f"{detail}"
+    )
+
+
+class _MarkupTextOwnership(HTMLParser):
+    """Find ordinary visible markup text that has no catalog-owning ancestor."""
+
+    def __init__(self, name: str, source: str):
+        super().__init__(convert_charrefs=True)
+        self.name = name
+        self.source = source
+        self.stack = []
+        self.errors = []
+
+    def handle_starttag(self, tag, attrs):
+        self.stack.append((tag, dict(attrs)))
+
+    def handle_startendtag(self, tag, attrs):
+        pass
+
+    def handle_endtag(self, tag):
+        for index in range(len(self.stack) - 1, -1, -1):
+            if self.stack[index][0] == tag:
+                del self.stack[index:]
+                break
+
+    def handle_data(self, data):
+        text = data.strip()
+        if not text or not looks_like_prose(text):
+            return
+        if any("data-i18n" in attrs for _, attrs in self.stack):
+            return
+        line, column = self.getpos()
+        offset = sum(len(line) + 1 for line in self.source.splitlines()[:line - 1]) + column
+        self.errors.append(unowned_ui_string(
+            self.name, self.source, offset,
+            f"markup text {text!r} — add a catalog-owned data-i18n sink",
+        ))
+
+
+def lint_untagged_markup(name: str, raw: str) -> list:
+    parser = _MarkupTextOwnership(name, raw)
+    parser.feed(strip_scripts(blank_comments(raw)))
+    return parser.errors
+
+
+PLURAL_SUFFIX = re.compile(
+    r"\b(?:[A-Za-z_$][\w$]*\.)?(?:length|lanes)\s*===\s*1\s*\?\s*''\s*:\s*'s'"
+)
+
+
+def lint_plural_suffixes(name: str, raw: str) -> list:
+    """A narrow guard for the documented English-only plural suffix shape."""
+    return [
+        unowned_ui_string(
+            name, raw, match.start(),
+            "English plural suffix — select explicit catalog variants through Intl.PluralRules",
+        )
+        for match in PLURAL_SUFFIX.finditer(strip_comments(raw))
+    ]
 
 
 
@@ -713,17 +776,17 @@ def lint_retired_vocabulary(name: str, raw: str, catalog=None) -> list:
 # CSS and class attributes gets switched off.
 
 SELFTEST_CASES = [
-    # (label, snippet, expected: "untagged" | "retired" | None)
-    ("assignment-single", "const zzq = 'Some fresh label here';", "untagged"),
-    ("assignment-double", 'const zzq = "Some fresh label here";', "untagged"),
-    ("equality-compare", "if (x === 'Some fresh label here') {}", "untagged"),
-    ("textContent-sink", "el.textContent = 'Some fresh label here';", "untagged"),
-    ("innerHTML-sink", "el.innerHTML = 'Some fresh label here';", "untagged"),
-    ("adjacent-arg", "bar(v.toFixed(1), 'Some fresh label here');", "untagged"),
-    ("statement-boundary", "el.style.width = w; bar('Some fresh label here');", "untagged"),
-    ("colon-prefixed-prose", "const z = `<div>note: some fresh label</div>`;", "untagged"),
-    ("template-text-node", "const z = `<div><span>Some fresh label</span></div>`;", "untagged"),
-    ("display-call-arg", "prow('Some fresh label here', 1);", "untagged"),
+    # (label, snippet, expected: "unowned-ui-string" | "retired" | None)
+    ("assignment-single", "const zzq = 'Some fresh label here';", "unowned-ui-string"),
+    ("assignment-double", 'const zzq = "Some fresh label here";', "unowned-ui-string"),
+    ("equality-compare", "if (x === 'Some fresh label here') {}", "unowned-ui-string"),
+    ("textContent-sink", "el.textContent = 'Some fresh label here';", "unowned-ui-string"),
+    ("innerHTML-sink", "el.innerHTML = 'Some fresh label here';", "unowned-ui-string"),
+    ("adjacent-arg", "bar(v.toFixed(1), 'Some fresh label here');", "unowned-ui-string"),
+    ("statement-boundary", "el.style.width = w; bar('Some fresh label here');", "unowned-ui-string"),
+    ("colon-prefixed-prose", "const z = `<div>note: some fresh label</div>`;", "unowned-ui-string"),
+    ("template-text-node", "const z = `<div><span>Some fresh label</span></div>`;", "unowned-ui-string"),
+    ("display-call-arg", "prow('Some fresh label here', 1);", "unowned-ui-string"),
     ("retired-in-markup", "const z = `<div>Harness</div>`;", "retired"),
     # A real multi-word retired key, wrapped. NOT "Latency breakdown" — that is
     # the REPLACEMENT term. Using it here is how a scratch test that grepped for
@@ -736,6 +799,23 @@ SELFTEST_CASES = [
     ("real-machinery", "document.querySelector('#tab-models');", None),
     ("frozen-unit", "const z = 'tok/s';", None),
     ("lowercase-token", "const z = 'sticky';", None),
+]
+
+SOURCE_CLASS_SELFTESTS = [
+    ("html-label", "tests/fixtures/locales/unowned-html.html",
+     '\n<div>Unowned static label</div>', lint_untagged_markup, 2),
+    ("js-toast", "tests/fixtures/locales/unowned-toast.js",
+     "\nshowToast('Unowned toast message');", lint_untagged, 2),
+    ("validation-error", "tests/fixtures/locales/unowned-validation.js",
+     "\nnote('err', 'Unowned validation error');", lint_untagged, 2),
+    ("dialog-fragment", "tests/fixtures/locales/unowned-dialog.js",
+     "\nconst dialog = `<p>Unowned dialog fragment</p>`;", lint_untagged, 2),
+    ("accessibility-attribute", "tests/fixtures/locales/unowned-a11y.html",
+     '\n<button aria-label="Unowned accessible name"></button>', lint_untagged, 2),
+    ("plural-branch", "tests/fixtures/locales/unowned-plural.js",
+     "\nconst text = `${cfg.lanes} key${cfg.lanes === 1 ? '' : 's'}`;", lint_plural_suffixes, 2),
+    ("settings-label", "src/web/settings.js",
+     "\nfunction renderSettings() { const label = 'Unowned settings label'; }", lint_untagged, 2),
 ]
 
 SINK_SELFTEST_CASES = [
@@ -1005,7 +1085,7 @@ def selftest() -> int:
         page = SELFTEST_PAGE % snippet
         found = set()
         if lint_untagged("selftest", page):
-            found.add("untagged")
+            found.add("unowned-ui-string")
         if lint_retired_vocabulary("selftest", page):
             found.add("retired")
         if want is None:
@@ -1019,6 +1099,17 @@ def selftest() -> int:
             )
         else:
             print(f"  ok  {label:24} trips {want}")
+
+    for label, name, snippet, check, line in SOURCE_CLASS_SELFTESTS:
+        found = check(name, snippet)
+        if (len(found) != 1
+                or "[unowned-ui-string]" not in found[0]
+                or f"{name}:{line}:" not in found[0]):
+            failures.append(
+                f"{label}: expected one attributed unowned-ui-string, got {found!r}"
+            )
+        else:
+            print(f"  ok  {label:24} trips unowned-ui-string")
 
     for label, snippet, want in SINK_SELFTEST_CASES:
         page = SELFTEST_PAGE % snippet
@@ -1052,7 +1143,7 @@ def selftest() -> int:
         for f in failures:
             print("  -", f)
         return 1
-    total = len(SELFTEST_CASES) + len(SINK_SELFTEST_CASES)
+    total = len(SELFTEST_CASES) + len(SOURCE_CLASS_SELFTESTS) + len(SINK_SELFTEST_CASES)
     print(f"\nselftest ok — {total} cases, every check observed to fail")
     return 0
 
@@ -1161,7 +1252,11 @@ def main() -> int:
             f"[{check}] {detail}"
             for check, detail in lint_catalog_sinks(name, page)
         ]
-        errors += lint_untagged(name, page)
+        errors += lint_untagged_markup(name, (ROOT / name).read_text())
+        for script in PAGE_SOURCES[name]:
+            script_source = (ROOT / script).read_text()
+            errors += lint_untagged(script, script_source)
+            errors += lint_plural_suffixes(script, script_source)
         errors += lint_retired_vocabulary(
             name,
             page,

--- a/scripts/check_i18n.py
+++ b/scripts/check_i18n.py
@@ -158,7 +158,7 @@ def tagged(source: str, attr: str):
 #   - NEVER_TRANSLATE holds the units and codes that must survive verbatim.
 
 NEVER_TRANSLATE = {
-    "TTFT", "TPOT", "tok/s", "Tools/req", "Msgs/req", "p50 / p95", "p50", "p95",
+    "TTFT", "TPOT", "tok", "tok/s", "Tools/req", "Msgs/req", "p50 / p95", "p50", "p95",
     "requests / min", "req/min", "rpm", "JSON", "HTTP", "POST", "SLO", "NIM",
     "/v1", "%", "429", "401", "503", "504", "5xx",
     "requests/min", "nvapi-\u2026", "npk_\u2026",
@@ -567,6 +567,12 @@ def lint_untagged(name: str, raw: str) -> list:
             # statement boundary in between.
             if gov and not ARG_BOUNDARY.search(window[gov.end():]):
                 continue
+            # className assignments are CSS state, even where a conditional
+            # puts the chosen class farther than the ordinary lookback window.
+            # Keep this to the current statement so it cannot hide a later
+            # display string on the same source line.
+            if re.search(r"\.className\s*=", before.rsplit(";", 1)[-1]):
+                continue
             # `class="logo cdnchip"` is an attribute value, not display text.
             if ATTR_VALUE.search(before):
                 continue
@@ -634,7 +640,7 @@ class _MarkupTextOwnership(HTMLParser):
         text = data.strip()
         if not text or not looks_like_prose(text):
             return
-        if any("data-i18n" in attrs for _, attrs in self.stack):
+        if any(any(key.startswith("data-i18n") for key in attrs) for _, attrs in self.stack):
             return
         line, column = self.getpos()
         offset = sum(len(line) + 1 for line in self.source.splitlines()[:line - 1]) + column
@@ -796,6 +802,8 @@ SELFTEST_CASES = [
     ("css-declaration", "const z = 'display:flex;gap:20px';", None),
     ("css-single-value", "const z = 'position:relative';", None),
     ("class-attribute", 'const z = `<div class="logo cdnchip"></div>`;', None),
+    ("class-assignment", "el.className = ready ? 'live' : 'live idle';", None),
+    ("class-adjacent-display", "el.className = 'live idle'; el.textContent = 'Some fresh label here';", "unowned-ui-string"),
     ("real-machinery", "document.querySelector('#tab-models');", None),
     ("frozen-unit", "const z = 'tok/s';", None),
     ("lowercase-token", "const z = 'sticky';", None),

--- a/scripts/render_check.js
+++ b/scripts/render_check.js
@@ -3285,6 +3285,11 @@ async function startProxy(tmpdir, setupRequired = IS_SETUP) {
 /* ---------- the run -------------------------------------------------------- */
 
 
+const isGeneratedFrozenP95 = text =>
+  /^\[p95 (?:–|(?:0|[1-9]\d{0,2}(?:,\d{3})*)\.\d sec|(?:0|[1-9]\d{0,2}(?:,\d{3})*) (?:ms|min)) e\]$/.test(text);
+const isIntlDurationRun = text =>
+  /^(?:(?:0|[1-9]\d{0,2}(?:,\d{3})*) ms|(?:0|[1-9]\d{0,2}(?:,\d{3})*)\.\d sec|(?:0|[1-9]\d{0,2}(?:,\d{3})*) min)$/.test(text);
+
 // A run of ASCII prose with no accented character, under a locale where every
 // translated message is accented, is a string the catalog never reached.
 const SCAN_UNTRANSLATED = `
@@ -3300,6 +3305,7 @@ const SCAN_UNTRANSLATED = `
       const padding = t.endsWith(']') ? t.slice(0, -1) : t;
       if (padding && [...padding].every((ch, i) => ch === pseudoPad[i % pseudoPad.length]))
         continue;
+      if (${isGeneratedFrozenP95.toString()}(t)) continue;
       if (/[\\u00C0-\\u024F]/.test(t)) continue;   // accented: the catalog reached it
       out.push(t);
     }
@@ -3319,7 +3325,7 @@ const dataLabelValues = (() => {
     const doc = JSON.parse(fs.readFileSync(p, 'utf8'));
     for (const bucket of ['totals', 'latest']) {
       for (const r of doc[bucket] || []) {
-        for (const k of ['model', 'client']) {
+        for (const k of ['model', 'client', 'mode']) {
           const v = (r.labels || {})[k];
           if (v && v !== 'none') out.add(v);
         }
@@ -5421,11 +5427,16 @@ async function main() {
     // Exact match only. Substring matching against data values excludes real
     // labels: a "Mo" monogram swallowed the heatmap's "Mon", and any run
     // containing "rpm" swallowed "0 / 24 rpm · 3 keys", whose "keys" is ours.
-    const isData = (t) => dataDerived.has(t);
+    const isData = (t) => dataDerived.has(t) || [...dataDerived].some(value =>
+      t.startsWith(value + ' ') && /^[0-9.,%]+$/.test(t.slice(value.length + 1)));
     // A run is correctly untranslated only if NOTHING of ours is left once the
     // frozen tokens, digits and punctuation are removed. "tok/s" goes; "24 rpm
     // available" stays, because "available" is a word we wrote.
     const isFrozen = (t) => {
+      // These are already-localized output from Intl.NumberFormat or
+      // Intl.DateTimeFormat. A catalog must not own dynamic numeric/date data.
+      if (isIntlDurationRun(t)) return true;
+      if (/^[A-Z][a-z]{2}\s+\d{1,2}$/.test(t)) return true;
       let rest = t;
       for (const f of [...frozen].sort((a, b) => b.length - a.length)) rest = rest.split(f).join(' ');
       return !/[a-zA-Z]{2,}/.test(rest);
@@ -5490,7 +5501,23 @@ async function main() {
   }
 }
 
-if (args.includes('--cleanup-selftest')) {
+if (args.includes('--pseudolocale-selftest')) {
+  const failures = [];
+  if (!isGeneratedFrozenP95('[p95 25.0 sec e]'))
+    failures.push('generated p95 duration was not recognized');
+  if (isGeneratedFrozenP95('[p95 arbitrary English e]'))
+    failures.push('arbitrary bracketed English was accepted');
+  for (const value of ['25 ms', '25.0 sec', '4 min'])
+    if (!isIntlDurationRun(value)) failures.push(`Intl duration ${JSON.stringify(value)} was not recognized`);
+  for (const value of ['25 sec', '25.00 sec', '25 min later'])
+    if (isIntlDurationRun(value)) failures.push(`non-Intl duration ${JSON.stringify(value)} was accepted`);
+  if (failures.length) {
+    for (const failure of failures) console.error(`[pseudolocale] ${failure}`);
+    process.exitCode = 1;
+  } else {
+    console.log('pseudolocale selftest ok — exact generated and Intl-format exemptions only');
+  }
+} else if (args.includes('--cleanup-selftest')) {
   cleanupSelftest().then(code => process.exit(code)).catch((e) => {
     console.error('cleanup selftest failed to run: ' + e.message);
     process.exit(2);

--- a/scripts/render_check.js
+++ b/scripts/render_check.js
@@ -2749,7 +2749,8 @@ const allStates = args.includes('--all-states');
 const PAGE_REL = path.join('src', 'web', `${pageArg}.html`);
 const localeArg = (() => {
   const i = args.indexOf('--locale');
-  return i >= 0 ? args[i + 1] : null;
+  if (i >= 0) return args[i + 1];
+  return args.includes('--pseudolocale') ? 'en-XA' : null;
 })();
 // Catalog values are plain Unicode text. The probe proves ordinary text and
 // allowed attributes render literally, while fixed-markup HTML builders
@@ -5434,6 +5435,10 @@ async function main() {
     console.log(`\nuntranslated runs under ${localeArg}: ${real.length} actionable`
       + ` (${correct} correctly untranslated: frozen tokens and data from the API)`);
     for (const [text, tab] of real) console.log(`   [${tab}] ${JSON.stringify(text)}`);
+    if (real.length) {
+      console.error(`FAIL — ${real.length} repository-owned run(s) bypassed the catalog`);
+      throw reportedFailure();
+    }
   }
 
   if (predicateFailures.length) {

--- a/scripts/render_check.js
+++ b/scripts/render_check.js
@@ -3368,7 +3368,7 @@ const SETUP_STEPS = {
     return shown.length > 0 && !$('err').hidden;
   })()`,
   step1: `(() => {
-    $('username').value = 'op'; $('password').value = 'probe-password-1';
+    $('username').value = 'fixture-user'; $('password').value = 'probe-password-1';
     $('confirm').value = 'probe-password-1'; $('to2').click();
     return !$('step2').hidden;
   })()`,
@@ -3376,10 +3376,7 @@ const SETUP_STEPS = {
     $('newkey').value = 'nvapi-probe-key';
     $('addkey').click();
     for (let i = 0; i < 40 && $('to3').disabled; i++) await new Promise(r => setTimeout(r, 50));
-    return !$('to3').disabled
-      && ($('keylist').textContent || '').includes(
-        ${JSON.stringify(`${JSON.parse(fs.readFileSync(path.join(FIXTURES, 'validate-success.json'), 'utf8')).models} models · 40 rpm`)},
-      );
+    return !$('to3').disabled && !!$('keylist').querySelector('li');
   })()`,
   step3: `(() => {
     $('to3').click();
@@ -5195,7 +5192,13 @@ async function main() {
         return document.querySelector('#tab-${tab}') ? !document.querySelector('#tab-${tab}').hidden : false;
       })()`);
     if (!switched) {
-      console.error(`FAIL — could not reach ${tab} in ${PAGE_REL}; the gate would measure the wrong panels`);
+      const detail = IS_SETUP
+        ? await evaluate(`JSON.stringify({
+          error: $('err')?.textContent || '', step1Hidden: $('step1')?.hidden,
+          step2Hidden: $('step2')?.hidden,
+        })`)
+        : '';
+      console.error(`FAIL — could not reach ${tab} in ${PAGE_REL}; the gate would measure the wrong panels ${detail}`);
       throw reportedFailure();
     }
     await sleep(1200);
@@ -5234,6 +5237,7 @@ async function main() {
         // the count stops meaning anything.
         for (const d of await evaluate(`
           (() => [
+            ($('username') && $('username').value) || '',
             ($('newkey') && $('newkey').value) || '',
             (document.querySelector('#keylist code') || {}).textContent || '',
             ($('baseurl') && $('baseurl').value) || 'https://integrate.api.nvidia.com',

--- a/scripts/render_check.js
+++ b/scripts/render_check.js
@@ -3345,11 +3345,16 @@ const SCAN_DATA_DERIVED = `
       try { out.add(prettyName(id)); } catch (e) {}
       try { out.add(publisher(id).name); } catch (e) {}
     }
-    // Anything Intl produces is CLDR data, not catalog text — weekday names and
-    // hour labels are correct-by-construction for the active locale and will
-    // never be accented under en-XA. Ask the page's own cached formatters
-    // rather than hardcoding a list that would drift from them.
+    // Anything Intl produces is CLDR data, not catalog text. Ask the page's
+    // own cached formatters rather than accepting a text-shaped heuristic that
+    // could hide an owned label such as "Key 12".
     try { for (const d of DAYS) out.add(d); } catch (e) {}
+    try {
+      for (let month = 0; month < 12; month++) for (let day = 1; day <= 31; day++) {
+        const ms = Date.UTC(2024, month, day);
+        if (new Date(ms).getUTCMonth() === month) out.add(DAY_SHORT.format(ms));
+      }
+    } catch (e) {}
     try {
       for (let h = 0; h < 24; h++) {
         out.add(HOUR_ONLY.format(Date.UTC(2024, 0, 1, h)));
@@ -5433,10 +5438,9 @@ async function main() {
     // frozen tokens, digits and punctuation are removed. "tok/s" goes; "24 rpm
     // available" stays, because "available" is a word we wrote.
     const isFrozen = (t) => {
-      // These are already-localized output from Intl.NumberFormat or
-      // Intl.DateTimeFormat. A catalog must not own dynamic numeric/date data.
+      // This is the exact trio of already-localized output shapes from secs().
+      // A catalog must not own dynamic numeric data.
       if (isIntlDurationRun(t)) return true;
-      if (/^[A-Z][a-z]{2}\s+\d{1,2}$/.test(t)) return true;
       let rest = t;
       for (const f of [...frozen].sort((a, b) => b.length - a.length)) rest = rest.split(f).join(' ');
       return !/[a-zA-Z]{2,}/.test(rest);

--- a/scripts/render_check.js
+++ b/scripts/render_check.js
@@ -484,8 +484,8 @@ const INTERACTION_ROWS = [
     category: 'edit',
     state: 'mutation-success',
     action: 'change fixture-user role to admin',
-    visible: 'the user row shows ADMIN',
-    dom: [{ selector: '#setbody .krow', property: 'fixture-user-role', equals: 'ADMIN' }],
+    visible: 'the user row shows admin',
+    dom: [{ selector: '#setbody .krow', property: 'fixture-user-role', equals: 'admin' }],
     request: {
       method: 'POST',
       path: '/api/settings/users',
@@ -548,7 +548,7 @@ const INTERACTION_ROWS = [
     action: 'enter the current and matching replacement passwords and activate Update password',
     visible: 'the password-updated success note is visible and inputs are clear',
     dom: [
-      { selector: '#a-err', property: 'textContent', equals: 'Password updated — this session was refreshed.' },
+      { selector: '#a-err', property: 'textContent', equals: 'Password updated. Other sessions were signed out.' },
       { selector: '#a-cur,#a-new,#a-conf', property: 'value-sequence', equals: ['', '', ''] },
     ],
     request: {
@@ -605,7 +605,7 @@ const INTERACTION_ROWS = [
     state: 'api-error',
     action: 'enter Settings and fulfill config with ApiError',
     visible: 'the settings load error is visible',
-    dom: [{ selector: '#setbody .empty', property: 'textContent-includes', equals: 'Could not load settings' }],
+    dom: [{ selector: '#setbody .empty', property: 'textContent-includes', equals: 'Could not load Settings. Reload the page and sign in again.' }],
     request: {
       method: 'GET',
       path: '/api/config',
@@ -630,13 +630,30 @@ const INTERACTION_ROWS = [
     },
   },
   {
+    id: 'error-settings-fallback',
+    category: 'error',
+    state: 'malformed-api-error',
+    action: 'submit locally valid history settings and fulfill with an API failure without a usable error message',
+    visible: 'the catalog-owned status fallback is visible beside the triggering control',
+    dom: [{ selector: '#history-err', property: 'textContent', equals: 'Request failed (HTTP 400).' }],
+    request: {
+      method: 'POST',
+      path: '/api/settings/history',
+      body: {
+        days: 30,
+        default_window_days: 7,
+        slo_target_percent: 99.9,
+      },
+    },
+  },
+  {
     id: 'error-nim-key-validation',
     category: 'error',
     state: 'mutation-error',
     action: 'activate Validate and add and fulfill key validation with an error',
-    visible: 'the validation failure and Add anyway control are visible',
+    visible: 'the raw API validation error is visible without a stale success state, and Add anyway is available',
     dom: [
-      { selector: '#nk-err', property: 'textContent-includes', equals: 'Validation failed' },
+      { selector: '#nk-err', property: 'textContent', equals: 'validation fixture rejected' },
       { selector: '#nk-force', property: 'hidden', equals: false },
     ],
     request: {
@@ -754,6 +771,17 @@ const INTERACTION_ROWS = [
     action: 'fulfill dashboard requests from the extreme-numeric Rust-owned fixture',
     visible: 'extreme numeric values render without a page error',
     dom: [{ selector: '#tab-overview', property: 'finite-layout', equals: true }],
+  },
+  {
+    id: 'state-settings-exact-large-values',
+    category: 'state',
+    state: 'exact-large-settings-values',
+    action: 'enter Access with a test-only high-value transform of the Rust-owned ConfigResponse',
+    visible: 'Settings shows locale-grouped, non-compact key and pool values above 10,000',
+    dom: [
+      { selector: '#pool-note', property: 'textContent', equals: 'Pool: 12,345 enabled · Total: 67,890 rpm' },
+      { selector: '[data-ksfp="f17e0001"]', property: 'textContent', equals: '12,345 / 67,890 in window' },
+    ],
   },
   {
     id: 'state-long-machine-values',
@@ -968,7 +996,7 @@ const DOM_CONTRACTS = {
   'mutation-user-role': [
     domContract('fixture-user-admin',
       `Array.from(document.querySelectorAll('#setbody .krow')).find(row => row.textContent.includes('fixture-user'))?.querySelector('.rbadge')?.textContent.trim() ?? null`,
-      'ADMIN'),
+      'admin'),
   ],
   'mutation-user-password-reset': [
     domContract('password-reset-note', `document.querySelector('#u-err')?.textContent.trim() ?? null`, 'Password reset for fixture-user.'),
@@ -987,7 +1015,7 @@ const DOM_CONTRACTS = {
   'account-password-update': [
     domContract('password-updated-note',
       `document.querySelector('#a-err')?.textContent.trim() ?? null`,
-      'Password updated — this session was refreshed.'),
+      'Password updated. Other sessions were signed out.'),
     domContract('password-fields-cleared',
       `['a-cur','a-new','a-conf'].map(id => document.getElementById(id)?.value ?? null)`,
       ['', '', '']),
@@ -1033,16 +1061,23 @@ const DOM_CONTRACTS = {
   ],
   'error-settings-load': [
     domContract('settings-load-error',
-      `document.querySelector('#setbody .empty')?.textContent.includes('Could not load settings') ?? false`,
+      `document.querySelector('#setbody .empty')?.textContent.includes('Could not load Settings. Reload the page and sign in again.') ?? false`,
       true),
   ],
   'error-settings-mutation': [
     domContract('typed-api-error', `document.querySelector('#history-err')?.textContent.trim() ?? null`, 'invalid history fixture'),
   ],
+  'error-settings-fallback': [
+    domContract('catalog-request-fallback',
+      `document.querySelector('#history-err')?.textContent.trim() ?? null`,
+      'Request failed (HTTP 400).'),
+  ],
   'error-nim-key-validation': [
-    domContract('validation-error',
-      `document.querySelector('#nk-err')?.textContent.includes('Validation failed') ?? false`,
-      true),
+    domContract('raw-validation-error',
+      `document.querySelector('#nk-err')?.textContent.trim() ?? null`,
+      'validation fixture rejected'),
+    domContract('validation-error-not-green',
+      `document.querySelector('#nk-err')?.classList.contains('ok') ?? null`, false),
     domContract('add-anyway-visible', `document.querySelector('#nk-force')?.hidden ?? null`, false),
   ],
   'error-setup-key-validation': [
@@ -1081,6 +1116,14 @@ const DOM_CONTRACTS = {
     domContract('finite-layout',
       `Number.isFinite(document.documentElement.scrollWidth) && !/(?:NaN|Infinity)/.test(document.body.textContent)`,
       true),
+  ],
+  'state-settings-exact-large-values': [
+    domContract('grouped-pool-capacity',
+      `document.querySelector('#pool-note')?.textContent.trim() ?? null`,
+      'Pool: 12,345 enabled · Total: 67,890 rpm'),
+    domContract('grouped-key-state',
+      `document.querySelector('[data-ksfp="f17e0001"]')?.textContent.trim() ?? null`,
+      '12,345 / 67,890 in window'),
   ],
   'state-long-machine-values': [
     domContract('machine-values-byte-exact-by-owning-surface',
@@ -1499,6 +1542,7 @@ const FIXTURE_SCENARIOS = {
     },
   }),
   'error-settings-mutation': dashboardRecipe({ response: 'api-error.json' }),
+  'error-settings-fallback': dashboardRecipe({ response: 'api-error.json' }),
   'error-nim-key-validation': dashboardRecipe({ response: 'validate-failure.json' }),
   'error-setup-key-validation': setupRecipe({ response: 'validate-failure.json' }),
   'setup-key-validation-success': setupRecipe({ response: 'validate-success.json' }),
@@ -1520,6 +1564,9 @@ const FIXTURE_SCENARIOS = {
   'state-extreme-numeric': dashboardRecipe({
     range: 'dashboard-extreme.json',
     boundary: 'startup-dashboard-range',
+  }),
+  'state-settings-exact-large-values': dashboardRecipe({
+    config: 'scenarios.json#access-before',
   }),
   'state-long-machine-values': dashboardRecipe({
     config: 'scenarios.json#long-values',
@@ -3635,6 +3682,7 @@ function matrixActionExpression(id) {
     'error-dashboard-now': `await pollNow()`,
     'error-settings-load': openSettings,
     'error-settings-mutation': `${setValue('#sv-retention-days', '30')};${setValue('#sv-default-days', '7')};${setValue('#sv-slo', '99.9')};${click('#save-history')}`,
+    'error-settings-fallback': `${setValue('#sv-retention-days', '30')};${setValue('#sv-default-days', '7')};${setValue('#sv-slo', '99.9')};${click('#save-history')}`,
     'error-nim-key-validation': `${setValue('#nk-key', 'nvapi-invalid-fixture')};${click('#nk-add')}`,
     'error-setup-key-validation': `${setValue('#newkey', 'nvapi-invalid-fixture')};${click('#addkey')}`,
     'setup-key-validation-success': `${setValue('#newkey', 'nvapi-ui-fixture')};${click('#addkey')}`,
@@ -3667,6 +3715,8 @@ const SETTINGS_PRESTATE_PANEL = new Map([
   ['account-password-validation', 'account'],
   ['account-password-update', 'account'],
   ['error-settings-mutation', 'server'],
+  ['error-settings-fallback', 'server'],
+  ['state-settings-exact-large-values', 'access'],
   ['error-nim-key-validation', 'access'],
 ]);
 
@@ -3775,6 +3825,21 @@ async function runMatrixContext({ browser, row, role, configuredProxy, setupProx
       await new Promise(resolve => { heldBootstrapRelease = resolve; });
     }
     const value = routeFixture(normalized);
+    if (row.id === 'error-settings-fallback'
+        && normalized.method === 'POST'
+        && pathname === '/api/settings/history') {
+      value.error = undefined;
+      value.ok = false;
+    }
+    if (row.id === 'state-settings-exact-large-values'
+        && normalized.method === 'GET'
+        && pathname === '/api/config') {
+      value.pool.enabled = 12345;
+      value.pool.capacity_rpm = 67890;
+      value.nim_keys[0].lane = 12344;
+      value.nim_keys[0].in_window = 12345;
+      value.nim_keys[0].rpm = 67890;
+    }
     if (value !== undefined) {
       const reference = activePlan.lastReference;
       const status = reference === 'validate-failure.json'
@@ -4902,15 +4967,20 @@ async function main() {
   };
 
   if (IS_LOGIN) {
+    const selectedLoginMessages = localeArg
+      ? publicCatalogProjection(loadTestLocaleCatalog(localeArg)).messages
+      : null;
+    const expectedAppName = selectedLoginMessages?.['common.app_name'] ?? 'NIM Proxy';
+    const expectedPrompt = selectedLoginMessages?.['login.prompt'] ?? 'Sign in to the dashboard.';
     const loginFailure = await evaluate(`
       (() => {
         if (document.body.hidden) return 'body stayed hidden after catalog resolution';
         if (!document.querySelector('form.login-card')) return 'login form is missing';
         if (document.querySelector('script[src^="/assets/operator/"]'))
           return 'login loaded an operator script';
-        if (document.querySelector('h1')?.textContent !== 'NIM Proxy')
+        if (document.querySelector('h1')?.textContent !== ${JSON.stringify(expectedAppName)})
           return 'catalog did not render the product name';
-        if (document.querySelector('.login-sub')?.textContent !== 'Sign in to the dashboard.')
+        if (document.querySelector('.login-sub')?.textContent !== ${JSON.stringify(expectedPrompt)})
           return 'catalog did not render the login prompt';
         return '';
       })()`);

--- a/src/web/dashboard.html
+++ b/src/web/dashboard.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="icon" href="data:,">
-<title>NIM Proxy</title>
+<title data-i18n-text="common.app_name">NIM Proxy</title>
 <link id="presentation-stylesheet" rel="stylesheet" href="/assets/operator/operator.css">
 </head>
 <body hidden>
@@ -12,7 +12,7 @@
 <aside id="side">
   <div class="brand">
     <!-- nim-proxy-icon -->
-    <span class="wordmark" aria-label="NIM Proxy" data-i18n-attr="aria-label:common.app_name"><b>NIM</b> Proxy</span>
+    <span class="wordmark" aria-label="NIM Proxy" data-i18n-attr="aria-label:common.app_name"><b>NIM</b> <span data-i18n="dashboard.brand.proxy">Proxy</span></span>
   </div>
   <nav role="tablist">
     <button role="tab" data-tab="overview" aria-selected="true"><span class="nbar"></span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 8.5L8 3l6 5.5M3.5 7.5V13h9V7.5"/></svg><span class="label" data-i18n="dashboard.nav.tab.overview">Overview</span></button>

--- a/src/web/dashboard.js
+++ b/src/web/dashboard.js
@@ -589,10 +589,9 @@ const LANE_COLORS = ['#76B900', '#4D6BFE', '#D9A521', '#16B8C0', '#615CED', '#EE
    form absent here can never be added by a translation, and ar/ru/pl/cy need
    categories English does not have. Ids are spelled out rather than built from
    the category, so the lint can still see them. */
-const KEY_PLURALS = new Intl.PluralRules(LOCALE);
 const errorCooldownSummary = (share, cooldowns) => {
   const p = { pct: pctOf(share / 100, share && share < 10 ? 1 : 0), cooldowns: fmt(cooldowns) };
-  switch (KEY_PLURALS.select(cooldowns)) {
+  switch (PLURALS.select(cooldowns)) {
     case 'zero': return catalogMessage('dashboard.overview.ring.errors.zero', p);
     case 'one': return catalogMessage('dashboard.overview.ring.errors.one', p);
     case 'two': return catalogMessage('dashboard.overview.ring.errors.two', p);
@@ -603,7 +602,7 @@ const errorCooldownSummary = (share, cooldowns) => {
 };
 const footerInfoId = (keys, auth) => {
   if (auth) {
-    switch (KEY_PLURALS.select(keys)) {
+    switch (PLURALS.select(keys)) {
       case 'zero': return 'dashboard.nav.footer.api_key_required.zero';
       case 'one': return 'dashboard.nav.footer.api_key_required.one';
       case 'two': return 'dashboard.nav.footer.api_key_required.two';
@@ -612,7 +611,7 @@ const footerInfoId = (keys, auth) => {
       default: return 'dashboard.nav.footer.api_key_required.other';
     }
   }
-  switch (KEY_PLURALS.select(keys)) {
+  switch (PLURALS.select(keys)) {
     case 'zero': return 'dashboard.nav.footer.open.zero';
     case 'one': return 'dashboard.nav.footer.open.one';
     case 'two': return 'dashboard.nav.footer.open.two';
@@ -623,7 +622,7 @@ const footerInfoId = (keys, auth) => {
 };
 const capacityKeySummary = (rpmNow, capacity, n) => {
   const p = { rpm_now: fmt(rpmNow), rpm_capacity: fmt(capacity), n: fmt(n) };
-  switch (KEY_PLURALS.select(n)) {
+  switch (PLURALS.select(n)) {
     case 'zero': return catalogMessage('dashboard.overview.ring.capacity_sub.zero', p);
     case 'one': return catalogMessage('dashboard.overview.ring.capacity_sub.one', p);
     case 'two': return catalogMessage('dashboard.overview.ring.capacity_sub.two', p);
@@ -633,7 +632,7 @@ const capacityKeySummary = (rpmNow, capacity, n) => {
   }
 };
 const modelCountId = n => {
-  switch (KEY_PLURALS.select(n)) {
+  switch (PLURALS.select(n)) {
     case 'zero': return 'dashboard.models.count.zero';
     case 'one': return 'dashboard.models.count.one';
     case 'two': return 'dashboard.models.count.two';
@@ -644,7 +643,7 @@ const modelCountId = n => {
 };
 const modelCount = n => catalogMessage(modelCountId(n), { n: fmt(n) });
 const modelCountWithSortId = n => {
-  switch (KEY_PLURALS.select(n)) {
+  switch (PLURALS.select(n)) {
     case 'zero': return 'dashboard.models.count_with_sort.zero';
     case 'one': return 'dashboard.models.count_with_sort.one';
     case 'two': return 'dashboard.models.count_with_sort.two';
@@ -655,7 +654,7 @@ const modelCountWithSortId = n => {
 };
 const enabledKeys = n => {
   const p = { n: fmt(n) };
-  switch (KEY_PLURALS.select(n)) {
+  switch (PLURALS.select(n)) {
     case 'zero': return catalogMessage('dashboard.capacity.note.enabled_keys.zero', p);
     case 'one': return catalogMessage('dashboard.capacity.note.enabled_keys.one', p);
     case 'two': return catalogMessage('dashboard.capacity.note.enabled_keys.two', p);
@@ -668,7 +667,7 @@ const enabledKeys = n => {
    second copy of English grammar in the render path. */
 const unknownIntervals = n => {
   const p = { n: fmt(n) };
-  switch (KEY_PLURALS.select(n)) {
+  switch (PLURALS.select(n)) {
     case 'zero': return catalogMessage('dashboard.capacity.history.no_data.zero', p);
     case 'one': return catalogMessage('dashboard.capacity.history.no_data.one', p);
     case 'two': return catalogMessage('dashboard.capacity.history.no_data.two', p);

--- a/src/web/dashboard.js
+++ b/src/web/dashboard.js
@@ -126,21 +126,22 @@ function renderOverview(c) {
   }).filter(Boolean);
   kpiCards($('o-kpis'), [
     { icon: 'pulse', label: catalogMessage('dashboard.common.col.requests'), value: fmt(wreq), sub: windowLabel, delta: deltaChip(reqPts), pts: reqPts },
-    { icon: 'stack', label: catalogMessage('dashboard.common.col.tokens_out'), value: fmt(allC), sub: `${fmt(allP)} in`, delta: deltaChip(ctokPts), pts: ctokPts },
+    { icon: 'stack', label: catalogMessage('dashboard.common.col.tokens_out'), value: fmt(allC), sub: catalogMessage('dashboard.overview.kpi.tokens_in', { tokens: fmt(allP) }), delta: deltaChip(ctokPts), pts: ctokPts },
     { icon: 'check', label: catalogMessage('dashboard.common.kpi.success_rate'), value: wreq ? pctOf(okRatio, 2) : NO_VALUE,
-      sub: `${fmt(wok)} of ${fmt(wreq)}`, delta: deltaChip(okPts), pts: okPts },
+      sub: catalogMessage('dashboard.overview.kpi.success_counts', { ok: fmt(wok), requests: fmt(wreq) }), delta: deltaChip(okPts), pts: okPts },
   ], true);
 
-  $('o-reqnow').textContent = fmt(curRpm) + ' now';
-  lineChart($('o-traffic'), [{ name: 'req/min', color: MED, pts: reqPts, area: true }], fmt, { height: 220 });
+  setMessageText($('o-reqnow'), 'dashboard.common.value.now', { value: fmt(curRpm) });
+  lineChart($('o-traffic'), [{ name: catalogMessage('dashboard.chart.requests_per_min'), color: MED, pts: reqPts, area: true }], fmt, { height: 220 });
 
   $('o-rings').innerHTML = '<div class="ringwrap" id="o-ring-cap"></div><div class="ringwrap" id="o-ring-ok"></div>';
   // ringGauge accepts an id and owns its separate HTML and attribute sinks.
   ringGauge($('o-ring-cap'), capRatio, pctOf(capRatio, 0), capColor,
-    'dashboard.overview.ring.capacity_used', `${fmt(rpmNow)} / ${fmt(capacity)} rpm · ${cfg.lanes} key${cfg.lanes === 1 ? '' : 's'}`);
+    'dashboard.overview.ring.capacity_used', capacityKeySummary(rpmNow, capacity, cfg.lanes));
   const errShare = wreq ? (wreq - wok) / wreq * 100 : 0;
   ringGauge($('o-ring-ok'), okRatio, wreq ? pctOf(okRatio, 0) : NO_VALUE, okColor,
-    'dashboard.common.kpi.success_rate', `errors ${pctOf(errShare / 100, errShare && errShare < 10 ? 1 : 0)} · ${fmt(cooldown429)} cooldowns`);
+    'dashboard.common.kpi.success_rate', errorCooldownSummary(
+      errShare, cooldown429));
   $('o-health').innerHTML =
     metricRow(catalogMessage('dashboard.common.row.active_now'), fmt(sum(rows, 'nimproxy_active_requests'))) +
     metricRow(catalogMessage('dashboard.common.row.queued'), fmt(sum(rows, 'nimproxy_queue_depth'))) +
@@ -184,17 +185,17 @@ function renderModels(c) {
   const chatReqs = [...reqModels.values()].reduce((a, b) => a + b, 0);
   const qmed = (metric, f) => { const v = quantile(wbuckets(metric, f), 0.5); return isFinite(v) ? v : NaN; };
   kpiCards($('m-kpis'), [
-    { icon: 'pulse', label: catalogMessage('dashboard.common.col.requests'), value: fmt(chatReqs), sub: `${models.length} model${models.length === 1 ? '' : 's'}`,
+    { icon: 'pulse', label: catalogMessage('dashboard.common.col.requests'), value: fmt(chatReqs), sub: modelCount(models.length),
       pts: rateSeries(s => sum(s.rows, 'nimproxy_requests_total', l => l.path === '/v1/chat/completions')) },
     { icon: 'stack', label: catalogMessage('dashboard.models.kpi.completion_tokens'), value: fmt(allC), sub: windowLabel,
       pts: rateSeries(s => sum(s.rows, 'nimproxy_completion_tokens_total')) },
     { icon: 'grid', label: catalogMessage('dashboard.models.kpi.prompt_tokens'), value: fmt(allP), sub: windowLabel,
       pts: rateSeries(s => sum(s.rows, 'nimproxy_prompt_tokens_total')) },
     { icon: 'clock', label: catalogMessage('dashboard.models.col.avg_ttft'), value: ttftN ? secs(ttftS / ttftN) : '–',
-      sub: `median ${secs(qmed('nimproxy_ttft_seconds'))}`,
+      sub: catalogMessage('dashboard.models.stat.median', { value: secs(qmed('nimproxy_ttft_seconds')) }),
       pts: avgSeries('nimproxy_ttft_seconds_sum', 'nimproxy_ttft_seconds_count') },
     { icon: 'bolt', label: catalogMessage('dashboard.models.kpi.avg_speed'), value: tpsN ? fmt(tpsS / tpsN) + ' tok/s' : '–',
-      sub: `median ${isFinite(qmed('nimproxy_tokens_per_second', l => l.source === 'usage')) ? fmt(qmed('nimproxy_tokens_per_second', l => l.source === 'usage')) + ' tok/s' : '–'}`,
+      sub: catalogMessage('dashboard.models.stat.median', { value: isFinite(qmed('nimproxy_tokens_per_second', l => l.source === 'usage')) ? fmt(qmed('nimproxy_tokens_per_second', l => l.source === 'usage')) + ' tok/s' : '–' }),
       pts: avgSeries('nimproxy_tokens_per_second_sum', 'nimproxy_tokens_per_second_count') },
   ]);
 
@@ -212,8 +213,8 @@ function renderModels(c) {
     lineChart($(chartId), series, fmtV, { height: 120 });
     const b = wbuckets(metric, f);
     $(valId).innerHTML =
-      `<span><i data-style="background:${MED}"></i>median ${fmtV(quantile(b, 0.5))}</span>` +
-      `<span><i data-style="background:${P95}"></i>p95 ${fmtV(quantile(b, 0.95))}</span>`;
+      `<span><i data-style="background:${MED}"></i>${escapeHtml(catalogMessage('dashboard.models.stat.median', { value: fmtV(quantile(b, 0.5)) }))}</span>` +
+      `<span><i data-style="background:${P95}"></i>${escapeHtml(catalogMessage('dashboard.models.stat.p95', { value: fmtV(quantile(b, 0.95)) }))}</span>`;
   };
   quad('chart-ttft', 'q-ttft', 'nimproxy_ttft_seconds', null, secs);
   quad('chart-tps', 'q-tps', 'nimproxy_tokens_per_second', l => l.source === 'usage', v => isFinite(v) ? fmt(v) + ' tok/s' : '–');
@@ -229,7 +230,8 @@ function renderModels(c) {
     ['other', catalogMessage('dashboard.models.finish.other'), '']];
   const finByReason = Object.fromEntries(FINISH.map(([r]) => [r, wgroups('nimproxy_finish_reason_total', 'model', l => l.reason === r)]));
   const finModels = models.filter(m => finTotal.get(m));
-  $('m-fincount').textContent = finModels.length ? `${finModels.length} model${finModels.length === 1 ? '' : 's'}` : '';
+  if (finModels.length) setMessageText($('m-fincount'), modelCountId(finModels.length), { n: fmt(finModels.length) });
+  else $('m-fincount').replaceChildren();
   sortTable($('table-finish'), 'finish',
     [{ label: catalogMessage('dashboard.common.col.model'), align: 'l', str: true }, ...FINISH.map(([, l]) => ({ label: l }))],
     finModels.map(m => {
@@ -256,7 +258,7 @@ function renderModels(c) {
   if (tcModels.length) barList($('m-toolcalls'), tcModels.map(m => {
     const n = toolCalls.get(m) || 0, r = reqModels.get(m) || 0;
     return { name: m, label: prettyName(m), v: n,
-      vtext: fmt(n) + (r ? ` · ${fmt(n / r)}/req` : ''), color: publisher(m).color };
+      vtext: r ? catalogMessage('dashboard.models.stat.tool_calls_per_request', { calls: fmt(n), per_request: fmt(n / r) }) : fmt(n), color: publisher(m).color };
   }), fmt);
 
   /* scorecard (ex-Compare): best in each column highlighted, still sortable */
@@ -290,21 +292,20 @@ function renderModels(c) {
         <div><div class="mname" title="${escapeHtml(m)}">${escapeHtml(prettyName(m))}</div><div class="mpub">${escapeHtml(pub.name)}</div></div>
       </div>
       <div class="mstats">
-        ${stat('requests', fmt(reqModels.get(m) || 0))}
+        ${stat(catalogMessage('dashboard.common.col.requests'), fmt(reqModels.get(m) || 0))}
         ${stat(catalogMessage('dashboard.common.note.tokens_out'), fmt(ct))}
         ${stat('TTFT', ttftMC.get(m) ? secs(avgTtft(m)) : '–')}
         ${stat('tok/s', tpsMC.get(m) ? fmt(avgTps(m)) : '–')}
-        ${stat('errors', errPct(m), isFinite(e) && e > 0 ? 'critc' : 'dim')}
+        ${stat(catalogMessage('dashboard.models.col.errors'), errPct(m), isFinite(e) && e > 0 ? 'critc' : 'dim')}
       </div></div>`;
   }).join('') || `<div class="empty">${escapeHtml(catalogMessage('dashboard.common.empty.no_traffic'))}</div>`;
 
   /* per-model table */
-  const modelCount = $('m-tablecount');
+  const modelCountNode = $('m-tablecount');
   if (models.length) {
-    setMessageText(modelCount, 'dashboard.common.sort_hint');
-    modelCount.prepend(`${models.length} model${models.length === 1 ? '' : 's'} · `);
+    setMessageText(modelCountNode, modelCountWithSortId(models.length), { n: fmt(models.length) });
   } else {
-    modelCount.replaceChildren();
+    modelCountNode.replaceChildren();
   }
   sortTable($('table-models'), 'models', [
     { label: catalogMessage('dashboard.common.col.model'), align: 'l', str: true }, { label: catalogMessage('dashboard.common.col.requests') }, { label: catalogMessage('dashboard.common.col.tokens_out') },
@@ -457,11 +458,11 @@ function renderReliability(c) {
     <div data-style="display:flex;justify-content:space-between;align-items:center;margin-top:14px;padding-top:12px;border-top:1px solid var(--hairline)"><span class="tlabel">${escapeHtml(catalogMessage('dashboard.common.row.error_rate'))}</span><span data-style="font:600 15px var(--mono);color:${errN ? 'var(--red)' : 'var(--ink-3)'}">${wreq ? pctOf(errN / wreq, 1) : NO_VALUE}</span></div>
     <div class="segbar" data-style="height:6px;border-radius:99px;margin-top:8px;gap:1px">${taxCounts.length ? taxCounts.map(x => `<div data-style="width:${(x.n / taxTot * 100).toFixed(1)}%;background:${x.color}" title="${escapeHtml(x.label)}: ${fmt(x.n)}"></div>`).join('') : '<div data-style="width:100%;background:var(--track)"></div>'}</div>`;
 
-  lineChart($('chart-reqrate'), [{ name: 'requests/min', color: MED, pts: reqPts, area: true }], fmt, { height: 150 });
+  lineChart($('chart-reqrate'), [{ name: catalogMessage('dashboard.chart.requests_per_min'), color: MED, pts: reqPts, area: true }], fmt, { height: 150 });
   const outcomeSeries = [
-    { name: 'ok', color: css('--green'), f: l => IS_2XX(l.status) },
-    { name: 'errors', color: css('--red'), f: l => IS_ERR(l.status) },
-    { name: 'disconnects', color: css('--amber'), f: l => l.status === 'disconnect' },
+    { name: catalogMessage('dashboard.chart.success'), color: css('--green'), f: l => IS_2XX(l.status) },
+    { name: catalogMessage('dashboard.chart.errors'), color: css('--red'), f: l => IS_ERR(l.status) },
+    { name: catalogMessage('dashboard.chart.disconnects'), color: css('--amber'), f: l => l.status === 'disconnect' },
   ].map(({ name, color, f }) => ({ name, color, pts: rateSeries(s => sum(s.rows, 'nimproxy_requests_total', f)) }));
   lineChart($('chart-outcomes'), outcomeSeries, fmt, { height: 150 });
   legend($('legend-outcomes'), outcomeSeries);
@@ -486,8 +487,8 @@ function renderReliability(c) {
   stackChart($('chart-outcome-stack'), stackSeries, fmt, { height: 200 });
   legend($('legend-outcome-stack'), stackSeries);
   const loadSeries = [
-    { name: 'active', color: css('--green'), pts: samples.map(s => ({ t: s.t, v: sum(s.rows, 'nimproxy_active_requests') })) },
-    { name: 'queued', color: css('--amber'), pts: samples.map(s => ({ t: s.t, v: sum(s.rows, 'nimproxy_queue_depth') })) },
+    { name: catalogMessage('dashboard.chart.active'), color: css('--green'), pts: samples.map(s => ({ t: s.t, v: sum(s.rows, 'nimproxy_active_requests') })) },
+    { name: catalogMessage('dashboard.chart.queued'), color: css('--amber'), pts: samples.map(s => ({ t: s.t, v: sum(s.rows, 'nimproxy_queue_depth') })) },
   ];
   lineChart($('chart-load'), loadSeries, fmt, { height: 150 });
   legend($('legend-load'), loadSeries);
@@ -589,6 +590,69 @@ const LANE_COLORS = ['#76B900', '#4D6BFE', '#D9A521', '#16B8C0', '#615CED', '#EE
    categories English does not have. Ids are spelled out rather than built from
    the category, so the lint can still see them. */
 const KEY_PLURALS = new Intl.PluralRules(LOCALE);
+const errorCooldownSummary = (share, cooldowns) => {
+  const p = { pct: pctOf(share / 100, share && share < 10 ? 1 : 0), cooldowns: fmt(cooldowns) };
+  switch (KEY_PLURALS.select(cooldowns)) {
+    case 'zero': return catalogMessage('dashboard.overview.ring.errors.zero', p);
+    case 'one': return catalogMessage('dashboard.overview.ring.errors.one', p);
+    case 'two': return catalogMessage('dashboard.overview.ring.errors.two', p);
+    case 'few': return catalogMessage('dashboard.overview.ring.errors.few', p);
+    case 'many': return catalogMessage('dashboard.overview.ring.errors.many', p);
+    default: return catalogMessage('dashboard.overview.ring.errors.other', p);
+  }
+};
+const footerInfoId = (keys, auth) => {
+  if (auth) {
+    switch (KEY_PLURALS.select(keys)) {
+      case 'zero': return 'dashboard.nav.footer.api_key_required.zero';
+      case 'one': return 'dashboard.nav.footer.api_key_required.one';
+      case 'two': return 'dashboard.nav.footer.api_key_required.two';
+      case 'few': return 'dashboard.nav.footer.api_key_required.few';
+      case 'many': return 'dashboard.nav.footer.api_key_required.many';
+      default: return 'dashboard.nav.footer.api_key_required.other';
+    }
+  }
+  switch (KEY_PLURALS.select(keys)) {
+    case 'zero': return 'dashboard.nav.footer.open.zero';
+    case 'one': return 'dashboard.nav.footer.open.one';
+    case 'two': return 'dashboard.nav.footer.open.two';
+    case 'few': return 'dashboard.nav.footer.open.few';
+    case 'many': return 'dashboard.nav.footer.open.many';
+    default: return 'dashboard.nav.footer.open.other';
+  }
+};
+const capacityKeySummary = (rpmNow, capacity, n) => {
+  const p = { rpm_now: fmt(rpmNow), rpm_capacity: fmt(capacity), n: fmt(n) };
+  switch (KEY_PLURALS.select(n)) {
+    case 'zero': return catalogMessage('dashboard.overview.ring.capacity_sub.zero', p);
+    case 'one': return catalogMessage('dashboard.overview.ring.capacity_sub.one', p);
+    case 'two': return catalogMessage('dashboard.overview.ring.capacity_sub.two', p);
+    case 'few': return catalogMessage('dashboard.overview.ring.capacity_sub.few', p);
+    case 'many': return catalogMessage('dashboard.overview.ring.capacity_sub.many', p);
+    default: return catalogMessage('dashboard.overview.ring.capacity_sub.other', p);
+  }
+};
+const modelCountId = n => {
+  switch (KEY_PLURALS.select(n)) {
+    case 'zero': return 'dashboard.models.count.zero';
+    case 'one': return 'dashboard.models.count.one';
+    case 'two': return 'dashboard.models.count.two';
+    case 'few': return 'dashboard.models.count.few';
+    case 'many': return 'dashboard.models.count.many';
+    default: return 'dashboard.models.count.other';
+  }
+};
+const modelCount = n => catalogMessage(modelCountId(n), { n: fmt(n) });
+const modelCountWithSortId = n => {
+  switch (KEY_PLURALS.select(n)) {
+    case 'zero': return 'dashboard.models.count_with_sort.zero';
+    case 'one': return 'dashboard.models.count_with_sort.one';
+    case 'two': return 'dashboard.models.count_with_sort.two';
+    case 'few': return 'dashboard.models.count_with_sort.few';
+    case 'many': return 'dashboard.models.count_with_sort.many';
+    default: return 'dashboard.models.count_with_sort.other';
+  }
+};
 const enabledKeys = n => {
   const p = { n: fmt(n) };
   switch (KEY_PLURALS.select(n)) {
@@ -685,7 +749,7 @@ function renderCapacity(c) {
   const lanes = Array.from({ length: cfg.lanes }, (_, i) => {
     const k = String(i);
     const currentRpm = nowLaneRates.get(k) || 0;
-    return { i, name: `Slot ${i + 1}`, cur: laneWindow.get(k) || 0, currentRpm,
+    return { i, name: catalogMessage('dashboard.capacity.slot', { n: fmt(i + 1) }), cur: laneWindow.get(k) || 0, currentRpm,
       util: Math.min(1, currentRpm / Math.max(1, laneRpm(i))),
       b429: lane429.get(k) || 0, bOther: laneOther.get(k) || 0 };
   });
@@ -745,9 +809,11 @@ function applyNowConfig(next) {
     retention_days: +next.retention_days || 0,
     slo_target_percent: +next.slo_target_percent || 99.9,
   };
-  $('verinfo').textContent = `v${cfg.version} · ${cfg.lanes} keys · auth ${cfg.auth ? 'on' : 'off'}`;
+  setMessageText($('verinfo'), footerInfoId(cfg.lanes, cfg.auth), {
+    version: cfg.version, keys: fmt(cfg.lanes),
+  });
   const defaultButton = document.querySelector('#ranges [data-range="default"]');
-  if (defaultButton) defaultButton.textContent = `Default · ${cfg.default_window_days}d`;
+  if (defaultButton) setMessageText(defaultButton, 'dashboard.topbar.range.default_dynamic', { days: fmt(cfg.default_window_days) });
 }
 
 function followingBounds() {
@@ -762,11 +828,7 @@ function followingBounds() {
   return { from: Math.max(0, to - seconds), to };
 }
 
-function presetLabel() {
-  if (mode.preset === 'default') return `Default · ${cfg.default_window_days}d`;
-  if (mode.preset === 'all-retained') return 'All time';
-  return ({ '3600': '1h', '21600': '6h', '86400': '24h', '604800': '7d', '2592000': '30d' })[mode.preset] || '';
-}
+const presetLabel = () => document.querySelector(`#ranges [data-range="${mode.preset}"]`)?.textContent || '';
 
 const scopeDate = seconds => at(DAY_SHORT, seconds * 1000);
 const scopeTime = seconds => at(SCOPE_TIME, seconds * 1000);
@@ -777,15 +839,17 @@ function updateScope() {
     nowData?.tail?.base_history_revision === rangeData.history_revision ? nowData.tail : null;
   const hasTraffic = mode.paused ? frozenHasTraffic : hasSelectedRequestTraffic(samples);
   if (!hasTraffic) {
-    $('rangeinfo').textContent = 'No data in selected time range';
+    setMessageText($('rangeinfo'), 'dashboard.common.empty.no_data_in_range');
     return;
   }
   const from = mode.paused ? mode.from : rangeData.window.effective_from ?? mode.from;
   const to = mode.paused ? mode.to : tail?.to ?? rangeData.window.effective_to ?? mode.to;
   if (mode.kind === 'following' && !mode.paused) {
-    $('rangeinfo').textContent = `● Live    ${presetLabel()}    ${scopeDate(from)} – ${scopeDate(to)}`;
+    setMessageText($('rangeinfo'), 'dashboard.topbar.scope.following', {
+      preset: presetLabel(), from: scopeDate(from), to: scopeDate(to),
+    });
   } else {
-    $('rangeinfo').textContent = `○ Absolute    ${scopeTime(from)} – ${scopeTime(to)}`;
+    setMessageText($('rangeinfo'), 'dashboard.topbar.scope.absolute', { from: scopeTime(from), to: scopeTime(to) });
   }
 }
 
@@ -887,7 +951,7 @@ for (const b of document.querySelectorAll('#ranges button')) {
       try {
         if (await refreshSelectedRange()) render();
       } catch {
-        $('rangeinfo').textContent = 'Failed to load time range';
+        setMessageText($('rangeinfo'), 'dashboard.topbar.error.load');
       }
     }
   });
@@ -901,7 +965,7 @@ $('applyRange').addEventListener('click', async () => {
   try {
     if (await refreshSelectedRange()) render();
   } catch {
-    $('rangeinfo').textContent = 'Failed to load time range';
+    setMessageText($('rangeinfo'), 'dashboard.topbar.error.load');
   }
 });
 $('live').addEventListener('click', async () => {
@@ -919,7 +983,7 @@ $('live').addEventListener('click', async () => {
     try {
       if (await refreshSelectedRange()) render();
     } catch {
-      $('rangeinfo').textContent = 'Failed to resume time range';
+      setMessageText($('rangeinfo'), 'dashboard.topbar.error.resume');
     }
   }
   syncFollowControl();

--- a/src/web/locales/en-US.json
+++ b/src/web/locales/en-US.json
@@ -1074,6 +1074,583 @@
       "desc": "Username input placeholder.",
       "hash": "e3b89e9d"
     },
+    "settings.account.confirm_password": {
+      "en": "Confirm new password",
+      "hash": "bf000421"
+    },
+    "settings.account.current_password": {
+      "en": "Current password",
+      "hash": "72ed2bd7"
+    },
+    "settings.account.heading": {
+      "en": "Account",
+      "hash": "7e1b0d56"
+    },
+    "settings.account.new_password": {
+      "en": "New password · at least 10 characters",
+      "hash": "24a62e18"
+    },
+    "settings.account.note": {
+      "en": "Changing your password signs out your other sessions.",
+      "hash": "eff3bf4c"
+    },
+    "settings.account.update": {
+      "en": "Update password",
+      "hash": "fe45b401"
+    },
+    "settings.account.username": {
+      "en": "Username",
+      "hash": "e3b89e9d"
+    },
+    "settings.client_key.empty": {
+      "en": "No client keys yet",
+      "hash": "27a9a0bf"
+    },
+    "settings.client_key.generate": {
+      "en": "+ Generate key",
+      "hash": "92abcd19"
+    },
+    "settings.client_key.heading.all": {
+      "en": "Client API keys",
+      "hash": "d82056dd"
+    },
+    "settings.client_key.heading.mine": {
+      "en": "My client API keys",
+      "hash": "57621a6e"
+    },
+    "settings.client_key.note": {
+      "en": "These bearer tokens authenticate your clients.",
+      "hash": "2cde1ba8"
+    },
+    "settings.client_key.placeholder": {
+      "en": "name this key, e.g. laptop-cli",
+      "hash": "70a0d9c2"
+    },
+    "settings.client_key.revoke": {
+      "en": "Revoke",
+      "hash": "87e6d00b"
+    },
+    "settings.common.done": {
+      "en": "Done",
+      "hash": "11a6767d"
+    },
+    "settings.common.save": {
+      "en": "Save",
+      "hash": "1509f561"
+    },
+    "settings.connection.base_url": {
+      "en": "Client base URL",
+      "hash": "32444228"
+    },
+    "settings.connection.heading": {
+      "en": "Connection",
+      "hash": "639a40e8"
+    },
+    "settings.copy.copied": {
+      "en": "Copied ✓",
+      "hash": "58d73ef4"
+    },
+    "settings.copy.copy": {
+      "en": "Copy",
+      "hash": "e21f935f"
+    },
+    "settings.copy.failed": {
+      "en": "Copy failed",
+      "hash": "5b50e7a6"
+    },
+    "settings.dialog.delete_user": {
+      "en": "Delete {username}? Their NIM API keys leave the pool and their client API keys are revoked.",
+      "hash": "56bdc932"
+    },
+    "settings.dialog.remove_key": {
+      "en": "Remove NIM API key nvapi-••••{last4} from the pool? In-flight requests finish, but its rate-limit window is lost.",
+      "hash": "73435aa0"
+    },
+    "settings.dialog.reset_password": {
+      "en": "New password for {username} (at least 10 characters):",
+      "hash": "338150d4"
+    },
+    "settings.dialog.revoke_client_key": {
+      "en": "Revoke client API key \"{name}\"? Clients using it stop working immediately.",
+      "hash": "5fb2a465"
+    },
+    "settings.error.load": {
+      "en": "Could not load Settings. Reload the page and sign in again.",
+      "hash": "caed8f2c"
+    },
+    "settings.error.request_failed": {
+      "en": "Request failed (HTTP {status}).",
+      "hash": "3692891d"
+    },
+    "settings.key.add_anyway": {
+      "en": "Add anyway",
+      "hash": "d0652ad3"
+    },
+    "settings.key.empty": {
+      "en": "No NIM API keys yet — add one below",
+      "hash": "fa52e200"
+    },
+    "settings.key.guarded": {
+      "en": "Protected: the superuser must keep at least one enabled NIM API key. Add or enable another before removing this one.",
+      "hash": "8f84df6b"
+    },
+    "settings.key.heading.all": {
+      "en": "NIM API keys",
+      "hash": "11fdda21"
+    },
+    "settings.key.heading.mine": {
+      "en": "My NIM API keys",
+      "hash": "af1c4f87"
+    },
+    "settings.key.notice.admin": {
+      "en": "Keys you add are assigned to your account and join the shared pool. Changes take effect immediately. Disabling a key preserves its rate-limit state.",
+      "hash": "4b69ae49"
+    },
+    "settings.key.notice.mine": {
+      "en": "Keys you add are assigned to your account and join the shared pool. Only you and admins can see that they exist. Changes take effect immediately. Disabling a key preserves its rate-limit state.",
+      "hash": "124f2a6c"
+    },
+    "settings.key.off": {
+      "en": "Disabled",
+      "hash": "75081b59"
+    },
+    "settings.key.placeholder": {
+      "en": "Paste a new NIM API key (nvapi-…)",
+      "hash": "4c922c00"
+    },
+    "settings.key.pool_note": {
+      "en": "Pool: {enabled} enabled · Total: {capacity} rpm",
+      "hash": "c2936548"
+    },
+    "settings.key.remove": {
+      "en": "Remove NIM API key",
+      "hash": "d15bafa9"
+    },
+    "settings.key.slot": {
+      "en": "Slot {n}",
+      "hash": "18616a78"
+    },
+    "settings.key.state.cooldown": {
+      "en": "cooldown {seconds}s",
+      "hash": "b35f8e5e"
+    },
+    "settings.key.state.disabled": {
+      "en": "Disabled",
+      "hash": "75081b59"
+    },
+    "settings.key.state.in_window": {
+      "en": "{in_window} / {rpm} in window",
+      "hash": "773cf007"
+    },
+    "settings.key.state.unassigned": {
+      "en": "Unassigned",
+      "hash": "14d33bd0"
+    },
+    "settings.key.toggle.disable": {
+      "en": "Disable. Rate-limit state is preserved.",
+      "hash": "48b5c705"
+    },
+    "settings.key.toggle.enable": {
+      "en": "Enable",
+      "hash": "5342e09f"
+    },
+    "settings.key.validate_add": {
+      "en": "Validate & add",
+      "hash": "15414785"
+    },
+    "settings.key.validating": {
+      "en": "Validating…",
+      "hash": "cd51f8c8"
+    },
+    "settings.mode.heading": {
+      "en": "API access mode",
+      "hash": "4668b68f"
+    },
+    "settings.mode.help": {
+      "en": "Controls /v1 client calls only. In API key required mode, clients use a bearer token. Open (no authentication) allows anyone who can reach /v1. Use only on trusted networks.",
+      "desc": "Full API access-mode explanation. This is deliberately one plain catalog sentence; the former bold literals are not parsed or reassembled at runtime.",
+      "hash": "3431dd52"
+    },
+    "settings.mode.keyed": {
+      "en": "API key required",
+      "hash": "3b855d54"
+    },
+    "settings.mode.keyed_note": {
+      "en": "Clients authenticate with a client API key.",
+      "hash": "7fd7e1d1"
+    },
+    "settings.mode.no_client_keys": {
+      "en": "Requiring an API key with no client API keys locks every client out. Generate one under Access & keys.",
+      "hash": "d3d6605c"
+    },
+    "settings.mode.open": {
+      "en": "Open (no authentication)",
+      "hash": "17759351"
+    },
+    "settings.mode.open_note": {
+      "en": "Anyone who can reach /v1 can use the pool.",
+      "hash": "d9251b4a"
+    },
+    "settings.nav.access": {
+      "en": "Access & keys",
+      "hash": "bb83749e"
+    },
+    "settings.nav.account": {
+      "en": "Account",
+      "hash": "7e1b0d56"
+    },
+    "settings.nav.server": {
+      "en": "Server",
+      "hash": "aef7de28"
+    },
+    "settings.nav.users": {
+      "en": "Users",
+      "hash": "6b0cc904"
+    },
+    "settings.secret.copy": {
+      "en": "Copy",
+      "hash": "e21f935f"
+    },
+    "settings.secret.ready": {
+      "en": "Client API key “{name}” is ready. Copy it now.",
+      "hash": "942f7f44"
+    },
+    "settings.secret.warning": {
+      "en": "You won't see this again.",
+      "hash": "8452e785"
+    },
+    "settings.server.adaptive": {
+      "en": "Automatic",
+      "hash": "d461a493"
+    },
+    "settings.server.add_override": {
+      "en": "Add override",
+      "hash": "fafc22c3"
+    },
+    "settings.server.base_url_note": {
+      "en": "Saving changes the upstream base URL and clears the model catalog cache.",
+      "hash": "eefdd484"
+    },
+    "settings.server.days": {
+      "en": "days",
+      "hash": "ab51004e"
+    },
+    "settings.server.history.bytes.few": {
+      "en": "{bytes} bytes",
+      "desc": "CLDR plural category 'few' for the history data-file size. {bytes} is already locale-formatted; English repeats the other form.",
+      "hash": "31800b69"
+    },
+    "settings.server.history.bytes.many": {
+      "en": "{bytes} bytes",
+      "desc": "CLDR plural category 'many' for the history data-file size. {bytes} is already locale-formatted; English repeats the other form.",
+      "hash": "31800b69"
+    },
+    "settings.server.history.bytes.one": {
+      "en": "{bytes} byte",
+      "desc": "CLDR plural category 'one' for the history data-file size. {bytes} is already locale-formatted.",
+      "hash": "51bd3673"
+    },
+    "settings.server.history.bytes.other": {
+      "en": "{bytes} bytes",
+      "desc": "CLDR plural category 'other' for the history data-file size. {bytes} is already locale-formatted.",
+      "hash": "31800b69"
+    },
+    "settings.server.history.bytes.two": {
+      "en": "{bytes} bytes",
+      "desc": "CLDR plural category 'two' for the history data-file size. {bytes} is already locale-formatted; English repeats the other form.",
+      "hash": "31800b69"
+    },
+    "settings.server.history.bytes.zero": {
+      "en": "{bytes} bytes",
+      "desc": "CLDR plural category 'zero' for the history data-file size. {bytes} is already locale-formatted; English repeats the other form.",
+      "hash": "31800b69"
+    },
+    "settings.server.history.compaction_pending": {
+      "en": "Compaction is pending.",
+      "hash": "1260d448"
+    },
+    "settings.server.history.data_file": {
+      "en": "Data file",
+      "hash": "38f5f508"
+    },
+    "settings.server.history.default_range": {
+      "en": "Default time range",
+      "hash": "5ec3c658"
+    },
+    "settings.server.history.heading": {
+      "en": "History & dashboard",
+      "hash": "d0c9c7aa"
+    },
+    "settings.server.history.no_data": {
+      "en": "No data yet",
+      "hash": "e2e18a76"
+    },
+    "settings.server.history.oldest": {
+      "en": "Oldest data point",
+      "hash": "ef4ab020"
+    },
+    "settings.server.history.retention": {
+      "en": "History retention · 0 = unlimited",
+      "hash": "c137c172"
+    },
+    "settings.server.history.slo": {
+      "en": "Availability SLO",
+      "hash": "226f7fe9"
+    },
+    "settings.server.limit.heartbeat": {
+      "en": "Heartbeat",
+      "hash": "9df89427"
+    },
+    "settings.server.limit.max_inflight": {
+      "en": "Max in-flight",
+      "hash": "ea457682"
+    },
+    "settings.server.limit.max_wait": {
+      "en": "Max wait",
+      "hash": "c2cd8e04"
+    },
+    "settings.server.limit.models_ttl": {
+      "en": "Model cache TTL",
+      "hash": "cbd325d5"
+    },
+    "settings.server.limit.request_timeout": {
+      "en": "Request timeout",
+      "hash": "70f60044"
+    },
+    "settings.server.limit.stream_idle": {
+      "en": "Stream idle timeout",
+      "hash": "c81a6778"
+    },
+    "settings.server.model_limits": {
+      "en": "Model limits",
+      "hash": "43e77160"
+    },
+    "settings.server.model_limits_help": {
+      "en": "Limits concurrent requests per model when NIM reports worker exhaustion. Limits adjust automatically; add an override only for a known concurrency limit.",
+      "hash": "e091e076"
+    },
+    "settings.server.model_placeholder": {
+      "en": "model id, e.g. moonshotai/kimi-k2.5",
+      "hash": "26ae28e9"
+    },
+    "settings.server.no_overrides": {
+      "en": "No overrides set",
+      "hash": "3cbc17e7"
+    },
+    "settings.server.remove_override": {
+      "en": "Remove override",
+      "hash": "6d43eea1"
+    },
+    "settings.server.strict_note": {
+      "en": "Rejects parameters the upstream does not accept.",
+      "hash": "4e5f898d"
+    },
+    "settings.server.strict_passthrough": {
+      "en": "Strict passthrough",
+      "hash": "75005c81"
+    },
+    "settings.server.unit.limit": {
+      "en": "concurrent",
+      "hash": "a35178ec"
+    },
+    "settings.server.unit.seconds": {
+      "en": "s",
+      "hash": "043a7187"
+    },
+    "settings.server.upstream_limits": {
+      "en": "Upstream & limits",
+      "hash": "e1ebfed2"
+    },
+    "settings.users.add": {
+      "en": "Add user",
+      "hash": "eec5c73a"
+    },
+    "settings.users.client_key_count.few": {
+      "en": "{n} client API keys",
+      "desc": "CLDR plural category 'few' for the user's client API key count. {n} is already locale-formatted; English repeats the other form.",
+      "hash": "db3cf8c9"
+    },
+    "settings.users.client_key_count.many": {
+      "en": "{n} client API keys",
+      "desc": "CLDR plural category 'many' for the user's client API key count. {n} is already locale-formatted; English repeats the other form.",
+      "hash": "db3cf8c9"
+    },
+    "settings.users.client_key_count.one": {
+      "en": "{n} client API key",
+      "desc": "CLDR plural category 'one' for the user's client API key count. {n} is already locale-formatted.",
+      "hash": "591f6a81"
+    },
+    "settings.users.client_key_count.other": {
+      "en": "{n} client API keys",
+      "desc": "CLDR plural category 'other' for the user's client API key count. {n} is already locale-formatted.",
+      "hash": "db3cf8c9"
+    },
+    "settings.users.client_key_count.two": {
+      "en": "{n} client API keys",
+      "desc": "CLDR plural category 'two' for the user's client API key count. {n} is already locale-formatted; English repeats the other form.",
+      "hash": "db3cf8c9"
+    },
+    "settings.users.client_key_count.zero": {
+      "en": "{n} client API keys",
+      "desc": "CLDR plural category 'zero' for the user's client API key count. {n} is already locale-formatted; English repeats the other form.",
+      "hash": "db3cf8c9"
+    },
+    "settings.users.delete": {
+      "en": "Delete",
+      "hash": "e2d0a549"
+    },
+    "settings.users.heading": {
+      "en": "Users",
+      "hash": "6b0cc904"
+    },
+    "settings.users.nim_key_count.few": {
+      "en": "{n} NIM API keys",
+      "desc": "CLDR plural category 'few' for the user's NIM API key count. {n} is already locale-formatted; English repeats the other form.",
+      "hash": "e964131c"
+    },
+    "settings.users.nim_key_count.many": {
+      "en": "{n} NIM API keys",
+      "desc": "CLDR plural category 'many' for the user's NIM API key count. {n} is already locale-formatted; English repeats the other form.",
+      "hash": "e964131c"
+    },
+    "settings.users.nim_key_count.one": {
+      "en": "{n} NIM API key",
+      "desc": "CLDR plural category 'one' for the user's NIM API key count. {n} is already locale-formatted.",
+      "hash": "edbe8c52"
+    },
+    "settings.users.nim_key_count.other": {
+      "en": "{n} NIM API keys",
+      "desc": "CLDR plural category 'other' for the user's NIM API key count. {n} is already locale-formatted.",
+      "hash": "e964131c"
+    },
+    "settings.users.nim_key_count.two": {
+      "en": "{n} NIM API keys",
+      "desc": "CLDR plural category 'two' for the user's NIM API key count. {n} is already locale-formatted; English repeats the other form.",
+      "hash": "e964131c"
+    },
+    "settings.users.nim_key_count.zero": {
+      "en": "{n} NIM API keys",
+      "desc": "CLDR plural category 'zero' for the user's NIM API key count. {n} is already locale-formatted; English repeats the other form.",
+      "hash": "e964131c"
+    },
+    "settings.users.note": {
+      "en": "Deleting a user removes their NIM API keys from the pool and revokes their client API keys.",
+      "hash": "10877a46"
+    },
+    "settings.users.password_placeholder": {
+      "en": "initial password (10+ characters)",
+      "hash": "460b4335"
+    },
+    "settings.users.reset_password": {
+      "en": "Reset password",
+      "hash": "e0edfeb3"
+    },
+    "settings.users.role": {
+      "en": "Role",
+      "hash": "14736a2e"
+    },
+    "settings.users.self_managed": {
+      "en": "Self-managed",
+      "hash": "122c90c3"
+    },
+    "settings.users.superuser_note": {
+      "en": "The superuser changes its own password in Account settings.",
+      "hash": "cf3196cb"
+    },
+    "settings.users.username_placeholder": {
+      "en": "new username",
+      "hash": "534c560d"
+    },
+    "settings.validation.client_key_name": {
+      "en": "Enter a client API key name, for example laptop-cli.",
+      "hash": "75659563"
+    },
+    "settings.validation.governor": {
+      "en": "Enter a model ID and a concurrency limit of at least 1.",
+      "hash": "82446307"
+    },
+    "settings.validation.history_default": {
+      "en": "Default time range must be at least 1 day.",
+      "hash": "d0de6732"
+    },
+    "settings.validation.history_retention": {
+      "en": "History retention must be 0 or more days.",
+      "hash": "6f5ebc67"
+    },
+    "settings.validation.initial_password": {
+      "en": "Initial password must be at least 10 characters.",
+      "hash": "fd6c7b3d"
+    },
+    "settings.validation.limits": {
+      "en": "Every limit needs a whole number ≥ 0.",
+      "hash": "bd14b8f3"
+    },
+    "settings.validation.models_added.few": {
+      "en": "✓ {n} models found. Adding NIM API key…",
+      "desc": "CLDR plural category 'few' for successful NIM API key validation. {n} is the number of returned models and is already locale-formatted; English repeats the other form.",
+      "hash": "8325eafc"
+    },
+    "settings.validation.models_added.many": {
+      "en": "✓ {n} models found. Adding NIM API key…",
+      "desc": "CLDR plural category 'many' for successful NIM API key validation. {n} is the number of returned models and is already locale-formatted; English repeats the other form.",
+      "hash": "8325eafc"
+    },
+    "settings.validation.models_added.one": {
+      "en": "✓ {n} model found. Adding NIM API key…",
+      "desc": "CLDR plural category 'one' for successful NIM API key validation. {n} is the number of returned models and is already locale-formatted.",
+      "hash": "c1e489e4"
+    },
+    "settings.validation.models_added.other": {
+      "en": "✓ {n} models found. Adding NIM API key…",
+      "desc": "CLDR plural category 'other' for successful NIM API key validation. {n} is the number of returned models and is already locale-formatted.",
+      "hash": "8325eafc"
+    },
+    "settings.validation.models_added.two": {
+      "en": "✓ {n} models found. Adding NIM API key…",
+      "desc": "CLDR plural category 'two' for successful NIM API key validation. {n} is the number of returned models and is already locale-formatted; English repeats the other form.",
+      "hash": "8325eafc"
+    },
+    "settings.validation.models_added.zero": {
+      "en": "✓ {n} models found. Adding NIM API key…",
+      "desc": "CLDR plural category 'zero' for successful NIM API key validation. {n} is the number of returned models and is already locale-formatted; English repeats the other form.",
+      "hash": "8325eafc"
+    },
+    "settings.validation.new_password": {
+      "en": "New password must be at least 10 characters.",
+      "hash": "cbe2939e"
+    },
+    "settings.validation.nim_key_required": {
+      "en": "Paste a NIM API key first.",
+      "hash": "45e7e8a4"
+    },
+    "settings.validation.password": {
+      "en": "Password must be at least 10 characters.",
+      "hash": "7e65d20b"
+    },
+    "settings.validation.password_mismatch": {
+      "en": "Passwords do not match.",
+      "hash": "6c6e178a"
+    },
+    "settings.validation.password_reset": {
+      "en": "Password reset for {username}.",
+      "hash": "42bdd256"
+    },
+    "settings.validation.password_updated": {
+      "en": "Password updated. Other sessions were signed out.",
+      "hash": "3856551c"
+    },
+    "settings.validation.saved": {
+      "en": "Saved.",
+      "hash": "fca046cc"
+    },
+    "settings.validation.slo": {
+      "en": "SLO target must be greater than 0 and at most 100.",
+      "hash": "90bf3754"
+    },
+    "settings.validation.username": {
+      "en": "Choose a username.",
+      "hash": "b9305ea3"
+    },
     "setup.document.title": {
       "en": "NIM Proxy — First-time setup",
       "desc": "Browser tab title. 'NIM Proxy' is the product name and stays.",

--- a/src/web/locales/en-US.json
+++ b/src/web/locales/en-US.json
@@ -7,6 +7,10 @@
       "desc": "Product name.",
       "hash": "1e2b099a"
     },
+    "dashboard.brand.proxy": {
+      "en": "Proxy",
+      "hash": "a68ee416"
+    },
     "dashboard.capacity.col.429s": {
       "en": "429s",
       "desc": "Column header. '429' is an HTTP status and must survive verbatim.",
@@ -132,6 +136,42 @@
     "dashboard.capacity.row.slots_in_use": {
       "en": "Enabled keys",
       "hash": "226de726"
+    },
+    "dashboard.capacity.slot": {
+      "en": "Slot {n}",
+      "hash": "18616a78"
+    },
+    "dashboard.chart.active": {
+      "en": "Active",
+      "hash": "92340695"
+    },
+    "dashboard.chart.disconnects": {
+      "en": "Disconnects",
+      "hash": "5c92edf8"
+    },
+    "dashboard.chart.errors": {
+      "en": "Errors",
+      "hash": "cb702378"
+    },
+    "dashboard.chart.median": {
+      "en": "median",
+      "hash": "7896a617"
+    },
+    "dashboard.chart.p95": {
+      "en": "p95",
+      "hash": "f771f4d3"
+    },
+    "dashboard.chart.queued": {
+      "en": "Queued",
+      "hash": "661ff40a"
+    },
+    "dashboard.chart.requests_per_min": {
+      "en": "Requests/min",
+      "hash": "ee05a90c"
+    },
+    "dashboard.chart.success": {
+      "en": "Success",
+      "hash": "c88a0b90"
     },
     "dashboard.clients.depth.heading": {
       "en": "Conversation depth",
@@ -415,6 +455,10 @@
       "desc": "Badge on a card heading: this figure is the live instant, not an aggregate over the selected time range. Adverb of time.",
       "hash": "fe18013d"
     },
+    "dashboard.common.value.now": {
+      "en": "{value} now",
+      "hash": "dc1a4806"
+    },
     "dashboard.modal.secret.heading": {
       "en": "One-time secret",
       "hash": "04a195c4"
@@ -449,6 +493,54 @@
     "dashboard.models.col.truncated": {
       "en": "Truncated",
       "hash": "d9d9fcf3"
+    },
+    "dashboard.models.count.few": {
+      "en": "{n} models",
+      "hash": "a394ccda"
+    },
+    "dashboard.models.count.many": {
+      "en": "{n} models",
+      "hash": "a394ccda"
+    },
+    "dashboard.models.count.one": {
+      "en": "{n} model",
+      "hash": "8044e016"
+    },
+    "dashboard.models.count.other": {
+      "en": "{n} models",
+      "hash": "a394ccda"
+    },
+    "dashboard.models.count.two": {
+      "en": "{n} models",
+      "hash": "a394ccda"
+    },
+    "dashboard.models.count.zero": {
+      "en": "{n} models",
+      "hash": "a394ccda"
+    },
+    "dashboard.models.count_with_sort.few": {
+      "en": "{n} models · click a column to sort",
+      "hash": "b8a32ca0"
+    },
+    "dashboard.models.count_with_sort.many": {
+      "en": "{n} models · click a column to sort",
+      "hash": "b8a32ca0"
+    },
+    "dashboard.models.count_with_sort.one": {
+      "en": "{n} model · click a column to sort",
+      "hash": "148617d0"
+    },
+    "dashboard.models.count_with_sort.other": {
+      "en": "{n} models · click a column to sort",
+      "hash": "b8a32ca0"
+    },
+    "dashboard.models.count_with_sort.two": {
+      "en": "{n} models · click a column to sort",
+      "hash": "b8a32ca0"
+    },
+    "dashboard.models.count_with_sort.zero": {
+      "en": "{n} models · click a column to sort",
+      "hash": "b8a32ca0"
     },
     "dashboard.models.empty.no_reasoning": {
       "en": "No reasoning tokens",
@@ -525,6 +617,18 @@
       "en": "top models head to head · best in each column highlighted",
       "hash": "91939a12"
     },
+    "dashboard.models.stat.median": {
+      "en": "median {value}",
+      "hash": "6a59ac2c"
+    },
+    "dashboard.models.stat.p95": {
+      "en": "p95 {value}",
+      "hash": "1b5e500c"
+    },
+    "dashboard.models.stat.tool_calls_per_request": {
+      "en": "{calls} · {per_request}/req",
+      "hash": "321ebcce"
+    },
     "dashboard.models.tokens_per_min.heading": {
       "en": "Completion tokens per minute",
       "hash": "0b7c1721"
@@ -548,6 +652,54 @@
     "dashboard.models.upstream.heading": {
       "en": "Upstream latency",
       "hash": "4d1a7ea7"
+    },
+    "dashboard.nav.footer.api_key_required.few": {
+      "en": "v{version} · {keys} keys · API key required",
+      "hash": "d0138474"
+    },
+    "dashboard.nav.footer.api_key_required.many": {
+      "en": "v{version} · {keys} keys · API key required",
+      "hash": "d0138474"
+    },
+    "dashboard.nav.footer.api_key_required.one": {
+      "en": "v{version} · {keys} key · API key required",
+      "hash": "2495b67e"
+    },
+    "dashboard.nav.footer.api_key_required.other": {
+      "en": "v{version} · {keys} keys · API key required",
+      "hash": "d0138474"
+    },
+    "dashboard.nav.footer.api_key_required.two": {
+      "en": "v{version} · {keys} keys · API key required",
+      "hash": "d0138474"
+    },
+    "dashboard.nav.footer.api_key_required.zero": {
+      "en": "v{version} · {keys} keys · API key required",
+      "hash": "d0138474"
+    },
+    "dashboard.nav.footer.open.few": {
+      "en": "v{version} · {keys} keys · Open (no authentication)",
+      "hash": "6b524fb3"
+    },
+    "dashboard.nav.footer.open.many": {
+      "en": "v{version} · {keys} keys · Open (no authentication)",
+      "hash": "6b524fb3"
+    },
+    "dashboard.nav.footer.open.one": {
+      "en": "v{version} · {keys} key · Open (no authentication)",
+      "hash": "094c6383"
+    },
+    "dashboard.nav.footer.open.other": {
+      "en": "v{version} · {keys} keys · Open (no authentication)",
+      "hash": "6b524fb3"
+    },
+    "dashboard.nav.footer.open.two": {
+      "en": "v{version} · {keys} keys · Open (no authentication)",
+      "hash": "6b524fb3"
+    },
+    "dashboard.nav.footer.open.zero": {
+      "en": "v{version} · {keys} keys · Open (no authentication)",
+      "hash": "6b524fb3"
     },
     "dashboard.nav.live.connecting": {
       "en": "connecting",
@@ -601,6 +753,14 @@
       "en": "Capacity & reliability",
       "hash": "fa267d5d"
     },
+    "dashboard.overview.kpi.success_counts": {
+      "en": "{ok} of {requests}",
+      "hash": "b15c5ac8"
+    },
+    "dashboard.overview.kpi.tokens_in": {
+      "en": "{tokens} in",
+      "hash": "b48a8ba7"
+    },
     "dashboard.overview.perf.higher_is_better": {
       "en": "higher is better",
       "desc": "Note beside a throughput distribution: larger numbers are better. Lowercase, sits under the card heading.",
@@ -619,10 +779,58 @@
       "en": "median & p95 across the time range",
       "hash": "3f0caaba"
     },
+    "dashboard.overview.ring.capacity_sub.few": {
+      "en": "{rpm_now} / {rpm_capacity} rpm · {n} keys",
+      "hash": "9fa2e113"
+    },
+    "dashboard.overview.ring.capacity_sub.many": {
+      "en": "{rpm_now} / {rpm_capacity} rpm · {n} keys",
+      "hash": "9fa2e113"
+    },
+    "dashboard.overview.ring.capacity_sub.one": {
+      "en": "{rpm_now} / {rpm_capacity} rpm · {n} key",
+      "hash": "ba394345"
+    },
+    "dashboard.overview.ring.capacity_sub.other": {
+      "en": "{rpm_now} / {rpm_capacity} rpm · {n} keys",
+      "hash": "9fa2e113"
+    },
+    "dashboard.overview.ring.capacity_sub.two": {
+      "en": "{rpm_now} / {rpm_capacity} rpm · {n} keys",
+      "hash": "9fa2e113"
+    },
+    "dashboard.overview.ring.capacity_sub.zero": {
+      "en": "{rpm_now} / {rpm_capacity} rpm · {n} keys",
+      "hash": "9fa2e113"
+    },
     "dashboard.overview.ring.capacity_used": {
       "en": "Capacity used",
       "desc": "Ring-gauge label. Share of the key pool's configured requests-per-minute currently in use.",
       "hash": "9448656c"
+    },
+    "dashboard.overview.ring.errors.few": {
+      "en": "errors {pct} · {cooldowns} cooldowns",
+      "hash": "17ac4dc4"
+    },
+    "dashboard.overview.ring.errors.many": {
+      "en": "errors {pct} · {cooldowns} cooldowns",
+      "hash": "17ac4dc4"
+    },
+    "dashboard.overview.ring.errors.one": {
+      "en": "errors {pct} · {cooldowns} cooldown",
+      "hash": "0e735443"
+    },
+    "dashboard.overview.ring.errors.other": {
+      "en": "errors {pct} · {cooldowns} cooldowns",
+      "hash": "17ac4dc4"
+    },
+    "dashboard.overview.ring.errors.two": {
+      "en": "errors {pct} · {cooldowns} cooldowns",
+      "hash": "17ac4dc4"
+    },
+    "dashboard.overview.ring.errors.zero": {
+      "en": "errors {pct} · {cooldowns} cooldowns",
+      "hash": "17ac4dc4"
     },
     "dashboard.overview.top_clients.heading": {
       "en": "Top clients",
@@ -778,6 +986,14 @@
       "desc": "Separator between the from and to datetime inputs. Preposition, not a verb.",
       "hash": "663ea1bf"
     },
+    "dashboard.topbar.error.load": {
+      "en": "Failed to load time range",
+      "hash": "3f4d86a6"
+    },
+    "dashboard.topbar.error.resume": {
+      "en": "Failed to resume time range",
+      "hash": "5bcd9d8e"
+    },
     "dashboard.topbar.range.all_time": {
       "en": "All time",
       "hash": "9755c8d7"
@@ -791,6 +1007,10 @@
       "en": "Default · 30d",
       "desc": "Toggle button. 'Default' is an adjective qualifying the preset time range; 30d is its length.",
       "hash": "4c1bd988"
+    },
+    "dashboard.topbar.range.default_dynamic": {
+      "en": "Default · {days}d",
+      "hash": "b8f2d75f"
     },
     "dashboard.topbar.range.p1h": {
       "en": "1h",
@@ -816,6 +1036,14 @@
       "en": "7d",
       "desc": "Short duration abbreviation on a time-range pill.",
       "hash": "a7c74264"
+    },
+    "dashboard.topbar.scope.absolute": {
+      "en": "○ Absolute {from} – {to}",
+      "hash": "49041a3c"
+    },
+    "dashboard.topbar.scope.following": {
+      "en": "● Live {preset} {from} – {to}",
+      "hash": "f24435d2"
     },
     "login.document.title": {
       "en": "NIM Proxy — Sign in",

--- a/src/web/settings.js
+++ b/src/web/settings.js
@@ -7,18 +7,28 @@ let SET = null, setSub = 'access';
 async function sPost(path, body) {
   const r = await fetch(path, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
   let j = {}; try { j = await r.json(); } catch {}
-  if (!r.ok || j.ok === false) throw new Error((j.error && j.error.message) || j.error || `Request failed (${r.status})`);
+  const apiError = typeof j.error === 'string'
+    ? j.error
+    : (j.error && typeof j.error.message === 'string' ? j.error.message : '');
+  if (!r.ok || j.ok === false)
+    throw new Error(apiError || message('settings.error.request_failed', { status: r.status }));
   return j;
 }
 /* inline feedback next to the control that caused it (textContent — never markup) */
 const note = (id, msg, ok) => { const el = $(id); if (el) { el.textContent = msg || ''; el.classList.toggle('ok', !!ok); } };
+const noteMessage = (id, messageId, params = {}, ok = false) => {
+  const el = $(id);
+  if (!el) return;
+  setMessageText(el, messageId, params);
+  el.classList.toggle('ok', ok);
+};
 
 async function loadSettings() {
   try {
     const j = await (await fetch('/api/config')).json();
     if (!j.nim_keys) throw 0;
     SET = j;
-  } catch { $('setbody').innerHTML = '<div class="empty">Could not load settings — reload to sign in again</div>'; return; }
+  } catch { $('setbody').innerHTML = `<div class="empty">${escapeHtml(catalogMessage('settings.error.load'))}</div>`; return; }
   renderSettings();
 }
 
@@ -32,11 +42,12 @@ const SICONS = {
 };
 
 function renderSettings() {
-  const subs = [['access', 'Access & keys'], ['server', 'Server'], ['users', 'Users'], ['account', 'Account']]
+  const subs = [['access', 'settings.nav.access'], ['server', 'settings.nav.server'], ['users', 'settings.nav.users'], ['account', 'settings.nav.account']]
     .filter(([id]) => id === 'access' || id === 'account' || (id === 'server' ? !!SET.server : !!SET.users));
   if (!subs.some(([id]) => id === setSub)) setSub = 'access';
   $('setnav').innerHTML = subs.map(([id, label]) =>
-    `<button role="tab" data-sub="${id}" aria-selected="${id === setSub}"><span class="nbar"></span>${SICONS[id]}<span>${escapeHtml(label)}</span></button>`).join('');
+    `<button role="tab" data-sub="${id}" aria-selected="${id === setSub}"><span class="nbar"></span>${SICONS[id]}<span data-i18n="${label}"></span></button>`).join('');
+  applyStatic($('setnav'));
   for (const b of $('setnav').querySelectorAll('button'))
     b.addEventListener('click', () => { setSub = b.dataset.sub; renderSettings(); });
   ({ access: renderAccess, server: renderServer, users: renderUsers, account: renderAccount })[setSub]();
@@ -44,18 +55,17 @@ function renderSettings() {
 
 /* live lane state for one key row (also patched in place by the 5s refresh) */
 function keyState(k) {
-  if (!k.enabled) return { text: 'disabled', cls: 'kstate dim' };
-  if (k.cooldown_ms > 0) return { text: `cooldown ${Math.ceil(k.cooldown_ms / 1000)}s`, cls: 'kstate warnc' };
-  if (k.in_window != null) return { text: `${+k.in_window} / ${+k.rpm} in window`, cls: 'kstate' };
-  return { text: 'unassigned', cls: 'kstate dim' };
+  if (!k.enabled) return { id: 'settings.key.state.disabled', cls: 'kstate dim' };
+  if (k.cooldown_ms > 0) return { id: 'settings.key.state.cooldown', params: { seconds: NUM_GROUPED.format(Math.ceil(k.cooldown_ms / 1000)) }, cls: 'kstate warnc' };
+  if (k.in_window != null) return { id: 'settings.key.state.in_window', params: { in_window: NUM_GROUPED.format(+k.in_window), rpm: NUM_GROUPED.format(+k.rpm) }, cls: 'kstate' };
+  return { id: 'settings.key.state.unassigned', cls: 'kstate dim' };
 }
-const poolNote = () => `${+SET.pool.enabled} enabled in pool · Total ${+SET.pool.capacity_rpm} rpm`;
 const clampInt = (v, lo, hi, dflt) => { const n = Math.round(+v); return isFinite(n) ? Math.max(lo, Math.min(hi, n)) : dflt; };
 
 async function copyText(text, btn) {
   const old = btn.textContent;
-  try { await navigator.clipboard.writeText(text); btn.textContent = 'copied ✓'; }
-  catch { btn.textContent = 'copy failed'; }
+  try { await navigator.clipboard.writeText(text); setMessageText(btn, 'settings.copy.copied'); }
+  catch { setMessageText(btn, 'settings.copy.failed'); }
   setTimeout(() => { btn.textContent = old; }, 1500);
 }
 
@@ -63,12 +73,13 @@ async function copyText(text, btn) {
    stray re-render can't eat the one chance to copy it */
 function showSecret(name, secret) {
   $('modal-body').innerHTML =
-    `<p data-style="margin:0 0 12px;color:var(--ink-2);font-size:13px">Client key <b>${escapeHtml(name)}</b> is ready. Copy it now — <b data-style="color:var(--amber-lt)">you won't see this again.</b></p>
+    `<p data-style="margin:0 0 12px;color:var(--ink-2);font-size:13px">${escapeHtml(catalogMessage('settings.secret.ready', { name }))} <b data-style="color:var(--amber-lt)" data-i18n="settings.secret.warning"></b></p>
     <div class="secretbox">${escapeHtml(secret)}</div>
     <div data-style="display:flex;gap:10px;justify-content:flex-end;margin-top:16px">
-      <button class="pbtn" id="modal-copy">Copy key</button>
-      <button class="gbtn" id="modal-done">Done</button>
+      <button class="pbtn" id="modal-copy" data-i18n="settings.secret.copy"></button>
+      <button class="gbtn" id="modal-done" data-i18n="settings.common.done"></button>
     </div>`;
+  applyStatic($('modal-body'));
   $('modal-copy').addEventListener('click', () => copyText(secret, $('modal-copy')));
   $('modal-done').addEventListener('click', () => $('modal').classList.remove('show'));
   $('modal').classList.add('show');
@@ -77,19 +88,29 @@ function showSecret(name, secret) {
 function renderAccess() {
   const admin = !!SET.users;
   const ownerChip = o => admin ? ` <span class="tag">${escapeHtml(o)}</span>` : '';
+  const validatedModelsId = n => {
+    switch (PLURALS.select(n)) {
+      case 'zero': return 'settings.validation.models_added.zero';
+      case 'one': return 'settings.validation.models_added.one';
+      case 'two': return 'settings.validation.models_added.two';
+      case 'few': return 'settings.validation.models_added.few';
+      case 'many': return 'settings.validation.models_added.many';
+      default: return 'settings.validation.models_added.other';
+    }
+  };
   const keyRows = SET.nim_keys.map((k, i) => {
     const st = keyState(k);
     return `<div class="krow${k.enabled ? '' : ' koff'}">
       <div data-style="min-width:0">
         <div class="kmask">nvapi-••••${escapeHtml(k.last4)}${ownerChip(k.owner)}</div>
-        <div class="kmeta">fp ${escapeHtml(String(k.fingerprint).slice(0, 8))} · ${k.lane != null ? `slot ${+k.lane + 1}` : k.enabled ? 'unassigned' : 'off'}</div>
+        <div class="kmeta">fp ${escapeHtml(String(k.fingerprint).slice(0, 8))} · ${k.lane != null ? escapeHtml(catalogMessage('settings.key.slot', { n: NUM_GROUPED.format(+k.lane + 1) })) : k.enabled ? escapeHtml(catalogMessage('settings.key.state.unassigned')) : escapeHtml(catalogMessage('settings.key.off'))}</div>
       </div>
-      <span class="${st.cls}" data-ksfp="${escapeHtml(k.fingerprint)}">${escapeHtml(st.text)}</span>
+      <span class="${st.cls}" data-ksfp="${escapeHtml(k.fingerprint)}">${escapeHtml(catalogMessage(st.id, st.params))}</span>
       <span class="rpmwrap"><input class="sin num" type="number" min="1" max="10000" value="${+k.rpm}" data-rpm="${i}"><span class="unitl">rpm</span></span>
-      <button class="tog" role="switch" aria-checked="${!!k.enabled}" data-tog="${i}" title="${k.enabled ? 'Disable — its rate window stays warm' : 'Enable'}"></button>
+      <button class="tog" role="switch" aria-checked="${!!k.enabled}" data-tog="${i}" data-i18n-attr="title:${k.enabled ? 'settings.key.toggle.disable' : 'settings.key.toggle.enable'}"></button>
       ${k.guarded
-        ? `<span class="klock" title="The pool keeps at least one enabled superuser key — add or enable another key before removing this one">${LOCK}</span>`
-        : `<button class="dbtn icon" data-kdel="${i}" title="Remove key">${TRASH}</button>`}
+        ? `<span class="klock" data-i18n-attr="title:settings.key.guarded">${LOCK}</span>`
+        : `<button class="dbtn icon" data-kdel="${i}" data-i18n-attr="title:settings.key.remove">${TRASH}</button>`}
     </div>`;
   }).join('');
   const ckRows = SET.client_keys.map((ck, i) =>
@@ -97,45 +118,46 @@ function renderAccess() {
       <span data-style="font-weight:600;flex:0 1 160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${escapeHtml(ck.name)}">${escapeHtml(ck.name)}</span>
       <span class="kmask" data-style="color:var(--ink-25);font-weight:500">npk_••••••••${escapeHtml(ck.last4)}</span>
       ${admin ? `<span class="tag">${escapeHtml(ck.owner)}</span>` : ''}
-      <button class="dbtn" data-style="margin-left:auto" data-ckdel="${i}">Revoke</button>
+      <button class="dbtn" data-style="margin-left:auto" data-ckdel="${i}" data-i18n="settings.client_key.revoke"></button>
     </div>`).join('');
   $('setbody').innerHTML = `
     <div class="card mb">
-      <h2>${admin ? 'NIM keys' : 'My NIM keys'} <span class="note" id="pool-note">${escapeHtml(poolNote())}</span></h2>
-      <p class="shint">Keys you add join the shared pool as yours${admin ? '' : ' — only you and admins see they exist'}. Changes apply live: kept keys keep their rate windows, disabled keys re-enable warm.</p>
-      <div>${keyRows || '<div class="empty">No NIM keys yet — add one below</div>'}</div>
+      <h2><span data-i18n="${admin ? 'settings.key.heading.all' : 'settings.key.heading.mine'}"></span> <span class="note" id="pool-note">${escapeHtml(catalogMessage('settings.key.pool_note', { enabled: NUM_GROUPED.format(+SET.pool.enabled), capacity: NUM_GROUPED.format(+SET.pool.capacity_rpm) }))}</span></h2>
+      <p class="shint" data-i18n="${admin ? 'settings.key.notice.admin' : 'settings.key.notice.mine'}"></p>
+      <div>${keyRows || '<div class="empty" data-i18n="settings.key.empty"></div>'}</div>
       <div class="addrow">
-        <input id="nk-key" class="sin" data-style="flex:1;min-width:200px" type="password" placeholder="nvapi-… paste a new NIM key" autocomplete="off" spellcheck="false">
+        <input id="nk-key" class="sin" data-style="flex:1;min-width:200px" type="password" data-i18n-attr="placeholder:settings.key.placeholder" autocomplete="off" spellcheck="false">
         <span class="rpmwrap"><input id="nk-rpm" class="sin num" type="number" min="1" max="10000" value="40"><span class="unitl">rpm</span></span>
-        <button class="pbtn" id="nk-add">Validate &amp; add</button>
-        <button class="gbtn" id="nk-force" hidden>Add anyway</button>
+        <button class="pbtn" id="nk-add" data-i18n="settings.key.validate_add"></button>
+        <button class="gbtn" id="nk-force" hidden data-i18n="settings.key.add_anyway"></button>
       </div>
       <div class="serr" id="nk-err"></div>
     </div>
     <div class="card mb">
-      <h2>${admin ? 'Client API keys' : 'My API keys'} <span class="note">bearer tokens your clients use</span></h2>
-      <div>${ckRows || '<div class="empty">No client keys yet</div>'}</div>
+      <h2><span data-i18n="${admin ? 'settings.client_key.heading.all' : 'settings.client_key.heading.mine'}"></span> <span class="note" data-i18n="settings.client_key.note"></span></h2>
+      <div>${ckRows || '<div class="empty" data-i18n="settings.client_key.empty"></div>'}</div>
       <div class="addrow">
-        <input id="ck-name" class="sin" data-style="flex:1;min-width:200px" placeholder="name this key, e.g. laptop-cli" maxlength="64" autocomplete="off" spellcheck="false">
-        <button class="pbtn" id="ck-add">+ Generate key</button>
+        <input id="ck-name" class="sin" data-style="flex:1;min-width:200px" data-i18n-attr="placeholder:settings.client_key.placeholder" maxlength="64" autocomplete="off" spellcheck="false">
+        <button class="pbtn" id="ck-add" data-i18n="settings.client_key.generate"></button>
       </div>
       <div class="serr" id="ck-err"></div>
     </div>
     <div class="card">
-      <h2>Connection</h2>
+      <h2 data-i18n="settings.connection.heading"></h2>
       <div class="congrid">
         <div class="conbox">
-          <div class="slabel">Point your client's base URL at</div>
-          <div data-style="display:flex;align-items:center;gap:10px"><span class="kmask" data-style="flex:1;overflow:hidden;text-overflow:ellipsis">${escapeHtml(location.origin + '/v1')}</span><button class="gbtn" id="copy-base">copy</button></div>
+          <div class="slabel" data-i18n="settings.connection.base_url"></div>
+          <div data-style="display:flex;align-items:center;gap:10px"><span class="kmask" data-style="flex:1;overflow:hidden;text-overflow:ellipsis">${escapeHtml(location.origin + '/v1')}</span><button class="gbtn" id="copy-base" data-i18n="settings.copy.copy"></button></div>
         </div>
         <div class="conbox">
-          <div class="slabel">API access mode</div>
-          <div class="kmask" data-style="color:${SET.mode === 'keyed' ? 'var(--green-lt)' : 'var(--amber-lt)'}">● ${SET.mode === 'keyed' ? 'API key required' : 'Open — no authentication'}</div>
-          <div class="kmeta" data-style="margin-top:4px">${SET.mode === 'keyed' ? 'clients authenticate with a client API key' : 'anyone who can reach /v1 can use the pool'}</div>
+          <div class="slabel" data-i18n="settings.mode.heading"></div>
+          <div class="kmask" data-style="color:${SET.mode === 'keyed' ? 'var(--green-lt)' : 'var(--amber-lt)'}">● <span data-i18n="${SET.mode === 'keyed' ? 'settings.mode.keyed' : 'settings.mode.open'}"></span></div>
+          <div class="kmeta" data-style="margin-top:4px" data-i18n="${SET.mode === 'keyed' ? 'settings.mode.keyed_note' : 'settings.mode.open_note'}"></div>
         </div>
       </div>
     </div>`;
   const body = $('setbody');
+  applyStatic(body);
   for (const el of body.querySelectorAll('[data-rpm]')) el.addEventListener('change', async () => {
     const k = SET.nim_keys[+el.dataset.rpm];
     try {
@@ -152,7 +174,7 @@ function renderAccess() {
   });
   for (const el of body.querySelectorAll('[data-kdel]')) el.addEventListener('click', async () => {
     const k = SET.nim_keys[+el.dataset.kdel];
-    if (!confirm(`Remove key nvapi-••••${k.last4} from the pool? In-flight requests finish; its rate window is lost.`)) return;
+    if (!confirmMessage('settings.dialog.remove_key', { last4: k.last4 })) return;
     try { await sPost('/api/settings/nim-keys', { remove: k.fingerprint }); await loadSettings(); }
     catch (e) { note('nk-err', e.message); }
   });
@@ -163,32 +185,33 @@ function renderAccess() {
   };
   $('nk-add').addEventListener('click', async () => {
     const key = $('nk-key').value.trim();
-    if (!key) return note('nk-err', 'Paste a NIM key first.');
-    $('nk-add').disabled = true; $('nk-add').textContent = 'Validating…';
+    if (!key) return noteMessage('nk-err', 'settings.validation.nim_key_required');
+    $('nk-add').disabled = true; setMessageText($('nk-add'), 'settings.key.validating');
     try {
       const v = await sPost('/api/settings/validate-key', { key });
-      note('nk-err', `✓ ${Array.isArray(v.models) ? v.models.length : +v.models} models · Adding…`, true);
+      const count = Array.isArray(v.models) ? v.models.length : +v.models;
+      noteMessage('nk-err', validatedModelsId(count), { n: NUM_GROUPED.format(count) }, true);
       await addKey();
       return;
     } catch (e) {
-      note('nk-err', `Validation failed: ${e.message}`);
+      note('nk-err', e.message);
       $('nk-force').hidden = false;
     }
-    $('nk-add').disabled = false; $('nk-add').textContent = 'Validate & add';
+    $('nk-add').disabled = false; setMessageText($('nk-add'), 'settings.key.validate_add');
   });
   $('nk-force').addEventListener('click', async () => {
-    if (!$('nk-key').value.trim()) return note('nk-err', 'Paste a NIM key first.');
+    if (!$('nk-key').value.trim()) return noteMessage('nk-err', 'settings.validation.nim_key_required');
     try { await addKey(); } catch (e) { note('nk-err', e.message); }
   });
   for (const el of body.querySelectorAll('[data-ckdel]')) el.addEventListener('click', async () => {
     const ck = SET.client_keys[+el.dataset.ckdel];
-    if (!confirm(`Revoke "${ck.name}"? Clients using it stop working immediately.`)) return;
+    if (!confirmMessage('settings.dialog.revoke_client_key', { name: ck.name })) return;
     try { await sPost('/api/settings/clients', { remove: ck.name }); await loadSettings(); }
     catch (e) { note('ck-err', e.message); }
   });
   $('ck-add').addEventListener('click', async () => {
     const name = $('ck-name').value.trim();
-    if (!name) return note('ck-err', 'Name the key first — e.g. laptop-cli.');
+    if (!name) return noteMessage('ck-err', 'settings.validation.client_key_name');
     try {
       const j = await sPost('/api/settings/clients', { add: { name } });
       showSecret(name, j.secret);
@@ -200,74 +223,86 @@ function renderAccess() {
 
 function renderServer() {
   const sv = SET.server, L = sv.limits;
-  const num = (id, label, val, unit, step) => `<div><div class="slabel">${label}</div>
-    <span class="rpmwrap" data-style="display:flex"><input id="${id}" class="sin" data-style="width:100%;text-align:right" type="number" min="0"${step ? ` step="${step}"` : ''} value="${+val}">${unit ? `<span class="unitl">${unit}</span>` : ''}</span></div>`;
+  const num = (id, label, val, unit, step) => `<div><div class="slabel" data-i18n="${label}"></div>
+    <span class="rpmwrap" data-style="display:flex"><input id="${id}" class="sin" data-style="width:100%;text-align:right" type="number" min="0"${step ? ` step="${step}"` : ''} value="${+val}">${unit ? `<span class="unitl" data-i18n="${unit}"></span>` : ''}</span></div>`;
   const ovr = Object.entries(sv.governor.overrides || {});
   const retainedFrom = sv.history.available_from == null
-    ? 'No data yet'
-    : at(STAMP, +sv.history.available_from * 1000);
-  const historyBytes = NUM_GROUPED.format(+sv.history.file_bytes || 0);
+    ? escapeHtml(catalogMessage('settings.server.history.no_data'))
+    : escapeHtml(at(STAMP, +sv.history.available_from * 1000));
+  const historyBytes = +sv.history.file_bytes || 0;
+  const historyBytesMessage = () => {
+    const params = { bytes: NUM_GROUPED.format(historyBytes) };
+    switch (PLURALS.select(historyBytes)) {
+      case 'zero': return catalogMessage('settings.server.history.bytes.zero', params);
+      case 'one': return catalogMessage('settings.server.history.bytes.one', params);
+      case 'two': return catalogMessage('settings.server.history.bytes.two', params);
+      case 'few': return catalogMessage('settings.server.history.bytes.few', params);
+      case 'many': return catalogMessage('settings.server.history.bytes.many', params);
+      default: return catalogMessage('settings.server.history.bytes.other', params);
+    }
+  };
   $('setbody').innerHTML = `
     <div class="card mb">
-      <h2>API access mode
+      <h2><span data-i18n="settings.mode.heading"></span>
         <span class="pills" data-style="margin-left:auto">
-          <button data-mode="open" aria-pressed="${SET.mode === 'open'}">Open (no authentication)</button>
-          <button data-mode="keyed" aria-pressed="${SET.mode === 'keyed'}">API key required</button>
+          <button data-mode="open" aria-pressed="${SET.mode === 'open'}" data-i18n="settings.mode.open"></button>
+          <button data-mode="keyed" aria-pressed="${SET.mode === 'keyed'}" data-i18n="settings.mode.keyed"></button>
         </span></h2>
-      <p class="shint">Controls <b>/v1</b> client calls only. <b>API key required</b> needs a bearer token; <b>Open</b> accepts anyone who can reach /v1 — trusted networks only.</p>
-      ${SET.mode === 'keyed' && !SET.client_keys.length ? '<p class="shint" data-style="color:var(--amber-lt)">Requiring an API key with no client keys locks every client out — generate one under Access &amp; keys.</p>' : ''}
+      <p class="shint" data-i18n="settings.mode.help"></p>
+      ${SET.mode === 'keyed' && !SET.client_keys.length ? '<p class="shint" data-style="color:var(--amber-lt)" data-i18n="settings.mode.no_client_keys"></p>' : ''}
       <div class="serr" id="mode-err"></div>
     </div>
     <div class="card mb">
-      <h2>Upstream &amp; limits <button class="pbtn" id="save-limits" data-style="margin-left:auto">Save</button></h2>
-      <div class="slabel">Upstream base URL · saving clears the model-catalog cache</div>
+      <h2><span data-i18n="settings.server.upstream_limits"></span> <button class="pbtn" id="save-limits" data-style="margin-left:auto" data-i18n="settings.common.save"></button></h2>
+      <div class="slabel" data-i18n="settings.server.base_url_note"></div>
       <input id="sv-base" class="sin" data-style="width:100%" value="${escapeHtml(sv.base_url)}" spellcheck="false">
       <div class="limgrid">
-        ${num('sv-maxwait', 'Max wait', L.max_wait_secs, 's')}
-        ${num('sv-heartbeat', 'Heartbeat', L.heartbeat_secs, 's')}
-        ${num('sv-idle', 'Stream idle', L.stream_idle_secs, 's')}
-        ${num('sv-timeout', 'Request timeout', L.request_timeout_secs, 's')}
-        ${num('sv-ttl', 'Models TTL', L.models_ttl_secs, 's')}
-        ${num('sv-inflight', 'Max in-flight', L.max_inflight, '')}
+        ${num('sv-maxwait', 'settings.server.limit.max_wait', L.max_wait_secs, 'settings.server.unit.seconds')}
+        ${num('sv-heartbeat', 'settings.server.limit.heartbeat', L.heartbeat_secs, 'settings.server.unit.seconds')}
+        ${num('sv-idle', 'settings.server.limit.stream_idle', L.stream_idle_secs, 'settings.server.unit.seconds')}
+        ${num('sv-timeout', 'settings.server.limit.request_timeout', L.request_timeout_secs, 'settings.server.unit.seconds')}
+        ${num('sv-ttl', 'settings.server.limit.models_ttl', L.models_ttl_secs, 'settings.server.unit.seconds')}
+        ${num('sv-inflight', 'settings.server.limit.max_inflight', L.max_inflight, '')}
       </div>
       <div data-style="display:flex;align-items:center;gap:10px;margin-top:16px">
         <button class="tog" role="switch" id="sv-strict" aria-checked="${!!L.strict_passthrough}"></button>
-        <span data-style="font-size:12.5px">Strict passthrough <span class="kmeta" data-style="display:inline">— reject params the upstream doesn't accept</span></span>
+        <span data-style="font-size:12.5px"><span data-i18n="settings.server.strict_passthrough"></span> <span class="kmeta" data-style="display:inline" data-i18n="settings.server.strict_note"></span></span>
       </div>
       <div class="serr" id="limits-err"></div>
     </div>
     <div class="card mb">
-      <h2>Model limits
-        <span data-style="margin-left:auto;display:inline-flex;align-items:center;gap:8px"><span class="kmeta">adaptive</span>
+      <h2><span data-i18n="settings.server.model_limits"></span>
+        <span data-style="margin-left:auto;display:inline-flex;align-items:center;gap:8px"><span class="kmeta" data-i18n="settings.server.adaptive"></span>
         <button class="tog" role="switch" id="gov-tog" aria-checked="${!!sv.governor.enabled}"></button></span></h2>
-      <p class="shint">Absorbs NIM worker-exhaustion per model without cooling down keys. Each model self-tunes: engages on the first exhaustion, climbs while stable, dissolves after a long clean stretch. Set an override only if you know a model's ceiling.</p>
+      <p class="shint" data-i18n="settings.server.model_limits_help"></p>
       <div>${ovr.map(([m, cap], i) =>
-        `<span class="ochip"><span title="${escapeHtml(m)}">${escapeHtml(m)}</span><b>${+cap} max</b><button data-govdel="${i}" title="Remove override">×</button></span>`).join('')
-        || '<span class="kmeta">No overrides set</span>'}</div>
+        `<span class="ochip"><span title="${escapeHtml(m)}">${escapeHtml(m)}</span><b>${+cap} <span data-i18n="settings.server.unit.limit"></span></b><button data-govdel="${i}" data-i18n-attr="title:settings.server.remove_override">×</button></span>`).join('')
+        || '<span class="kmeta" data-i18n="settings.server.no_overrides"></span>'}</div>
       <div class="addrow">
-        <input id="gov-model" class="sin" data-style="flex:1;min-width:200px" placeholder="model id, e.g. moonshotai/kimi-k2.5" autocomplete="off" spellcheck="false">
-        <span class="rpmwrap"><input id="gov-cap" class="sin num" type="number" min="1" max="10000" value="8"><span class="unitl">max</span></span>
-        <button class="gbtn" id="gov-add">+ override</button>
+        <input id="gov-model" class="sin" data-style="flex:1;min-width:200px" data-i18n-attr="placeholder:settings.server.model_placeholder" autocomplete="off" spellcheck="false">
+        <span class="rpmwrap"><input id="gov-cap" class="sin num" type="number" min="1" max="10000" value="8"><span class="unitl" data-i18n="settings.server.unit.limit"></span></span>
+        <button class="gbtn" id="gov-add" data-i18n="settings.server.add_override"></button>
       </div>
       <div class="serr" id="gov-err"></div>
     </div>
     <div class="card">
-      <h2>History &amp; dashboard <button class="pbtn" id="save-history" data-style="margin-left:auto">Save</button></h2>
+      <h2><span data-i18n="settings.server.history.heading"></span> <button class="pbtn" id="save-history" data-style="margin-left:auto" data-i18n="settings.common.save"></button></h2>
       <div class="limgrid" data-style="margin-top:6px">
-        <div><div class="slabel">Default time range</div>
-          <span class="rpmwrap" data-style="display:flex"><input id="sv-default-days" class="sin" data-style="width:100%;text-align:right" type="number" min="1" step="1" value="${+sv.dashboard.default_window_days}"><span class="unitl">days</span></span></div>
-        <div><div class="slabel">History retention · 0 = unlimited</div>
-          <span class="rpmwrap" data-style="display:flex"><input id="sv-retention-days" class="sin" data-style="width:100%;text-align:right" type="number" min="0" step="1" value="${+sv.history.days}"><span class="unitl">days</span></span></div>
-        <div><div class="slabel">Availability SLO</div>
+        <div><div class="slabel" data-i18n="settings.server.history.default_range"></div>
+          <span class="rpmwrap" data-style="display:flex"><input id="sv-default-days" class="sin" data-style="width:100%;text-align:right" type="number" min="1" step="1" value="${+sv.dashboard.default_window_days}"><span class="unitl" data-i18n="settings.server.days"></span></span></div>
+        <div><div class="slabel" data-i18n="settings.server.history.retention"></div>
+          <span class="rpmwrap" data-style="display:flex"><input id="sv-retention-days" class="sin" data-style="width:100%;text-align:right" type="number" min="0" step="1" value="${+sv.history.days}"><span class="unitl" data-i18n="settings.server.days"></span></span></div>
+        <div><div class="slabel" data-i18n="settings.server.history.slo"></div>
           <span class="rpmwrap" data-style="display:flex"><input id="sv-slo" class="sin" data-style="width:100%;text-align:right" type="number" min="0.1" max="100" step="0.1" value="${+sv.dashboard.slo_target_percent}"><span class="unitl">%</span></span></div>
       </div>
       <div class="congrid" data-style="margin-top:16px">
-        <div class="conbox"><div class="slabel">Oldest data point</div><div class="kmeta" data-style="display:block">${escapeHtml(retainedFrom)}</div></div>
-        <div class="conbox"><div class="slabel">Data file</div><div class="kmeta" data-style="display:block">${escapeHtml(historyBytes)} bytes</div></div>
+        <div class="conbox"><div class="slabel" data-i18n="settings.server.history.oldest"></div><div class="kmeta" data-style="display:block">${retainedFrom}</div></div>
+        <div class="conbox"><div class="slabel" data-i18n="settings.server.history.data_file"></div><div class="kmeta" data-style="display:block">${escapeHtml(historyBytesMessage())}</div></div>
       </div>
-      ${sv.history.compaction_pending ? '<p class="shint" data-style="color:var(--amber-lt)">compaction pending</p>' : ''}
+      ${sv.history.compaction_pending ? '<p class="shint" data-style="color:var(--amber-lt)" data-i18n="settings.server.history.compaction_pending"></p>' : ''}
       <div class="serr" id="history-err"></div>
     </div>`;
+  applyStatic($('setbody'));
   for (const b of $('setbody').querySelectorAll('[data-mode]')) b.addEventListener('click', async () => {
     if (b.dataset.mode === SET.mode) return;
     try { await sPost('/api/settings/clients', { mode: b.dataset.mode }); await loadSettings(); }
@@ -284,14 +319,14 @@ function renderServer() {
     const limits = { strict_passthrough: $('sv-strict').getAttribute('aria-checked') === 'true' };
     for (const [field, id] of Object.entries(nums)) {
       const n = Math.round(+$(id).value);
-      if (!isFinite(n) || n < 0) return note('limits-err', 'Every limit needs a whole number ≥ 0.');
+      if (!isFinite(n) || n < 0) return noteMessage('limits-err', 'settings.validation.limits');
       limits[field] = n;
     }
     try {
       if (base !== sv.base_url) await sPost('/api/settings/upstream', { base_url: base });
       await sPost('/api/settings/limits', limits);
       await loadSettings();
-      note('limits-err', 'Saved.', true);
+      noteMessage('limits-err', 'settings.validation.saved', {}, true);
     } catch (e) { note('limits-err', e.message); }
   });
   $('gov-tog').addEventListener('click', async () => {
@@ -304,7 +339,7 @@ function renderServer() {
   });
   $('gov-add').addEventListener('click', async () => {
     const model = $('gov-model').value.trim(), cap = Math.round(+$('gov-cap').value);
-    if (!model || !(cap >= 1)) return note('gov-err', 'Give a model id and a cap ≥ 1.');
+    if (!model || !(cap >= 1)) return noteMessage('gov-err', 'settings.validation.governor');
     try { await sPost('/api/settings/governor', { set_override: { model, cap } }); await loadSettings(); }
     catch (e) { note('gov-err', e.message); }
   });
@@ -313,11 +348,11 @@ function renderServer() {
     const retention = Math.round(+$('sv-retention-days').value);
     const slo = +$('sv-slo').value;
     if (!isFinite(defaultDays) || defaultDays < 1)
-      return note('history-err', 'Default time range must be at least 1 day.');
+      return noteMessage('history-err', 'settings.validation.history_default');
     if (!isFinite(retention) || retention < 0)
-      return note('history-err', 'History retention must be 0 or more days.');
+      return noteMessage('history-err', 'settings.validation.history_retention');
     if (!isFinite(slo) || slo <= 0 || slo > 100)
-      return note('history-err', 'SLO target must be greater than 0 and at most 100.');
+      return noteMessage('history-err', 'settings.validation.slo');
     try {
       await sPost('/api/settings/history', {
         days: retention,
@@ -325,48 +360,71 @@ function renderServer() {
         slo_target_percent: slo,
       });
       await loadSettings();
-      note('history-err', 'Saved.', true);
+      noteMessage('history-err', 'settings.validation.saved', {}, true);
     } catch (e) { note('history-err', e.message); }
   });
 }
 
 function renderUsers() {
   const RCLS = { superuser: 'superuser', admin: 'admin', user: 'user' };
+  const nimKeyCount = n => {
+    const params = { n: NUM_GROUPED.format(n) };
+    switch (PLURALS.select(n)) {
+      case 'zero': return catalogMessage('settings.users.nim_key_count.zero', params);
+      case 'one': return catalogMessage('settings.users.nim_key_count.one', params);
+      case 'two': return catalogMessage('settings.users.nim_key_count.two', params);
+      case 'few': return catalogMessage('settings.users.nim_key_count.few', params);
+      case 'many': return catalogMessage('settings.users.nim_key_count.many', params);
+      default: return catalogMessage('settings.users.nim_key_count.other', params);
+    }
+  };
+  const clientKeyCount = n => {
+    const params = { n: NUM_GROUPED.format(n) };
+    switch (PLURALS.select(n)) {
+      case 'zero': return catalogMessage('settings.users.client_key_count.zero', params);
+      case 'one': return catalogMessage('settings.users.client_key_count.one', params);
+      case 'two': return catalogMessage('settings.users.client_key_count.two', params);
+      case 'few': return catalogMessage('settings.users.client_key_count.few', params);
+      case 'many': return catalogMessage('settings.users.client_key_count.many', params);
+      default: return catalogMessage('settings.users.client_key_count.other', params);
+    }
+  };
   const rows = SET.users.map((u, i) => `<div class="krow">
     <span class="umono">${escapeHtml((u.username[0] || '?').toUpperCase())}</span>
     <div data-style="min-width:0">
       <div data-style="font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${escapeHtml(u.username)}</div>
-      <div class="kmeta">${+u.nim_keys} NIM · ${+u.client_keys} client</div>
+      <div class="kmeta">${escapeHtml(nimKeyCount(+u.nim_keys))} · ${escapeHtml(clientKeyCount(+u.client_keys))}</div>
     </div>
-    <span class="rbadge ${RCLS[u.role] || 'user'}" data-style="margin-left:auto">${escapeHtml(String(u.role).toUpperCase())}</span>
-    ${u.role !== 'superuser' ? `<button class="gbtn" data-urp="${i}">Reset password</button>
-      <select class="sin" data-urole="${i}" title="Role">
+    <span class="rbadge ${RCLS[u.role] || 'user'}" data-style="margin-left:auto">${escapeHtml(String(u.role))}</span>
+    ${u.role !== 'superuser' ? `<button class="gbtn" data-urp="${i}" data-i18n="settings.users.reset_password"></button>
+      <select class="sin" data-urole="${i}" data-i18n-attr="title:settings.users.role">
         <option value="admin"${u.role === 'admin' ? ' selected' : ''}>admin</option>
         <option value="user"${u.role === 'user' ? ' selected' : ''}>user</option>
       </select>
-      <button class="dbtn" data-udel="${i}">Delete</button>`
-      : `<span class="note" title="The superuser changes its own password in Account settings">self-managed</span>`}
+      <button class="dbtn" data-udel="${i}" data-i18n="settings.users.delete"></button>`
+      : `<span class="note" data-i18n-attr="title:settings.users.superuser_note" data-i18n="settings.users.self_managed"></span>`}
   </div>`).join('');
   $('setbody').innerHTML = `<div class="card">
-    <h2>Users <span class="note">deleting a user pulls their NIM keys from the pool &amp; stops their clients</span></h2>
+    <h2><span data-i18n="settings.users.heading"></span> <span class="note" data-i18n="settings.users.note"></span></h2>
     <div>${rows}</div>
     <div class="addrow">
-      <input id="u-name" class="sin" data-style="flex:1;min-width:150px" placeholder="new username" autocomplete="off" spellcheck="false">
-      <input id="u-pass" class="sin" data-style="flex:1;min-width:150px" type="password" placeholder="initial password (10+ chars)" autocomplete="new-password">
+      <input id="u-name" class="sin" data-style="flex:1;min-width:150px" data-i18n-attr="placeholder:settings.users.username_placeholder" autocomplete="off" spellcheck="false">
+      <input id="u-pass" class="sin" data-style="flex:1;min-width:150px" type="password" data-i18n-attr="placeholder:settings.users.password_placeholder" autocomplete="new-password">
       <span class="pills"><button data-urolepick="user" aria-pressed="true">user</button><button data-urolepick="admin" aria-pressed="false">admin</button></span>
-      <button class="pbtn" id="u-add">Add user</button>
+      <button class="pbtn" id="u-add" data-i18n="settings.users.add"></button>
     </div>
     <div class="serr" id="u-err"></div>
   </div>`;
   const body = $('setbody');
+  applyStatic(body);
   for (const b of body.querySelectorAll('[data-urp]')) b.addEventListener('click', async () => {
     const u = SET.users[+b.dataset.urp];
-    const pw = prompt(`New password for ${u.username} (at least 10 characters):`);
+    const pw = promptMessage('settings.dialog.reset_password', { username: u.username });
     if (pw == null) return;
-    if (pw.length < 10) return note('u-err', 'Password must be at least 10 characters.');
+    if (pw.length < 10) return noteMessage('u-err', 'settings.validation.password');
     try {
       await sPost('/api/settings/users', { reset_password: { username: u.username, new_password: pw } });
-      note('u-err', `Password reset for ${u.username}.`, true);
+      noteMessage('u-err', 'settings.validation.password_reset', { username: u.username }, true);
     } catch (e) { note('u-err', e.message); }
   });
   for (const s of body.querySelectorAll('[data-urole]')) s.addEventListener('change', async () => {
@@ -376,7 +434,7 @@ function renderUsers() {
   });
   for (const b of body.querySelectorAll('[data-udel]')) b.addEventListener('click', async () => {
     const u = SET.users[+b.dataset.udel];
-    if (!confirm(`Delete ${u.username}? Their NIM keys leave the pool and their API keys stop working.`)) return;
+    if (!confirmMessage('settings.dialog.delete_user', { username: u.username })) return;
     try { await sPost('/api/settings/users', { remove: u.username }); await loadSettings(); }
     catch (e) { note('u-err', e.message); }
   });
@@ -387,8 +445,8 @@ function renderUsers() {
   });
   $('u-add').addEventListener('click', async () => {
     const username = $('u-name').value.trim(), password = $('u-pass').value;
-    if (!username) return note('u-err', 'Pick a username.');
-    if (password.length < 10) return note('u-err', 'Initial password must be at least 10 characters.');
+    if (!username) return noteMessage('u-err', 'settings.validation.username');
+    if (password.length < 10) return noteMessage('u-err', 'settings.validation.initial_password');
     try { await sPost('/api/settings/users', { add: { username, password, role: newRole } }); await loadSettings(); }
     catch (e) { note('u-err', e.message); }
   });
@@ -396,28 +454,29 @@ function renderUsers() {
 
 function renderAccount() {
   $('setbody').innerHTML = `<div class="card" data-style="max-width:560px">
-    <h2>Account</h2>
-    <div class="slabel">Username</div>
+    <h2 data-i18n="settings.account.heading"></h2>
+    <div class="slabel" data-i18n="settings.account.username"></div>
     <input class="sin" data-style="width:100%" value="${escapeHtml(SET.username)}" disabled>
-    <div class="slabel" data-style="margin-top:14px">Current password</div>
+    <div class="slabel" data-style="margin-top:14px" data-i18n="settings.account.current_password"></div>
     <input id="a-cur" class="sin" data-style="width:100%" type="password" autocomplete="current-password">
-    <div class="slabel" data-style="margin-top:14px">New password · at least 10 characters</div>
+    <div class="slabel" data-style="margin-top:14px" data-i18n="settings.account.new_password"></div>
     <input id="a-new" class="sin" data-style="width:100%" type="password" autocomplete="new-password">
-    <div class="slabel" data-style="margin-top:14px">Confirm new password</div>
+    <div class="slabel" data-style="margin-top:14px" data-i18n="settings.account.confirm_password"></div>
     <input id="a-conf" class="sin" data-style="width:100%" type="password" autocomplete="new-password">
-    <p class="shint" data-style="margin-top:14px">Changing your password signs out your other sessions.</p>
-    <button class="pbtn" id="a-save">Update password</button>
+    <p class="shint" data-style="margin-top:14px" data-i18n="settings.account.note"></p>
+    <button class="pbtn" id="a-save" data-i18n="settings.account.update"></button>
     <div class="serr" id="a-err"></div>
   </div>`;
+  applyStatic($('setbody'));
   $('a-save').addEventListener('click', async () => {
     const nw = $('a-new').value;
-    if (nw.length < 10) return note('a-err', 'New password must be at least 10 characters.');
-    if (nw !== $('a-conf').value) return note('a-err', 'Passwords do not match.');
+    if (nw.length < 10) return noteMessage('a-err', 'settings.validation.new_password');
+    if (nw !== $('a-conf').value) return noteMessage('a-err', 'settings.validation.password_mismatch');
     $('a-save').disabled = true; // password hashing is deliberately slow
     try {
       await sPost('/api/settings/account', { current_password: $('a-cur').value, new_password: nw });
       for (const id of ['a-cur', 'a-new', 'a-conf']) $(id).value = '';
-      note('a-err', 'Password updated — this session was refreshed.', true);
+      noteMessage('a-err', 'settings.validation.password_updated', {}, true);
     } catch (e) { note('a-err', e.message); }
     $('a-save').disabled = false;
   });
@@ -436,10 +495,10 @@ setInterval(async () => {
       const k = byFp.get(el.dataset.ksfp);
       if (!k) continue;
       const st = keyState(k);
-      el.textContent = st.text;
+      setMessageText(el, st.id, st.params);
       el.className = st.cls;
     }
     const pn = $('pool-note');
-    if (pn) pn.textContent = poolNote();
+    if (pn) setMessageText(pn, 'settings.key.pool_note', { enabled: NUM_GROUPED.format(+SET.pool.enabled), capacity: NUM_GROUPED.format(+SET.pool.capacity_rpm) });
   } catch {}
 }, 5000);

--- a/src/web/shared.js
+++ b/src/web/shared.js
@@ -218,6 +218,12 @@ function setMessageAttr(node, attr, id, params = {}) {
     throw new Error(`forbidden catalog attribute: ${attr}`);
   node.setAttribute(attr, message(id, params));
 }
+function confirmMessage(id, params = {}) {
+  return confirm(message(id, params));
+}
+function promptMessage(id, params = {}) {
+  return prompt(message(id, params));
+}
 /* Static markup carries data-i18n="<id>" for content and
    data-i18n-attr="<attr>:<id>[,<attr>:<id>]" for attributes. */
 function applyStatic(root) {
@@ -308,6 +314,7 @@ let PCT_3;
 let PCT_SIGNED_0;
 let PCT_SIGNED_1;
 let DAYS;
+let PLURALS;
 function initializeFormatters() {
   const tag = I18N.locale || 'en-US';
   try {
@@ -370,6 +377,7 @@ function initializeFormatters() {
     maximumFractionDigits: 1,
     signDisplay: 'exceptZero',
   });
+  PLURALS = new Intl.PluralRules(LOCALE);
   DAYS = Array.from({ length: 7 }, (_, i) =>
     WEEKDAY_SHORT.format(
       Date.UTC(2024, 0, 1 + ((FIRST_DAY - 1 + i) % 7)),

--- a/src/web/shared.js
+++ b/src/web/shared.js
@@ -562,8 +562,8 @@ const avgSeries = (sumName, cntName, f) => samples.slice(1).map((s, i) => {
 
 /* quantile median/p95 series from windowed bucket deltas over `samples`;
    `filter` narrows the source buckets (e.g. source="usage"). */
-const quantSeries = (metric, filter) => [[0.5, 'median', MED], [0.95, 'p95', P95]].map(([q, name, color]) => ({
-  name, color,
+const quantSeries = (metric, filter) => [[0.5, 'dashboard.chart.median', MED], [0.95, 'dashboard.chart.p95', P95]].map(([q, nameId, color]) => ({
+  nameId, color,
   pts: samples.slice(1).map((s, i) => {
     const bA = s2 => buckets(s2.rows, metric, filter);
     return { t: s.t, v: quantile(deltaBuckets(bA(s), bA(samples[i])), q) };
@@ -636,7 +636,7 @@ function lineChart(el, series, unitFmt, opts = {}) {
       let p = s.pts[0];
       for (const q of s.pts) if (Math.abs(q.t - best.t) < Math.abs(p.t - best.t)) p = q;
       dots += `<circle cx="${X(p.t)}" cy="${Y(p.v)}" r="4" fill="${s.color}" stroke="${css('--bg')}" stroke-width="1.5"/>`;
-      html += `<div class="row"><span><i class="sw" data-style="background:${s.color}"></i>${escapeHtml(s.name)}</span><b>${unitFmt(p.v)}</b></div>`;
+      html += `<div class="row"><span><i class="sw" data-style="background:${s.color}"></i>${escapeHtml(s.nameId ? catalogMessage(s.nameId) : s.name)}</span><b>${unitFmt(p.v)}</b></div>`;
     }
     hoverg.innerHTML = xh.outerHTML + dots;
     hoverg.setAttribute('visibility', 'visible');
@@ -723,7 +723,7 @@ function stackChart(el, series, unitFmt, opts = {}) {
 
 function legend(el, series) {
   el.innerHTML = series.length > 1
-    ? series.map(s => `<span><i data-style="background:${s.color}"></i>${escapeHtml(s.name)}</span>`).join('')
+    ? series.map(s => `<span><i data-style="background:${s.color}"></i>${escapeHtml(s.nameId ? catalogMessage(s.nameId) : s.name)}</span>`).join('')
     : '';
 }
 
@@ -783,7 +783,7 @@ function barList(el, entries, fmtV, maxV) {
   el.innerHTML = entries.map(e =>
     `<div class="brow"><span class="bname" title="${escapeHtml(e.name)}">${escapeHtml(e.label ?? e.name)}</span>` +
     `<span class="btrack">${isFinite(e.v) ? `<span data-style="width:${Math.max(2, e.v / max * 100).toFixed(0)}%;background:${e.color}"></span>` : ''}</span>` +
-    `<span class="bval">${e.vtext ?? (isFinite(e.v) ? fmtV(e.v) : '–')}</span></div>`).join('');
+    `<span class="bval">${escapeHtml(e.vtext ?? (isFinite(e.v) ? fmtV(e.v) : '–'))}</span></div>`).join('');
 }
 
 /* leaderboard rows: chip square + name + value + thin progress bar */

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -2916,14 +2916,27 @@ async fn dashboard_history_settings_markup() {
 
     let settings_js = client()
         .get(proxy.url("/assets/operator/settings.js"))
-        .header("cookie", cookie)
+        .header("cookie", &cookie)
         .send()
         .await
         .unwrap()
         .text()
         .await
         .unwrap();
-    assert!(settings_js.contains("History &amp; dashboard"));
+    let catalog: serde_json::Value = client()
+        .get(proxy.url("/assets/operator/locales/en-US.json"))
+        .header("cookie", &cookie)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(settings_js.contains(r#"data-i18n="settings.server.history.heading""#));
+    assert_eq!(
+        catalog["messages"]["settings.server.history.heading"],
+        "History & dashboard"
+    );
     assert!(settings_js.contains("sv-default-days"));
     assert!(settings_js.contains("sv-retention-days"));
     assert!(settings_js.contains("sv-slo"));


### PR DESCRIPTION
## Summary

Completes catalog ownership for repository-written UI text across Dashboard and Settings, including static labels, dynamic messages, dialogs, validation, accessibility text, plural forms, empty/loading/error states, and the public Login path. Standard operations vocabulary replaces prototype metaphors while API/model/client/publisher/metric/persisted values remain raw and production still ships exactly en-US.

The change extends the existing catalog, source checker, generated test-only en-XA probe, and Rust-owned browser matrix. It adds no frontend framework, dependency, general message parser, visible locale selector, API/wire/config change, or layout redesign.

## Type of change

- [ ] Bug fix (no behavior change beyond the fix)
- [ ] New feature / behavior change
- [ ] Performance / rate-limiting
- [ ] Security / hardening
- [x] Refactor (no behavior change)
- [ ] Docs / knowledge base only
- [ ] CI / build / release infrastructure
- [ ] Release (version bump)

## Related issues

Relates to #96.

## What & why

The prototype accumulated hand-written labels, metaphors, inconsistent terms, English plural branches, and UI-owned transformations of machine data. This PR reconciles each owned string to standard proxy/load-balancer/operations language and routes it through the existing catalog so later translation is mechanical rather than interpretive.

The narrow implementation preserves the current architecture: native DOM text/attribute sinks, explicit CLDR plural IDs selected by one shared cached `Intl.PluralRules`, native confirm/prompt wrappers, and exact raw API/platform errors where present. The affected plan and knowledge pages record the ownership, vocabulary, escaping, formatting, and test boundaries.

## How it was tested

```sh
python3 scripts/check_i18n.py --selftest
# selftest ok — 102 cases, every check observed to fail
python3 scripts/check_i18n.py
# i18n OK — 427 ids referenced, round-trip clean
python3 scripts/locale_v1.py --all
# locale-v1 ok — 1 catalog set(s) clean
python3 scripts/gen_pseudolocale.py --check
# en-XA generation OK — 427 messages, test-only, no production file
node --check scripts/render_check.js
node --check src/web/shared.js
node --check src/web/dashboard.js
node --check src/web/settings.js
node scripts/render_check.js --pseudolocale
# rendered 5 tabs, hovered 17 charts; no uncaught page errors
node scripts/render_check.js --page setup --pseudolocale
# drove 5 wizard steps; no uncaught page errors
node scripts/render_check.js --page login --pseudolocale
# rendered anonymous login from the public catalog; no uncaught page errors
node scripts/render_check.js --all-states --pseudolocale
# interaction matrix ok — 54 named rows observed; no uncaught page errors
TZ=UTC LC_ALL=en_US.UTF-8 node scripts/formatter_fixture.js --check
# formatters unchanged — 125 cases
cargo test --tests
# 135 library, 104 e2e, and 7 OpenAPI tests passed
cargo fmt --check
git diff --check fe69e31..HEAD
```

Independent frozen review and both controller-correction micro-reviews reported no Critical, Important, or Minor findings.

## Screenshots / output

No layout redesign. The generated en-XA served-page probes exercise longer bracketed strings across all named states and confirm zero actionable catalog bypasses.

## Breaking changes & migration

No API, status, content-type, OpenAPI, config/history format, metric, stable identifier, or Rust behavior changes. User-visible English copy is intentionally standardized.

## Checklist

### Code quality
- [x] `cargo fmt --check` is clean.
- ~~`cargo clippy --all-targets -- -D warnings` is clean (zero warnings).~~ — No Rust source or dependency changed; GitHub CI remains authoritative.
- [x] `cargo test` passes locally (unit + end-to-end).
- [x] New behavior ships with tests (unit and/or e2e), and existing guard tests still pass.
- [x] Scope is tight; commit messages explain the *why*.

### Docs & knowledge base — lockstep is a hard rule (see AGENTS.md)
- ~~README / `examples/` updated if user-facing behavior or setup changed.~~ — No setup procedure or example changed.
- [x] Affected `knowledge/` pages updated **in this PR** (code and knowledge must not diverge).
- ~~New decision → new `knowledge/decisions/` page **and** a `knowledge/index.md` row, in ADR shape (Context → Options → Choice → Consequences).~~ — Existing decisions were extended; no new concept page was added.
- [x] Dated entry appended to `knowledge/log.md` (`## [YYYY-MM-DD] ingest|decision|lint — summary`).
- ~~`CHANGELOG.md` `[Unreleased]` updated (Keep a Changelog format).~~ — Integration-level v0.6.6 release notes remain owned by the active plan's release task.

### Security — required if this touches `src/auth.rs`, `src/config.rs`, `src/settings.rs`, the API-key gate or label sanitizing in `src/proxy.rs`, or the dashboard `innerHTML`
- [x] Fail-closed posture preserved (pre-setup data plane closed; post-setup surfaces require a session; corrupt/future-version store refuses to boot).
- [x] Every dynamic value written to `innerHTML` goes through the canonical escape boundary; label sanitizing invariants remain unchanged.
- [x] Reviewed against `SECURITY.md` and the message-catalog/escaping and input-boundary knowledge.

### Rate-limiting — required if this touches pacing, the key pool, the dispatcher, or affinity
- ~~Load harness shows **zero upstream rate violations** (`scripts/mock_nim.py --enforce` + `scripts/loadtest.py`).~~ — No pacing, pool, dispatcher, affinity, or proxy Rust code changed.

### Workflows & supply chain — required if this touches `.github/workflows/**` or the release path
- ~~New/changed Actions are pinned to a full commit SHA with a `# vX.Y.Z` comment; `actionlint` + `zizmor` pass.~~ — No workflow changed.
- ~~Release or version changes follow `knowledge/ops/release.md`.~~ — No release/version artifact changed in this task.

