### PR TITLE
feat: publish canonical history v1 safely

### DIFF
--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -2962,6 +2962,12 @@ publication.
   restart boundaries, invalid-byte preservation, legacy warning/no-mutation,
   idle checkpoints/live capacity, and every injected filesystem failure. No
   GREEN implementation is included in that commit.
+- 2026-07-31: controller review corrected the RED crash-state table before
+  GREEN: pre-link failures leave the canonical path absent, directory-sync
+  failure leaves its linked complete boot as evidence, and append versus sync
+  failures preserve distinct restart-tail states. The RED proof also names the
+  actual unsupported-version diagnostic, a non-file canonical path, stale
+  partial temporary bytes, and exact restart boot-id/checkpoint ownership.
 
 **Files:**
 

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -2957,6 +2957,11 @@ publication.
   #99/project item are Done.
 - 2026-07-31: Task 11 kickoff in
   `work/v0.6.6-task-11-history-store`. Scope delta: none.
+- 2026-07-31: controller review found the initial RED table incomplete. A
+  second RED-only commit expands it to publication races/stale temporaries,
+  restart boundaries, invalid-byte preservation, legacy warning/no-mutation,
+  idle checkpoints/live capacity, and every injected filesystem failure. No
+  GREEN implementation is included in that commit.
 
 **Files:**
 

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -2979,6 +2979,20 @@ publication.
   stale-temporary reporting. Scope delta: none; recovery and compaction remain
   deferred to Tasks 12 and 13.
 
+- 2026-07-31: controller-authorized scope delta adds only
+  `knowledge/ops/configure-env.md` to remove its obsolete legacy-compaction
+  claim. Round-2 review accepts guards that keep canonical history out of the
+  legacy compactor and route partial-write injection through production poison
+  assignment. It rejects a cross-process writer lock: shared `DATA_DIR`
+  operation is unsupported, config/auth have no such coordination, the
+  standard-library lock requires Rust 1.89 while MSRV is 1.87, and unsafe FFI
+  or a dependency violate Task 11. Publication remains no-clobber and each
+  process retains its own writer mutex; this does not claim multi-process
+  writer support.
+- 2026-07-31: fifth RED commit adds a deterministic canonical-mode regression:
+  old compaction generation must stay zero even after the legacy dropped-row
+  threshold is exceeded. It fails against the mixed GREEN implementation with
+  generation `1`; production guard and final proof are pending.
 **Files:**
 
 - Create: `src/history/store.rs`
@@ -2989,6 +3003,8 @@ publication.
 - Modify: `knowledge/decisions/reset-aware-dashboard-history.md`
 - Modify: `knowledge/testing/test-strategy.md`
 - Modify: `knowledge/log.md`
+- Modify: `knowledge/ops/configure-env.md` (controller-authorized fifth-round
+  documentation correction only)
 
 **Interfaces:**
 

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -2971,14 +2971,20 @@ publication.
 - 2026-07-31: GREEN implementation publishes and scans canonical history
   before listener bind, writes a store-owned fresh boot, replays canonical
   samples/checkpoints into the dashboard index, and leaves experimental
-  history opaque. Focused store, fail-closed E2E, history, full-suite, Clippy,
-  formatting, and diff proof are pending final rerun and independent review.
+  history opaque. The scan streams newline-delimited rows in file order and
+  moves validated records once to the index; the runtime writer retains only
+  timestamp/state append boundaries. Its initial proof report is superseded by
+  the controller-validated fourth RED and fifth-round proof below.
 - 2026-07-31: independent review requires a fourth RED-only correction round:
   strict pre-append stream sequencing/newline checks, poisoned runtime append
   behavior, canonical `file_bytes`, split filesystem injection seams, and
   stale-temporary reporting. Scope delta: none; recovery and compaction remain
   deferred to Tasks 12 and 13.
-
+- 2026-07-31: GREEN correction implements the fourth RED table: strict
+  sequencing/newline refusal before a fresh boot append, exact injection
+  seams, poisoned runtime writer, count-only stale-temporary warning, and live
+  canonical file metadata. Scope delta: none; final proof and independent
+  review remain pending.
 - 2026-07-31: controller-authorized scope delta adds only
   `knowledge/ops/configure-env.md` to remove its obsolete legacy-compaction
   claim. Round-2 review accepts guards that keep canonical history out of the
@@ -2991,8 +2997,16 @@ publication.
   writer support.
 - 2026-07-31: fifth RED commit adds a deterministic canonical-mode regression:
   old compaction generation must stay zero even after the legacy dropped-row
-  threshold is exceeded. It fails against the mixed GREEN implementation with
-  generation `1`; production guard and final proof are pending.
+  threshold is exceeded. It failed against mixed GREEN with generation `1`.
+- 2026-07-31: fifth GREEN keeps legacy serialization and compaction inactive
+  whenever canonical storage is active, and makes the partial-write seam run
+  through the production append/poison branch. Fresh proof passed the new
+  deterministic unit, 15 store tests, fail-closed E2E, 58 history unit plus 10
+  history E2E tests, and the full suite (154 unit, 108 E2E, 7 OpenAPI).
+  Formatting, Clippy with warnings denied, and diff checks passed. Independent
+  round-3 review approved the complete package with no blocking findings;
+  GREEN remains uncommitted for the controller's final staged-package check.
+
 **Files:**
 
 - Create: `src/history/store.rs`

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -2942,6 +2942,22 @@ git commit -m "feat: define canonical history v1 records"
 
 **GitHub issue title:** `v0.6.6: publish canonical history v1 safely`
 
+#### Execution record
+
+**Outcome:** Crash-safe canonical history-v1 publication and writes.
+**Proof:** Committed RED publication/startup regression checks followed by the
+named store, E2E, history, full-suite, lint, format, and diff checks.
+**Constraint:** Invalid canonical bytes and experimental `history.jsonl` stay
+untouched; recovery, compaction, API, and scheduler changes remain out of
+scope. **Ponytail Rung:** 3/4 — `std::fs` plus same-directory hard-link
+publication.
+
+- 2026-07-31: Task 10 PR #119 merged into `release/v0.6.6` at
+  `e20c081a5edeba43489ffb4f0b6fad2879217276`; all 11 checks passed and issue
+  #99/project item are Done.
+- 2026-07-31: Task 11 kickoff in
+  `work/v0.6.6-task-11-history-store`. Scope delta: none.
+
 **Files:**
 
 - Create: `src/history/store.rs`

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -2968,6 +2968,16 @@ publication.
   failures preserve distinct restart-tail states. The RED proof also names the
   actual unsupported-version diagnostic, a non-file canonical path, stale
   partial temporary bytes, and exact restart boot-id/checkpoint ownership.
+- 2026-07-31: GREEN implementation publishes and scans canonical history
+  before listener bind, writes a store-owned fresh boot, replays canonical
+  samples/checkpoints into the dashboard index, and leaves experimental
+  history opaque. Focused store, fail-closed E2E, history, full-suite, Clippy,
+  formatting, and diff proof are pending final rerun and independent review.
+- 2026-07-31: independent review requires a fourth RED-only correction round:
+  strict pre-append stream sequencing/newline checks, poisoned runtime append
+  behavior, canonical `file_bytes`, split filesystem injection seams, and
+  stale-temporary reporting. Scope delta: none; recovery and compaction remain
+  deferred to Tasks 12 and 13.
 
 **Files:**
 

--- a/knowledge/architecture/metrics-history.md
+++ b/knowledge/architecture/metrics-history.md
@@ -1,7 +1,7 @@
 ---
 type: Component
 title: Metrics & history (src/history.rs)
-description: Prometheus registry, versioned JSONL snapshots, reset-aware startup index, exact range rollups, and atomic retention compaction.
+description: Prometheus registry, versioned JSONL snapshots, reset-aware startup index, exact range rollups, and deferred canonical retention compaction.
 tags: [metrics, history, prometheus]
 timestamp: 2026-07-02T00:00:00Z
 ---
@@ -17,9 +17,15 @@ longer downloads or parses its raw exposition.
 ## Persisted format
 
 Task 10 defines the canonical successor format, `nimproxy-history/v1`; Task
-11 owns publication and runtime use. Until then, the checked-in runtime still
-uses its experimental history behavior and this codec does not open, read, or
-write any history path.
+11 publishes and appends it at runtime. `HistoryStore::open` streams existing
+canonical rows strictly before appending one fresh boot boundary, or publishes
+the first boot through a unique same-directory temporary, file sync,
+no-overwrite hard link, temporary-name removal, and directory sync. Any empty,
+unterminated, malformed, future-version, mis-sequenced, or timestamp-regressing
+canonical history refuses startup without repair or truncation. A startup
+attempt whose fresh boot append or sync fails also refuses; a sync failure can
+leave a complete valid boot record, while a partial failed tail remains
+evidence.
 
 Every canonical JSONL row begins, in this exact order, with
 `format:"nimproxy-history"`, `v:1`, and `kind`. The complete field order is:
@@ -42,10 +48,19 @@ An unknown `format` or `v` is explicitly `unsupported_format` or
 `unsupported_version`, not corrupt-line recovery; Task 11 uses those errors to
 refuse startup.
 
-The canonical destination is `history-v1.jsonl`. The production runtime must
-never read, rename, truncate, delete, or migrate experimental `history.jsonl`.
-Timestamp stream ordering, startup refusal, checkpoint expansion, and recovery
-semantics are intentionally outside this codec and belong to Tasks 11–12.
+The canonical destination is `history-v1.jsonl`. The production runtime never
+reads, renames, truncates, deletes, migrates, or compacts experimental
+`history.jsonl`; it emits one startup warning containing only that path and
+byte length. Stale same-directory canonical temporaries are likewise opaque
+evidence; startup emits at most one warning containing their count, and never
+their names or contents. A nonempty canonical record must end with a newline;
+file order is authoritative, timestamps never decrease, and every sample or
+checkpoint must follow a matching boot. Canonical samples replay into the
+in-memory dashboard index, and a checkpoint carries forward the latest sample
+only inside its boot epoch. A runtime encode/write/flush/sync failure poisons
+the writer, so later ticks cannot append after partial evidence. `file_bytes`
+is live metadata from the canonical writer. Task 12 owns malformed-stream
+recovery semantics; Task 13 owns compaction.
 
 ### Sanitized corpus evidence
 
@@ -68,14 +83,13 @@ values.
 ## Startup index and range rollups
 
 History indexing is a synchronous startup task and completes before the
-server listens. The parser scans and sorts the complete physical JSONL,
-enforcing exposition metric-line and series bounds. It normalizes every valid
-sample so a pre-retention sample can supply the boundary baseline, then indexes
-only the retained points (or all points when retention is unlimited). Stale
-disk rows may remain until compaction. Startup logs bytes, valid samples,
-skipped records/metric lines, normalized series, inferred resets, and
-duration. This is the only precomputation: page-specific dashboard models are
-deliberately not cached
+server listens. The canonical store streams and validates the physical JSONL
+in file order, then moves its validated records once into the typed index; it
+does not sort, repair, or reread raw rows. It normalizes every valid sample so
+a pre-retention sample can supply the boundary baseline, then indexes only the
+retained points (or all points when retention is unlimited). Canonical startup
+does not promise the older detailed byte/sample diagnostic summary. This is the
+only precomputation: page-specific dashboard models are deliberately not cached
 ([reset-aware decision](../decisions/reset-aware-dashboard-history.md)).
 
 `History::rollup(from, to, points)` returns:
@@ -110,18 +124,9 @@ range revision, so a newly persisted sample cannot be double-counted.
 long as the default dashboard window.
 
 Changing retention in Settings validates and persists the complete config,
-then immediately trims the visible in-memory index. File compaction runs
-off the async executor and writes a temporary file, flushes it, atomically
-renames it, and syncs the directory. It preserves the newest pre-cutoff
-sample as a hidden baseline plus the relevant boot marker, which keeps the
-first retained counter delta exact. A pre-replacement failure leaves the old
-file untouched and the retry pending; a post-rename directory-sync failure is
-reported as committed-but-pending.
-
-At boot, expired rows are excluded from the index immediately and exposed as
-compaction debt for a subsequent append. Routine append-driven compaction also
-starts after more than 288 expired samples accumulate (about one day at the
-five-minute interval). A history-file write failure warns and leaves the
-in-memory index operating, while an unusable `DATA_DIR` or config store is
-still a hard boot error
+then immediately trims the visible in-memory index. Task 11 deliberately does
+not compact canonical history; Task 13 owns the atomic replacement protocol
+and its recovery proof. A canonical history-file write failure warns and
+leaves the in-memory index operating, but poisons further durable writes for
+that process; an unusable `DATA_DIR` or config store is still a hard boot error
 ([configuration](../ops/configure-env.md)).

--- a/knowledge/decisions/reset-aware-dashboard-history.md
+++ b/knowledge/decisions/reset-aware-dashboard-history.md
@@ -41,10 +41,12 @@ history and embedded dashboard should remain lightweight.
 
 Choose option 5.
 
-- Future JSONL records carry an explicit random boot id, boot marker, and
-  sample-time capacity. Existing v1 records stay readable; counter decreases
-  and a no-counters-to-counters transition receive best-effort legacy reset
-  inference with diagnostics.
+- Canonical JSONL records carry a store-owned random boot id, boot marker, and
+  sample-time capacity. Existing valid v1 records stay readable; canonical
+  file order is strict, with nondecreasing timestamps and a matching boot
+  before every sample or checkpoint. Counter decreases and a
+  no-counters-to-counters transition receive best-effort reset inference with
+  diagnostics inside the canonical index.
 - Startup synchronously scans the complete physical JSONL before listening,
   normalizes all valid samples so the retention boundary has a baseline, and
   indexes only retained gauges, deltas, and capacity. Startup latency is
@@ -93,6 +95,15 @@ Choose option 5.
   ([retention decision](history-retention-days-not-size.md)).
 - The old `/api/history` and `/dash/config.json` dashboard transports are
   removed. Prometheus `/metrics` remains for authenticated scrapers.
+
+The v0.6.6 canonical writer establishes its new boot before listening. The
+first sample/checkpoint uses that store-owned id; unchanged normalized state
+writes a checkpoint, while changed state writes a full sample with the live
+capacity supplied at that write. Experimental `history.jsonl` is intentionally
+not an "old v1" reader input and therefore cannot contribute inferred epochs.
+The store streams validation before moving records into the index, and a
+runtime durable-write failure poisons later writes rather than extending a
+partial tail.
 
 See [metrics-history](../architecture/metrics-history.md),
 [dashboard](../architecture/dashboard.md), and

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,22 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-07-31] component — canonical history-v1 fail-closed store
+
+Task 11 publishes `history-v1.jsonl` through a synced same-directory temporary
+and no-overwrite hard link, then appends/syncs a store-owned boot before the
+server listens. Existing canonical bytes are streamed strictly: records must
+be newline-terminated, ordered by nondecreasing timestamp, and sequenced under
+a matching boot. An invalid file or failed startup boot append/sync refuses;
+sync may leave a complete valid boot while a partial tail remains evidence.
+Runtime encode/write/flush/sync failure poisons later writes. Legacy
+`history.jsonl` is only warned by path and size, never parsed or changed;
+stale canonical temporaries are counted once without inspection. Samples carry
+live capacity; unchanged normalized state becomes checkpoints. See
+[metrics history](architecture/metrics-history.md), the
+[reset-aware decision](decisions/reset-aware-dashboard-history.md), and the
+[test strategy](testing/test-strategy.md).
+
 ## [2026-07-31] component — canonical history-v1 codec foundation
 
 Task 10 defines the exact `nimproxy-history/v1` boot, sample, and checkpoint

--- a/knowledge/ops/configure-env.md
+++ b/knowledge/ops/configure-env.md
@@ -58,8 +58,9 @@ default to 30 days. The default window must be at least one day. Retention `0`
 is unlimited; finite retention must be at least the default window. The SLO
 must be a finite percentage greater than 0 and at most 100. A combined save is
 all-or-nothing: any invalid field leaves the persisted and live configuration
-unchanged. Reducing retention trims the visible index immediately and
-schedules atomic background compaction of `history.jsonl`.
+unchanged. Reducing retention trims the visible index immediately. Task 11
+does not compact canonical `history-v1.jsonl` or experimental `history.jsonl`;
+Task 13 owns the atomic canonical-compaction protocol.
 
 **Legacy env vars are ignored.** `NIM_API_KEYS`, `PROXY_API_KEYS`,
 `ADMIN_PASSWORD`, `INSECURE_NO_AUTH`, `NIM_BASE_URL`, `RPM_PER_KEY`,

--- a/knowledge/testing/test-strategy.md
+++ b/knowledge/testing/test-strategy.md
@@ -34,6 +34,15 @@ that proof.
   prompt, completion, or client-selected value. This unit proof does not open
   a history file or establish stream ordering; storage/startup and recovery
   proofs are separate work.
+- **Canonical history store:** `cargo test history::store::tests --lib`
+  exercises hard-link first publication, concurrent creators, stale temporary
+  preservation, newline and stream-order refusal, fresh restart boot
+  boundaries, poisoned partial runtime writes, changed-sample versus
+  idle-checkpoint writes, live capacity, and each test-local filesystem failure
+  point. `cargo test --test e2e history_startup_is_fail_closed -- --exact`
+  proves the real binary never listens with empty, corrupt, or future canonical
+  history; the named stale-temporary and config-history E2E checks prove opaque
+  count-only warning and live canonical `file_bytes` reporting.
 - **Handlers or wire types:** `UPDATE_OPENAPI=1 cargo test --test openapi`,
   then verify that `openapi.json` has only the deliberate diff.
 - **HTTP trust boundaries:** `cargo test routes::tests --lib` proves the

--- a/src/history.rs
+++ b/src/history.rs
@@ -19,6 +19,7 @@ use utoipa::ToSchema;
 // it to storage; until then no runtime caller constructs canonical records.
 #[allow(dead_code)]
 pub mod codec;
+pub mod store;
 
 pub const SAMPLE_SECS: u64 = 300;
 const MAX_EXPOSITION_LINE_BYTES: usize = 1024 * 1024;

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,9 +1,8 @@
-//! Metrics history: the sampler appends one full Prometheus snapshot at
-//! startup and every 5 minutes thereafter when a data dir is writable, then
-//! normalizes it into a typed in-memory index. Dashboard range queries consume
-//! exact totals plus bounded rollup points from that index. Snapshot size
-//! varies with registry cardinality; retention is an operator-facing time
-//! boundary rather than a predicted byte cap.
+//! Metrics history uses a canonical, newline-delimited v1 store. It publishes
+//! a boot record before listeners start, then writes normalized state samples
+//! or idle checkpoints as the sampler runs. Dashboard range queries consume a
+//! typed in-memory index reconstructed from the store's already-validated
+//! records. The prior `history.jsonl` format remains opaque reset evidence.
 
 use std::collections::BTreeMap;
 use std::fs;
@@ -20,6 +19,8 @@ use utoipa::ToSchema;
 #[allow(dead_code)]
 pub mod codec;
 pub mod store;
+
+pub type MetricState = codec::StateEntry;
 
 pub const SAMPLE_SECS: u64 = 300;
 const MAX_EXPOSITION_LINE_BYTES: usize = 1024 * 1024;
@@ -296,6 +297,84 @@ fn normalize(
     }
 }
 
+fn canonical_capacity(capacity: &CapacitySnapshot) -> codec::Capacity {
+    codec::Capacity {
+        capacity_rpm: capacity.capacity_rpm,
+        enabled_keys: capacity.enabled_lanes,
+        key_rpms: capacity.rpms.clone(),
+    }
+}
+
+fn canonical_state(snapshot: &ParsedSnapshot) -> Vec<MetricState> {
+    let mut state = Vec::with_capacity(snapshot.counters.len() + snapshot.gauges.len());
+    for (key, value) in &snapshot.counters {
+        state.push(MetricState {
+            kind: codec::StateKind::Counter,
+            metric: key.metric.clone(),
+            labels: key.labels.clone(),
+            value: *value,
+        });
+    }
+    for (key, value) in &snapshot.gauges {
+        state.push(MetricState {
+            kind: codec::StateKind::Gauge,
+            metric: key.metric.clone(),
+            labels: key.labels.clone(),
+            value: *value,
+        });
+    }
+    state
+}
+
+fn parsed_canonical_state(state: &[MetricState]) -> ParsedSnapshot {
+    let mut parsed = ParsedSnapshot::default();
+    for entry in state {
+        let key = MetricKey {
+            metric: entry.metric.clone(),
+            labels: entry.labels.clone(),
+        };
+        match entry.kind {
+            codec::StateKind::Counter => {
+                parsed.counters.insert(key, entry.value);
+            }
+            codec::StateKind::Gauge => {
+                parsed.gauges.insert(key, entry.value);
+            }
+        }
+    }
+    parsed
+}
+
+fn ingest_canonical_sample(
+    inner: &mut HistoryInner,
+    timestamp: u64,
+    boot_id: String,
+    capacity: codec::Capacity,
+    current: ParsedSnapshot,
+    cutoff: Option<u64>,
+) {
+    let reset =
+        inner.last_parsed.is_some() && inner.last_sample_boot.as_deref() != Some(boot_id.as_str());
+    let normalized = normalize(inner.last_parsed.as_ref(), &current, reset);
+    inner.diagnostics.valid_samples += 1;
+    inner.diagnostics.normalized_series += normalized.deltas.len() + normalized.gauges.len();
+    if cutoff.is_none_or(|cutoff| timestamp >= cutoff) {
+        inner.points.push(IndexedPoint {
+            t: timestamp,
+            deltas: normalized.deltas,
+            gauges: normalized.gauges,
+            capacity: Some(CapacitySnapshot {
+                enabled_lanes: capacity.enabled_keys,
+                rpms: capacity.key_rpms,
+                capacity_rpm: capacity.capacity_rpm,
+            }),
+        });
+    }
+    inner.revision = inner.revision.wrapping_add(1);
+    inner.last_parsed = Some(current);
+    inner.last_sample_boot = Some(boot_id);
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct CapacitySnapshot {
     pub enabled_lanes: usize,
@@ -457,9 +536,90 @@ pub struct History {
     boot_id: String,
     boot_t: u64,
     initial_capacity: CapacitySnapshot,
+    canonical: Option<Mutex<store::HistoryStore>>,
 }
 
 impl History {
+    /// Open the canonical store before any listener exists. The legacy reader
+    /// is intentionally not consulted here: `history.jsonl` remains opaque
+    /// reset evidence, not input to the new format.
+    pub fn open(
+        dir: PathBuf,
+        days: u64,
+        initial_capacity: CapacitySnapshot,
+    ) -> Result<Self, store::OpenError> {
+        let timestamp = unix_now();
+        let capacity = canonical_capacity(&initial_capacity);
+        if let Ok(count) = store::stale_temporary_count(&dir) {
+            if count > 0 {
+                tracing::warn!("stale canonical history temporaries: count={count}");
+            }
+        }
+        let mut canonical = store::HistoryStore::open(&dir, timestamp, capacity)?;
+        let legacy = dir.join("history.jsonl");
+        if let Ok(metadata) = fs::metadata(&legacy) {
+            tracing::warn!(
+                "legacy history ignored: path={} bytes={}",
+                legacy.display(),
+                metadata.len()
+            );
+        }
+        let mut history = Self::load(None, days, initial_capacity);
+        let records = canonical.take_replay_records();
+        history.load_canonical(&records, days);
+        history.boot_id = canonical.boot_id().to_owned();
+        history.boot_t = timestamp;
+        history.canonical = Some(Mutex::new(canonical));
+        Ok(history)
+    }
+
+    fn load_canonical(&mut self, records: &[codec::Record], days: u64) {
+        let cutoff = (days > 0).then(|| unix_now().saturating_sub(days.saturating_mul(86_400)));
+        let mut current_boot = None;
+        let mut current_state = None;
+        let mut inner = self.inner.lock().unwrap();
+
+        for record in records {
+            match record {
+                codec::Record::Boot(boot) => {
+                    current_boot = Some(boot.boot_id.clone());
+                    current_state = None;
+                }
+                codec::Record::Sample(sample) => {
+                    let parsed = parsed_canonical_state(&sample.state);
+                    ingest_canonical_sample(
+                        &mut inner,
+                        sample.timestamp,
+                        sample.boot_id.clone(),
+                        sample.capacity.clone(),
+                        parsed,
+                        cutoff,
+                    );
+                    current_boot = Some(sample.boot_id.clone());
+                    current_state = Some(sample.state.clone());
+                }
+                codec::Record::Checkpoint(checkpoint)
+                    if current_boot.as_deref() == Some(checkpoint.boot_id.as_str()) =>
+                {
+                    if let Some(state) = &current_state {
+                        let parsed = parsed_canonical_state(state);
+                        ingest_canonical_sample(
+                            &mut inner,
+                            checkpoint.timestamp,
+                            checkpoint.boot_id.clone(),
+                            checkpoint.capacity.clone(),
+                            parsed,
+                            cutoff,
+                        );
+                    }
+                }
+                codec::Record::Checkpoint(_) => {}
+            }
+        }
+        inner.available_from = inner.points.first().map(|point| point.t);
+        inner.available_to = inner.points.last().map(|point| point.t);
+    }
+
     pub fn load(dir: Option<PathBuf>, days: u64, initial_capacity: CapacitySnapshot) -> Self {
         let started = std::time::Instant::now();
         let boot_t = unix_now();
@@ -578,6 +738,7 @@ impl History {
             boot_id,
             boot_t,
             initial_capacity,
+            canonical: None,
         };
         history.persist_boot_marker();
         let inner = history.inner.lock().unwrap();
@@ -637,11 +798,21 @@ impl History {
             (inner.available_from, inner.available_to)
         };
         let compaction_pending = self.compaction_pending.load(Ordering::SeqCst);
-        let file_bytes = self
-            .file
-            .as_ref()
-            .and_then(|path| fs::metadata(path).ok())
-            .map_or(0, |metadata| metadata.len());
+        let file_bytes = self.canonical.as_ref().map_or_else(
+            || {
+                self.file
+                    .as_ref()
+                    .and_then(|path| fs::metadata(path).ok())
+                    .map_or(0, |metadata| metadata.len())
+            },
+            |store| {
+                store
+                    .lock()
+                    .ok()
+                    .and_then(|store| store.file_bytes().ok())
+                    .unwrap_or(0)
+            },
+        );
         HistoryStatus {
             available_from,
             available_to,
@@ -652,6 +823,7 @@ impl History {
 
     pub fn append(self: &Arc<Self>, t: u64, snapshot: &str, capacity: CapacitySnapshot) {
         let current = parse_exposition(snapshot);
+        let canonical_state = canonical_state(&current);
         let mut inner = self.inner.lock().unwrap();
         // Wall clocks can move backward, and a retained file can contain a
         // future-dated point. Keep ingestion order without fabricating time:
@@ -687,22 +859,36 @@ impl History {
         inner.last_sample_boot = Some(self.boot_id.clone());
         drop(inner);
 
-        let line = serde_json::to_string(&SampleRecord {
-            v: 2,
-            t,
-            boot: &self.boot_id,
-            capacity: &capacity,
-            m: snapshot,
-        })
-        .expect("history sample record serializes");
-        self.persist_sample(&line);
+        if self.file.is_some() {
+            let line = serde_json::to_string(&SampleRecord {
+                v: 2,
+                t,
+                boot: &self.boot_id,
+                capacity: &capacity,
+                m: snapshot,
+            })
+            .expect("history sample record serializes");
+            self.persist_sample(&line);
+        }
 
-        if self.compaction_pending.load(Ordering::SeqCst) {
-            self.start_pending_compaction();
-        } else if days > 0
-            && *self.dropped_since_compact.lock().unwrap() > COMPACT_AFTER_EXPIRED_SAMPLES
-        {
-            self.request_compaction(t.saturating_sub(days.saturating_mul(86_400)));
+        if let Some(store) = &self.canonical {
+            if let Err(error) = store.lock().unwrap().append_sample(
+                t,
+                canonical_capacity(&capacity),
+                canonical_state,
+            ) {
+                tracing::warn!("canonical history append failed: {error}");
+            }
+        }
+
+        if self.file.is_some() {
+            if self.compaction_pending.load(Ordering::SeqCst) {
+                self.start_pending_compaction();
+            } else if days > 0
+                && *self.dropped_since_compact.lock().unwrap() > COMPACT_AFTER_EXPIRED_SAMPLES
+            {
+                self.request_compaction(t.saturating_sub(days.saturating_mul(86_400)));
+            }
         }
     }
 
@@ -1166,6 +1352,7 @@ mod tests {
             boot_id: "00000000000000000000000000000000".to_owned(),
             boot_t: 0,
             initial_capacity: capacity(40),
+            canonical: None,
         })
     }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -1422,6 +1422,22 @@ nimproxy_ttft_seconds_count{model="z-ai/glm-5.2"} 4
         assert_eq!(value(&rollup.totals, "requests_total"), 15.0);
     }
 
+    #[tokio::test]
+    async fn canonical_history_never_schedules_legacy_compaction() {
+        let dir = TestDir::new();
+        let history = Arc::new(History::open(dir.0.clone(), 1, capacity(40)).unwrap());
+        *history.dropped_since_compact.lock().unwrap() = COMPACT_AFTER_EXPIRED_SAMPLES + 1;
+
+        history.append(unix_now(), SNAPSHOT, capacity(40));
+
+        assert_eq!(
+            history.compaction_generation.load(Ordering::SeqCst),
+            0,
+            "canonical history must not schedule the legacy compactor"
+        );
+        assert!(!history.compaction_pending.load(Ordering::SeqCst));
+    }
+
     /// A unique per-test scratch dir (std-only; removed on drop).
     struct TestDir(PathBuf);
     impl TestDir {

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -4,8 +4,8 @@
 mod tests {
     use std::fs;
 
-    use super::{HistoryStore, OpenError};
-    use crate::history::codec::{decode_record, Capacity, Record};
+    use super::{open_with_test_failure, FailurePoint, HistoryStore, OpenError, WriteError};
+    use crate::history::codec::{decode_record, Capacity, Record, StateEntry, StateKind};
 
     fn capacity() -> Capacity {
         Capacity {
@@ -13,6 +13,27 @@ mod tests {
             enabled_keys: 2,
             key_rpms: vec![40, 40],
         }
+    }
+
+    fn state(value: f64) -> Vec<StateEntry> {
+        vec![StateEntry {
+            kind: StateKind::Counter,
+            metric: "nimproxy_requests_total".into(),
+            labels: Default::default(),
+            value,
+        }]
+    }
+
+    fn test_dir(label: &str) -> std::path::PathBuf {
+        static SERIAL: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "nim-proxy-history-store-{label}-{}-{}",
+            std::process::id(),
+            SERIAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
     }
 
     #[test]
@@ -60,5 +81,190 @@ mod tests {
         assert!(matches!(error, OpenError::InvalidCanonical { .. }));
         assert_eq!(fs::read(path).unwrap(), before);
         let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn missing_parent_directory_is_created_for_first_publication() {
+        // This catches assuming the caller pre-created DATA_DIR.
+        let dir = test_dir("missing-parent").join("new").join("data");
+        HistoryStore::open(&dir, 1, capacity()).unwrap();
+        assert!(dir.join("history-v1.jsonl").is_file());
+        let _ = fs::remove_dir_all(dir.parent().unwrap().parent().unwrap());
+    }
+
+    #[test]
+    fn concurrent_first_open_has_one_published_boot_without_clobbering_it() {
+        // This catches check-then-rename publication, which can replace a
+        // concurrent creator's evidence.
+        let dir = test_dir("concurrent");
+        let first = std::thread::scope(|scope| {
+            let left = scope.spawn(|| HistoryStore::open(&dir, 1, capacity()));
+            let right = scope.spawn(|| HistoryStore::open(&dir, 2, capacity()));
+            (left.join().unwrap(), right.join().unwrap())
+        });
+        assert!(
+            first.0.is_ok() && first.1.is_ok(),
+            "both creators can use the winner"
+        );
+        let records = fs::read_to_string(dir.join("history-v1.jsonl")).unwrap();
+        assert_eq!(
+            records.lines().count(),
+            2,
+            "each successful process owns one boot"
+        );
+        assert!(records
+            .lines()
+            .all(|line| decode_record(line.as_bytes()).is_ok()));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn stale_temporary_is_ignored_and_left_as_evidence() {
+        // This catches parsing or deleting a stale publication temporary.
+        let dir = test_dir("stale-temp");
+        let stale = dir.join("history-v1.jsonl.tmp-stale");
+        let stale_bytes = b"partial evidence";
+        fs::write(&stale, stale_bytes).unwrap();
+        HistoryStore::open(&dir, 1, capacity()).unwrap();
+        assert_eq!(fs::read(stale).unwrap(), stale_bytes);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn valid_restart_appends_a_new_boot_and_keeps_it_for_first_sample() {
+        // This catches using a caller-provided boot id or crossing a reset
+        // boundary before the new process has written one.
+        let dir = test_dir("restart");
+        let mut first = HistoryStore::open(&dir, 1, capacity()).unwrap();
+        first.append_sample(2, capacity(), state(1.0)).unwrap();
+        drop(first);
+        let mut second = HistoryStore::open(&dir, 3, capacity()).unwrap();
+        second.append_sample(4, capacity(), state(1.0)).unwrap();
+        let records = fs::read_to_string(dir.join("history-v1.jsonl")).unwrap();
+        let records: Vec<_> = records
+            .lines()
+            .map(|line| decode_record(line.as_bytes()).unwrap())
+            .collect();
+        assert!(
+            matches!(records[2], Record::Boot(_)),
+            "restart boot precedes new epoch state"
+        );
+        assert!(
+            matches!(records[3], Record::Sample(_)),
+            "first new-epoch state is full"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn invalid_empty_corrupt_and_future_files_remain_exactly_unchanged() {
+        // This catches treating existing invalid evidence as a missing file.
+        for (name, before) in [
+            ("empty", b"".as_slice()),
+            ("corrupt", b"{not json}\n".as_slice()),
+            ("future", br#"{"format":"nimproxy-history","v":2,"kind":"boot","timestamp":1,"boot_id":"x","capacity":{"capacity_rpm":80,"enabled_keys":2,"key_rpms":[40,40]}}\n"#),
+        ] {
+            let dir = test_dir(name);
+            let path = dir.join("history-v1.jsonl");
+            fs::write(&path, before).unwrap();
+            assert!(HistoryStore::open(&dir, 2, capacity()).is_err());
+            assert_eq!(fs::read(path).unwrap(), before, "{name} canonical evidence");
+            let _ = fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
+    fn legacy_file_is_never_parsed_or_mutated_when_canonical_is_absent_or_present() {
+        // This catches accidental migration or a compatibility reader.
+        for canonical in [false, true] {
+            let dir = test_dir(if canonical {
+                "legacy-plus-canonical"
+            } else {
+                "legacy-only"
+            });
+            let legacy = dir.join("history.jsonl");
+            let legacy_bytes = b"legacy bytes stay opaque\n";
+            fs::write(&legacy, legacy_bytes).unwrap();
+            if canonical {
+                HistoryStore::open(&dir, 1, capacity()).unwrap();
+            }
+            HistoryStore::open(&dir, 2, capacity()).unwrap();
+            assert_eq!(fs::read(legacy).unwrap(), legacy_bytes);
+            let _ = fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
+    fn changed_state_writes_sample_unchanged_state_writes_checkpoint_and_capacity_is_live() {
+        // This catches re-emitting full idle snapshots or freezing capacity at open.
+        let dir = test_dir("idle");
+        let mut store = HistoryStore::open(&dir, 1, capacity()).unwrap();
+        store.append_sample(2, capacity(), state(1.0)).unwrap();
+        let changed_capacity = Capacity {
+            capacity_rpm: 20,
+            enabled_keys: 1,
+            key_rpms: vec![20],
+        };
+        store
+            .append_sample(3, changed_capacity.clone(), state(1.0))
+            .unwrap();
+        store
+            .append_sample(4, changed_capacity.clone(), state(2.0))
+            .unwrap();
+        let records = fs::read_to_string(dir.join("history-v1.jsonl")).unwrap();
+        let records: Vec<_> = records
+            .lines()
+            .map(|line| decode_record(line.as_bytes()).unwrap())
+            .collect();
+        assert!(matches!(records[2], Record::Checkpoint(_)));
+        let Record::Checkpoint(checkpoint) = &records[2] else {
+            unreachable!()
+        };
+        assert_eq!(checkpoint.capacity, changed_capacity);
+        assert!(matches!(records[3], Record::Sample(_)));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn every_injected_filesystem_failure_fires_and_preserves_canonical_bytes() {
+        // This catches tests that merely configure a failure without proving
+        // the intended operation was actually reached.
+        for point in [
+            FailurePoint::Create,
+            FailurePoint::Write,
+            FailurePoint::Sync,
+            FailurePoint::Link,
+            FailurePoint::DirectorySync,
+            FailurePoint::Append,
+        ] {
+            let dir = test_dir("injected");
+            let canonical = dir.join("history-v1.jsonl");
+            let before = fs::read(&canonical).ok();
+            let failure = open_with_test_failure(&dir, 1, capacity(), point);
+            assert!(failure.result.is_err(), "{point:?} must reject startup");
+            assert_eq!(failure.fired, Some(point), "{point:?} injection must fire");
+            assert_eq!(
+                fs::read(&canonical).ok(),
+                before,
+                "{point:?} must not alter canonical bytes"
+            );
+            let _ = fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
+    fn append_and_sync_failures_do_not_hide_partial_tail_evidence() {
+        // This catches truncate/repair after a failed restart boot append.
+        for point in [FailurePoint::Append, FailurePoint::Sync] {
+            let dir = test_dir("restart-failure");
+            HistoryStore::open(&dir, 1, capacity()).unwrap();
+            let before = fs::read(dir.join("history-v1.jsonl")).unwrap();
+            let failure = open_with_test_failure(&dir, 2, capacity(), point);
+            assert!(failure.result.is_err());
+            assert_eq!(failure.fired, Some(point));
+            let after = fs::read(dir.join("history-v1.jsonl")).unwrap();
+            assert!(after.starts_with(&before), "failed tail remains evidence");
+            let _ = fs::remove_dir_all(dir);
+        }
     }
 }

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -1,0 +1,64 @@
+//! Durable publication and append boundary for canonical history-v1.
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::{HistoryStore, OpenError};
+    use crate::history::codec::{decode_record, Capacity, Record};
+
+    fn capacity() -> Capacity {
+        Capacity {
+            capacity_rpm: 80,
+            enabled_keys: 2,
+            key_rpms: vec![40, 40],
+        }
+    }
+
+    #[test]
+    fn first_open_publishes_one_synced_canonical_boot_record() {
+        // This catches a missing safe-publication boundary, including an
+        // accidental fallback to the legacy history.jsonl path.
+        let dir = std::env::temp_dir().join(format!(
+            "nim-proxy-history-store-red-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        let result = HistoryStore::open(&dir, 1_000, capacity());
+        assert!(
+            result.is_ok(),
+            "missing canonical path must publish a boot: {result:?}"
+        );
+
+        let bytes = fs::read(dir.join("history-v1.jsonl")).unwrap();
+        let Record::Boot(boot) = decode_record(bytes.trim_ascii_end()).unwrap() else {
+            panic!("publication must contain a canonical boot record");
+        };
+        assert_eq!(boot.timestamp, 1_000);
+        assert_eq!(boot.capacity, capacity());
+        assert!(!boot.boot_id.is_empty(), "store owns a fresh boot id");
+        assert!(!dir.join("history.jsonl").exists());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn invalid_canonical_history_refuses_without_changing_its_bytes() {
+        // This catches accepting a corrupt canonical file as if it were absent.
+        let dir = std::env::temp_dir().join(format!(
+            "nim-proxy-history-store-red-invalid-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("history-v1.jsonl");
+        let before = b"{not canonical}\n";
+        fs::write(&path, before).unwrap();
+
+        let error = HistoryStore::open(&dir, 1_000, capacity()).unwrap_err();
+        assert!(matches!(error, OpenError::InvalidCanonical { .. }));
+        assert_eq!(fs::read(path).unwrap(), before);
+        let _ = fs::remove_dir_all(dir);
+    }
+}

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -4,7 +4,7 @@
 mod tests {
     use std::fs;
 
-    use super::{open_with_test_failure, FailurePoint, HistoryStore, OpenError, WriteError};
+    use super::{open_with_test_failure, FailurePoint, HistoryStore, OpenError};
     use crate::history::codec::{decode_record, Capacity, Record, StateEntry, StateKind};
 
     fn capacity() -> Capacity {
@@ -123,7 +123,7 @@ mod tests {
         // This catches parsing or deleting a stale publication temporary.
         let dir = test_dir("stale-temp");
         let stale = dir.join("history-v1.jsonl.tmp-stale");
-        let stale_bytes = b"partial evidence";
+        let stale_bytes = b"{partial canonical boot evidence";
         fs::write(&stale, stale_bytes).unwrap();
         HistoryStore::open(&dir, 1, capacity()).unwrap();
         assert_eq!(fs::read(stale).unwrap(), stale_bytes);
@@ -131,7 +131,7 @@ mod tests {
     }
 
     #[test]
-    fn valid_restart_appends_a_new_boot_and_keeps_it_for_first_sample() {
+    fn valid_restart_has_a_distinct_boot_id_for_its_first_checkpoint_and_sample() {
         // This catches using a caller-provided boot id or crossing a reset
         // boundary before the new process has written one.
         let dir = test_dir("restart");
@@ -139,20 +139,20 @@ mod tests {
         first.append_sample(2, capacity(), state(1.0)).unwrap();
         drop(first);
         let mut second = HistoryStore::open(&dir, 3, capacity()).unwrap();
-        second.append_sample(4, capacity(), state(1.0)).unwrap();
+        second.checkpoint(4, capacity()).unwrap();
+        second.append_sample(5, capacity(), state(1.0)).unwrap();
         let records = fs::read_to_string(dir.join("history-v1.jsonl")).unwrap();
         let records: Vec<_> = records
             .lines()
             .map(|line| decode_record(line.as_bytes()).unwrap())
             .collect();
-        assert!(
-            matches!(records[2], Record::Boot(_)),
-            "restart boot precedes new epoch state"
-        );
-        assert!(
-            matches!(records[3], Record::Sample(_)),
-            "first new-epoch state is full"
-        );
+        let Record::Boot(first_boot) = &records[0] else { panic!("first record must boot") };
+        let Record::Boot(second_boot) = &records[2] else { panic!("restart must boot") };
+        let Record::Checkpoint(first_after_restart) = &records[3] else { panic!("first restart record after boot must exercise checkpoint") };
+        let Record::Sample(second_after_restart) = &records[4] else { panic!("restart state must be a full sample") };
+        assert_ne!(first_boot.boot_id, second_boot.boot_id, "each process owns a new reset id");
+        assert_eq!(first_after_restart.boot_id, second_boot.boot_id);
+        assert_eq!(second_after_restart.boot_id, second_boot.boot_id);
         let _ = fs::remove_dir_all(dir);
     }
 
@@ -162,15 +162,28 @@ mod tests {
         for (name, before) in [
             ("empty", b"".as_slice()),
             ("corrupt", b"{not json}\n".as_slice()),
-            ("future", br#"{"format":"nimproxy-history","v":2,"kind":"boot","timestamp":1,"boot_id":"x","capacity":{"capacity_rpm":80,"enabled_keys":2,"key_rpms":[40,40]}}\n"#),
+            ("future", b"{\"format\":\"nimproxy-history\",\"v\":2,\"kind\":\"boot\",\"timestamp\":1,\"boot_id\":\"x\",\"capacity\":{\"capacity_rpm\":80,\"enabled_keys\":2,\"key_rpms\":[40,40]}}\n".as_slice()),
         ] {
             let dir = test_dir(name);
             let path = dir.join("history-v1.jsonl");
             fs::write(&path, before).unwrap();
+            if name == "future" {
+                assert_eq!(decode_record(before.trim_ascii_end()).unwrap_err().diagnostic(), "unsupported_version");
+            }
             assert!(HistoryStore::open(&dir, 2, capacity()).is_err());
             assert_eq!(fs::read(path).unwrap(), before, "{name} canonical evidence");
             let _ = fs::remove_dir_all(dir);
         }
+    }
+
+    #[test]
+    fn canonical_non_file_path_refuses_without_replacing_it() {
+        let dir = test_dir("canonical-directory");
+        let canonical = dir.join("history-v1.jsonl");
+        fs::create_dir(&canonical).unwrap();
+        assert!(HistoryStore::open(&dir, 1, capacity()).is_err());
+        assert!(canonical.is_dir(), "failed open must not replace path evidence");
+        let _ = fs::remove_dir_all(dir);
     }
 
     #[test]
@@ -226,30 +239,28 @@ mod tests {
     }
 
     #[test]
-    fn every_injected_filesystem_failure_fires_and_preserves_canonical_bytes() {
+    fn publication_failures_preserve_their_actual_crash_state_and_fire() {
         // This catches tests that merely configure a failure without proving
         // the intended operation was actually reached.
-        for point in [
-            FailurePoint::Create,
-            FailurePoint::Write,
-            FailurePoint::Sync,
-            FailurePoint::Link,
-            FailurePoint::DirectorySync,
-            FailurePoint::Append,
-        ] {
+        for point in [FailurePoint::Create, FailurePoint::Write, FailurePoint::Sync, FailurePoint::Link] {
             let dir = test_dir("injected");
             let canonical = dir.join("history-v1.jsonl");
-            let before = fs::read(&canonical).ok();
             let failure = open_with_test_failure(&dir, 1, capacity(), point);
             assert!(failure.result.is_err(), "{point:?} must reject startup");
             assert_eq!(failure.fired, Some(point), "{point:?} injection must fire");
-            assert_eq!(
-                fs::read(&canonical).ok(),
-                before,
-                "{point:?} must not alter canonical bytes"
-            );
+            assert!(!canonical.exists(), "{point:?} occurs before publication");
+            if point != FailurePoint::Create {
+                assert!(fs::read_dir(&dir).unwrap().any(|entry| entry.unwrap().file_name().to_string_lossy().starts_with("history-v1.jsonl.tmp-")));
+            }
             let _ = fs::remove_dir_all(dir);
         }
+        let dir = test_dir("directory-sync");
+        let canonical = dir.join("history-v1.jsonl");
+        let failure = open_with_test_failure(&dir, 1, capacity(), FailurePoint::DirectorySync);
+        assert!(failure.result.is_err());
+        assert_eq!(failure.fired, Some(FailurePoint::DirectorySync));
+        let Record::Boot(_) = decode_record(&fs::read(&canonical).unwrap()).unwrap() else { panic!("directory-sync failure retains linked boot") };
+        let _ = fs::remove_dir_all(dir);
     }
 
     #[test]
@@ -264,6 +275,11 @@ mod tests {
             assert_eq!(failure.fired, Some(point));
             let after = fs::read(dir.join("history-v1.jsonl")).unwrap();
             assert!(after.starts_with(&before), "failed tail remains evidence");
+            if point == FailurePoint::Append {
+                assert_eq!(after, before, "append failure writes no new tail");
+            } else {
+                assert!(after.len() > before.len(), "sync failure retains partial new boot tail");
+            }
             let _ = fs::remove_dir_all(dir);
         }
     }

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -4,7 +4,7 @@
 mod tests {
     use std::fs;
 
-    use super::{open_with_test_failure, FailurePoint, HistoryStore, OpenError};
+    use super::{append_with_test_failure, open_with_test_failure, FailurePoint, HistoryStore, OpenError};
     use crate::history::codec::{decode_record, Capacity, Record, StateEntry, StateKind};
 
     fn capacity() -> Capacity {
@@ -80,6 +80,41 @@ mod tests {
         let error = HistoryStore::open(&dir, 1_000, capacity()).unwrap_err();
         assert!(matches!(error, OpenError::InvalidCanonical { .. }));
         assert_eq!(fs::read(path).unwrap(), before);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn structurally_invalid_canonical_streams_refuse_before_fresh_boot_append() {
+        let boot = b"{\"format\":\"nimproxy-history\",\"v\":1,\"kind\":\"boot\",\"timestamp\":10,\"boot_id\":\"boot-a\",\"capacity\":{\"capacity_rpm\":80,\"enabled_keys\":2,\"key_rpms\":[40,40]}}\n";
+        let sample_a = b"{\"format\":\"nimproxy-history\",\"v\":1,\"kind\":\"sample\",\"timestamp\":11,\"boot_id\":\"boot-a\",\"capacity\":{\"capacity_rpm\":80,\"enabled_keys\":2,\"key_rpms\":[40,40]},\"state\":[]}\n";
+        let sample_b = b"{\"format\":\"nimproxy-history\",\"v\":1,\"kind\":\"sample\",\"timestamp\":11,\"boot_id\":\"boot-b\",\"capacity\":{\"capacity_rpm\":80,\"enabled_keys\":2,\"key_rpms\":[40,40]},\"state\":[]}\n";
+        let checkpoint_b = b"{\"format\":\"nimproxy-history\",\"v\":1,\"kind\":\"checkpoint\",\"timestamp\":11,\"boot_id\":\"boot-b\",\"capacity\":{\"capacity_rpm\":80,\"enabled_keys\":2,\"key_rpms\":[40,40]}}\n";
+        let checkpoint_a = b"{\"format\":\"nimproxy-history\",\"v\":1,\"kind\":\"checkpoint\",\"timestamp\":11,\"boot_id\":\"boot-a\",\"capacity\":{\"capacity_rpm\":80,\"enabled_keys\":2,\"key_rpms\":[40,40]}}\n";
+        let sample_mismatch = [boot.as_slice(), sample_b.as_slice()].concat();
+        let checkpoint_mismatch = [boot.as_slice(), checkpoint_b.as_slice()].concat();
+        let regression = [boot.as_slice(), sample_a.as_slice(), boot.as_slice()].concat();
+        for (name, bytes) in [("sample-before-boot", sample_a.as_slice()), ("sample-boot-mismatch", sample_mismatch.as_slice()), ("checkpoint-boot-mismatch", checkpoint_mismatch.as_slice()), ("timestamp-regression", regression.as_slice())] {
+            let dir = test_dir(name);
+            let path = dir.join("history-v1.jsonl");
+            fs::write(&path, bytes).unwrap();
+            assert!(HistoryStore::open(&dir, 20, capacity()).is_err(), "{name}");
+            assert_eq!(fs::read(&path).unwrap(), bytes, "{name} stays evidence");
+            let _ = fs::remove_dir_all(dir);
+        }
+        let dir = test_dir("checkpoint-after-boot");
+        fs::write(dir.join("history-v1.jsonl"), [boot.as_slice(), checkpoint_a.as_slice()].concat()).unwrap();
+        HistoryStore::open(&dir, 20, capacity()).unwrap();
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn final_canonical_record_requires_a_terminating_newline() {
+        let dir = test_dir("unterminated-record");
+        let path = dir.join("history-v1.jsonl");
+        let bytes = b"{\"format\":\"nimproxy-history\",\"v\":1,\"kind\":\"boot\",\"timestamp\":1,\"boot_id\":\"boot-a\",\"capacity\":{\"capacity_rpm\":80,\"enabled_keys\":2,\"key_rpms\":[40,40]}}";
+        fs::write(&path, bytes).unwrap();
+        assert!(HistoryStore::open(&dir, 2, capacity()).is_err());
+        assert_eq!(fs::read(path).unwrap(), bytes);
         let _ = fs::remove_dir_all(dir);
     }
 
@@ -242,23 +277,23 @@ mod tests {
     fn publication_failures_preserve_their_actual_crash_state_and_fire() {
         // This catches tests that merely configure a failure without proving
         // the intended operation was actually reached.
-        for point in [FailurePoint::Create, FailurePoint::Write, FailurePoint::Sync, FailurePoint::Link] {
+        for point in [FailurePoint::TempCreate, FailurePoint::TempWrite, FailurePoint::TempSync, FailurePoint::HardLink] {
             let dir = test_dir("injected");
             let canonical = dir.join("history-v1.jsonl");
             let failure = open_with_test_failure(&dir, 1, capacity(), point);
             assert!(failure.result.is_err(), "{point:?} must reject startup");
             assert_eq!(failure.fired, Some(point), "{point:?} injection must fire");
             assert!(!canonical.exists(), "{point:?} occurs before publication");
-            if point != FailurePoint::Create {
+            if point != FailurePoint::TempCreate {
                 assert!(fs::read_dir(&dir).unwrap().any(|entry| entry.unwrap().file_name().to_string_lossy().starts_with("history-v1.jsonl.tmp-")));
             }
             let _ = fs::remove_dir_all(dir);
         }
         let dir = test_dir("directory-sync");
         let canonical = dir.join("history-v1.jsonl");
-        let failure = open_with_test_failure(&dir, 1, capacity(), FailurePoint::DirectorySync);
+        let failure = open_with_test_failure(&dir, 1, capacity(), FailurePoint::ParentDirectorySync);
         assert!(failure.result.is_err());
-        assert_eq!(failure.fired, Some(FailurePoint::DirectorySync));
+        assert_eq!(failure.fired, Some(FailurePoint::ParentDirectorySync));
         let Record::Boot(_) = decode_record(&fs::read(&canonical).unwrap()).unwrap() else { panic!("directory-sync failure retains linked boot") };
         let _ = fs::remove_dir_all(dir);
     }
@@ -266,7 +301,7 @@ mod tests {
     #[test]
     fn append_and_sync_failures_do_not_hide_partial_tail_evidence() {
         // This catches truncate/repair after a failed restart boot append.
-        for point in [FailurePoint::Append, FailurePoint::Sync] {
+        for point in [FailurePoint::RestartBootAppend, FailurePoint::RestartBootSync] {
             let dir = test_dir("restart-failure");
             HistoryStore::open(&dir, 1, capacity()).unwrap();
             let before = fs::read(dir.join("history-v1.jsonl")).unwrap();
@@ -275,12 +310,26 @@ mod tests {
             assert_eq!(failure.fired, Some(point));
             let after = fs::read(dir.join("history-v1.jsonl")).unwrap();
             assert!(after.starts_with(&before), "failed tail remains evidence");
-            if point == FailurePoint::Append {
+            if point == FailurePoint::RestartBootAppend {
                 assert_eq!(after, before, "append failure writes no new tail");
             } else {
                 assert!(after.len() > before.len(), "sync failure retains partial new boot tail");
             }
             let _ = fs::remove_dir_all(dir);
         }
+    }
+
+    #[test]
+    fn runtime_partial_append_poison_prevents_the_next_tick_from_mutating_history() {
+        let dir = test_dir("runtime-poison");
+        let mut store = HistoryStore::open(&dir, 1, capacity()).unwrap();
+        let path = dir.join("history-v1.jsonl");
+        let failed = append_with_test_failure(&mut store, 2, capacity(), state(1.0), FailurePoint::RuntimePartialAppend);
+        assert!(failed.result.is_err());
+        assert_eq!(failed.fired, Some(FailurePoint::RuntimePartialAppend));
+        let after_failed_tick = fs::read(&path).unwrap();
+        assert!(store.append_sample(3, capacity(), state(2.0)).is_err());
+        assert_eq!(fs::read(path).unwrap(), after_failed_tick);
+        let _ = fs::remove_dir_all(dir);
     }
 }

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -1,10 +1,568 @@
 //! Durable publication and append boundary for canonical history-v1.
 
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use super::codec::{
+    decode_record, encode_record, BootRecord, Capacity, CheckpointRecord, DecodeError, Record,
+    SampleRecord, StateEntry,
+};
+
+const CANONICAL_NAME: &str = "history-v1.jsonl";
+const TEMP_PREFIX: &str = "history-v1.jsonl.tmp-";
+
+#[derive(Debug)]
+pub struct HistoryStore {
+    file: File,
+    boot_id: String,
+    last_state: Option<Vec<StateEntry>>,
+    replay_records: Vec<Record>,
+    last_timestamp: Option<u64>,
+    poisoned: bool,
+}
+
+#[derive(Debug)]
+pub enum OpenError {
+    Io(io::Error),
+    EmptyCanonical,
+    InvalidCanonical { line: usize, error: DecodeError },
+    UnterminatedRecord,
+    InvalidStream { line: usize, reason: &'static str },
+}
+
+impl std::fmt::Display for OpenError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(error) => write!(formatter, "history store I/O error: {error}"),
+            Self::EmptyCanonical => formatter.write_str("canonical history is empty"),
+            Self::InvalidCanonical { line, error } => write!(
+                formatter,
+                "invalid canonical history at line {line}: {}",
+                error.diagnostic()
+            ),
+            Self::UnterminatedRecord => {
+                formatter.write_str("canonical history ends with an unterminated record")
+            }
+            Self::InvalidStream { line, reason } => {
+                write!(
+                    formatter,
+                    "invalid canonical history stream at line {line}: {reason}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for OpenError {}
+
+impl From<io::Error> for OpenError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<WriteError> for OpenError {
+    fn from(error: WriteError) -> Self {
+        match error {
+            WriteError::Io(error) => Self::Io(error),
+            WriteError::Encode => Self::Io(io::Error::other("canonical history encode failure")),
+            WriteError::Poisoned => {
+                Self::Io(io::Error::other("canonical history store is poisoned"))
+            }
+            WriteError::TimestampRegression => {
+                Self::Io(io::Error::other("canonical history timestamp regresses"))
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum WriteError {
+    Encode,
+    Io(io::Error),
+    Poisoned,
+    TimestampRegression,
+}
+
+impl std::fmt::Display for WriteError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Encode => formatter.write_str("cannot encode canonical history record"),
+            Self::Io(error) => write!(formatter, "history store I/O error: {error}"),
+            Self::Poisoned => {
+                formatter.write_str("canonical history store is poisoned after a failed append")
+            }
+            Self::TimestampRegression => {
+                formatter.write_str("canonical history timestamp regresses")
+            }
+        }
+    }
+}
+
+impl std::error::Error for WriteError {}
+
+impl HistoryStore {
+    pub fn open(data_dir: &Path, timestamp: u64, capacity: Capacity) -> Result<Self, OpenError> {
+        Self::open_inner(data_dir, timestamp, capacity, None)
+    }
+
+    fn open_inner(
+        data_dir: &Path,
+        timestamp: u64,
+        capacity: Capacity,
+        mut failure: Option<&mut FailureSwitch>,
+    ) -> Result<Self, OpenError> {
+        let path = data_dir.join(CANONICAL_NAME);
+        let boot_id = new_boot_id();
+        let boot = Record::Boot(BootRecord {
+            timestamp,
+            boot_id: boot_id.clone(),
+            capacity,
+        });
+        match OpenOptions::new().read(true).open(&path) {
+            Ok(_) => {
+                let mut records = validate_canonical(&path)?;
+                ensure_open_timestamp(&records, &boot)?;
+                let mut file = OpenOptions::new().append(true).open(&path)?;
+                append_record(&mut file, &boot, failure.as_deref_mut(), true)?;
+                records.push(boot);
+                let last_timestamp = records.last().map(record_timestamp);
+                Ok(Self {
+                    file,
+                    boot_id,
+                    last_state: None,
+                    replay_records: records,
+                    last_timestamp,
+                    poisoned: false,
+                })
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                fs::create_dir_all(data_dir)?;
+                match publish_first_boot(&path, &boot, failure.as_deref_mut()) {
+                    Ok(()) => {
+                        let file = OpenOptions::new().append(true).open(&path)?;
+                        let last_timestamp = Some(record_timestamp(&boot));
+                        Ok(Self {
+                            file,
+                            boot_id,
+                            last_state: None,
+                            replay_records: vec![boot],
+                            last_timestamp,
+                            poisoned: false,
+                        })
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                        let mut records = validate_canonical(&path)?;
+                        ensure_open_timestamp(&records, &boot)?;
+                        let mut file = OpenOptions::new().append(true).open(&path)?;
+                        append_record(&mut file, &boot, failure, true)?;
+                        records.push(boot);
+                        let last_timestamp = records.last().map(record_timestamp);
+                        Ok(Self {
+                            file,
+                            boot_id,
+                            last_state: None,
+                            replay_records: records,
+                            last_timestamp,
+                            poisoned: false,
+                        })
+                    }
+                    Err(error) => Err(error.into()),
+                }
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    pub fn append_sample(
+        &mut self,
+        timestamp: u64,
+        capacity: Capacity,
+        state: Vec<StateEntry>,
+    ) -> Result<(), WriteError> {
+        self.append_sample_inner(timestamp, capacity, state, None)
+    }
+
+    fn append_sample_inner(
+        &mut self,
+        timestamp: u64,
+        capacity: Capacity,
+        state: Vec<StateEntry>,
+        failure: Option<&mut FailureSwitch>,
+    ) -> Result<(), WriteError> {
+        if self.poisoned {
+            return Err(WriteError::Poisoned);
+        }
+        if self.last_state.as_ref() == Some(&state) {
+            return self.checkpoint(timestamp, capacity);
+        }
+        let record = Record::Sample(SampleRecord {
+            timestamp,
+            boot_id: self.boot_id.clone(),
+            capacity,
+            state: state.clone(),
+        });
+        ensure_runtime_timestamp(self.last_timestamp, &record)?;
+        if let Err(error) = append_record(&mut self.file, &record, failure, false) {
+            self.poisoned = true;
+            return Err(error);
+        }
+        self.last_timestamp = Some(record_timestamp(&record));
+        self.last_state = Some(state);
+        Ok(())
+    }
+
+    pub fn checkpoint(&mut self, timestamp: u64, capacity: Capacity) -> Result<(), WriteError> {
+        self.checkpoint_inner(timestamp, capacity, None)
+    }
+
+    fn checkpoint_inner(
+        &mut self,
+        timestamp: u64,
+        capacity: Capacity,
+        failure: Option<&mut FailureSwitch>,
+    ) -> Result<(), WriteError> {
+        if self.poisoned {
+            return Err(WriteError::Poisoned);
+        }
+        let record = Record::Checkpoint(CheckpointRecord {
+            timestamp,
+            boot_id: self.boot_id.clone(),
+            capacity,
+        });
+        ensure_runtime_timestamp(self.last_timestamp, &record)?;
+        if let Err(error) = append_record(&mut self.file, &record, failure, false) {
+            self.poisoned = true;
+            return Err(error);
+        }
+        self.last_timestamp = Some(record_timestamp(&record));
+        Ok(())
+    }
+
+    pub(crate) fn boot_id(&self) -> &str {
+        &self.boot_id
+    }
+
+    pub(crate) fn take_replay_records(&mut self) -> Vec<Record> {
+        std::mem::take(&mut self.replay_records)
+    }
+
+    pub(crate) fn file_bytes(&self) -> io::Result<u64> {
+        self.file.metadata().map(|metadata| metadata.len())
+    }
+}
+
+pub(crate) fn stale_temporary_count(directory: &Path) -> io::Result<usize> {
+    fs::read_dir(directory)?.try_fold(0, |count, entry| {
+        let name = entry?.file_name();
+        Ok(count + usize::from(name.to_string_lossy().starts_with(TEMP_PREFIX)))
+    })
+}
+
+fn validate_canonical(path: &Path) -> Result<Vec<Record>, OpenError> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    let mut records = Vec::new();
+    let mut active_boot: Option<String> = None;
+    let mut last_timestamp = None;
+    let mut line = Vec::new();
+    let mut index = 0;
+    loop {
+        line.clear();
+        let read = reader.read_until(b'\n', &mut line)?;
+        if read == 0 {
+            break;
+        }
+        index += 1;
+        if line.last() != Some(&b'\n') {
+            return Err(OpenError::UnterminatedRecord);
+        }
+        line.pop();
+        if line.iter().all(u8::is_ascii_whitespace) {
+            continue;
+        }
+        let record = decode_record(&line)
+            .map_err(|error| OpenError::InvalidCanonical { line: index, error })?;
+        let (timestamp, boot_id, is_boot) = match &record {
+            Record::Boot(record) => (record.timestamp, &record.boot_id, true),
+            Record::Sample(record) => (record.timestamp, &record.boot_id, false),
+            Record::Checkpoint(record) => (record.timestamp, &record.boot_id, false),
+        };
+        if last_timestamp.is_some_and(|previous| timestamp < previous) {
+            return Err(OpenError::InvalidStream {
+                line: index,
+                reason: "timestamp regresses",
+            });
+        }
+        if !is_boot && active_boot.as_deref() != Some(boot_id.as_str()) {
+            return Err(OpenError::InvalidStream {
+                line: index,
+                reason: "sample or checkpoint has no preceding matching boot",
+            });
+        }
+        if is_boot {
+            active_boot = Some(boot_id.clone());
+        }
+        last_timestamp = Some(timestamp);
+        records.push(record);
+    }
+    (!records.is_empty())
+        .then_some(records)
+        .ok_or(OpenError::EmptyCanonical)
+}
+
+fn record_timestamp(record: &Record) -> u64 {
+    match record {
+        Record::Boot(record) => record.timestamp,
+        Record::Sample(record) => record.timestamp,
+        Record::Checkpoint(record) => record.timestamp,
+    }
+}
+
+fn ensure_open_timestamp(records: &[Record], next: &Record) -> Result<(), OpenError> {
+    if records
+        .last()
+        .is_some_and(|previous| record_timestamp(next) < record_timestamp(previous))
+    {
+        return Err(OpenError::InvalidStream {
+            line: records.len() + 1,
+            reason: "timestamp regresses",
+        });
+    }
+    Ok(())
+}
+
+fn ensure_runtime_timestamp(last_timestamp: Option<u64>, next: &Record) -> Result<(), WriteError> {
+    if last_timestamp.is_some_and(|previous| record_timestamp(next) < previous) {
+        return Err(WriteError::TimestampRegression);
+    }
+    Ok(())
+}
+
+fn publish_first_boot(
+    path: &Path,
+    boot: &Record,
+    mut failure: Option<&mut FailureSwitch>,
+) -> io::Result<()> {
+    let directory = path
+        .parent()
+        .ok_or_else(|| io::Error::other("history path has no parent"))?;
+    let (temporary, mut file) = create_temporary(directory, &mut failure)?;
+    write_record(
+        &mut file,
+        boot,
+        failure.as_deref_mut(),
+        Some(FailurePoint::TempWrite),
+    )
+    .map_err(write_error_to_io)?;
+    file.flush()?;
+    fail(&mut failure, FailurePoint::TempSync)?;
+    file.sync_all()?;
+    fail(&mut failure, FailurePoint::HardLink)?;
+    fs::hard_link(&temporary, path)?;
+    fs::remove_file(&temporary)?;
+    fail(&mut failure, FailurePoint::ParentDirectorySync)?;
+    sync_directory(directory)
+}
+
+fn create_temporary(
+    directory: &Path,
+    failure: &mut Option<&mut FailureSwitch>,
+) -> io::Result<(PathBuf, File)> {
+    for _ in 0..32 {
+        let path = directory.join(format!("{TEMP_PREFIX}{}", new_boot_id()));
+        fail(failure, FailurePoint::TempCreate)?;
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => return Ok((path, file)),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "unique history temporary unavailable",
+    ))
+}
+
+fn append_record(
+    file: &mut File,
+    record: &Record,
+    mut failure: Option<&mut FailureSwitch>,
+    startup_append: bool,
+) -> Result<(), WriteError> {
+    if startup_append {
+        fail(&mut failure, FailurePoint::RestartBootAppend).map_err(WriteError::Io)?;
+    }
+    #[cfg(test)]
+    if failure
+        .as_deref()
+        .is_some_and(|failure| failure.point == FailurePoint::RuntimePartialAppend)
+    {
+        return write_partial_record(file, record, &mut failure);
+    }
+    write_record(file, record, failure.as_deref_mut(), None)?;
+    file.flush().map_err(WriteError::Io)?;
+    if startup_append {
+        fail(&mut failure, FailurePoint::RestartBootSync).map_err(WriteError::Io)?;
+    }
+    file.sync_all().map_err(WriteError::Io)
+}
+
+#[cfg(test)]
+fn write_partial_record(
+    file: &mut File,
+    record: &Record,
+    failure: &mut Option<&mut FailureSwitch>,
+) -> Result<(), WriteError> {
+    let encoded = encode_record(record).map_err(|_| WriteError::Encode)?;
+    let partial = encoded.len().max(1) / 2;
+    file.write_all(&encoded[..partial])
+        .map_err(WriteError::Io)?;
+    file.flush().map_err(WriteError::Io)?;
+    fail(failure, FailurePoint::RuntimePartialAppend).map_err(WriteError::Io)
+}
+
+fn write_record(
+    file: &mut File,
+    record: &Record,
+    mut failure: Option<&mut FailureSwitch>,
+    failure_point: Option<FailurePoint>,
+) -> Result<(), WriteError> {
+    if let Some(point) = failure_point {
+        fail(&mut failure, point).map_err(WriteError::Io)?;
+    }
+    let encoded = encode_record(record).map_err(|_| WriteError::Encode)?;
+    file.write_all(&encoded).map_err(WriteError::Io)?;
+    file.write_all(b"\n").map_err(WriteError::Io)
+}
+
+fn write_error_to_io(error: WriteError) -> io::Error {
+    match error {
+        WriteError::Encode => io::Error::other("canonical history encode failure"),
+        WriteError::Io(error) => error,
+        WriteError::Poisoned => io::Error::other("canonical history store is poisoned"),
+        WriteError::TimestampRegression => {
+            io::Error::other("canonical history timestamp regresses")
+        }
+    }
+}
+
+#[cfg(unix)]
+fn sync_directory(directory: &Path) -> io::Result<()> {
+    File::open(directory)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_directory: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+fn new_boot_id() -> String {
+    let mut bytes = [0_u8; 16];
+    getrandom::getrandom(&mut bytes).expect("OS RNG for canonical history boot ID");
+    let mut id = String::with_capacity(32);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        write!(&mut id, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    id
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FailurePoint {
+    TempCreate,
+    TempWrite,
+    TempSync,
+    HardLink,
+    ParentDirectorySync,
+    RestartBootAppend,
+    RestartBootSync,
+    RuntimePartialAppend,
+}
+
+#[cfg(not(test))]
+#[derive(Clone, Copy)]
+enum FailurePoint {
+    TempCreate,
+    TempWrite,
+    TempSync,
+    HardLink,
+    ParentDirectorySync,
+    RestartBootAppend,
+    RestartBootSync,
+}
+
+struct FailureSwitch {
+    #[cfg(test)]
+    point: FailurePoint,
+    #[cfg(test)]
+    fired: Option<FailurePoint>,
+}
+
+fn fail(failure: &mut Option<&mut FailureSwitch>, point: FailurePoint) -> io::Result<()> {
+    #[cfg(test)]
+    if let Some(failure) = failure {
+        if failure.point == point {
+            failure.fired = Some(point);
+            return Err(io::Error::other(format!("injected {point:?} failure")));
+        }
+    }
+    let _ = (failure, point);
+    Ok(())
+}
+
+#[cfg(test)]
+struct InjectedOpen {
+    result: Result<HistoryStore, OpenError>,
+    fired: Option<FailurePoint>,
+}
+
+#[cfg(test)]
+fn open_with_test_failure(
+    data_dir: &Path,
+    timestamp: u64,
+    capacity: Capacity,
+    point: FailurePoint,
+) -> InjectedOpen {
+    let mut failure = FailureSwitch { point, fired: None };
+    let result = HistoryStore::open_inner(data_dir, timestamp, capacity, Some(&mut failure));
+    InjectedOpen {
+        result,
+        fired: failure.fired,
+    }
+}
+
+#[cfg(test)]
+struct InjectedWrite {
+    result: Result<(), WriteError>,
+    fired: Option<FailurePoint>,
+}
+
+#[cfg(test)]
+fn append_with_test_failure(
+    store: &mut HistoryStore,
+    timestamp: u64,
+    capacity: Capacity,
+    state: Vec<StateEntry>,
+    point: FailurePoint,
+) -> InjectedWrite {
+    let mut failure = FailureSwitch { point, fired: None };
+    let result = store.append_sample_inner(timestamp, capacity, state, Some(&mut failure));
+    InjectedWrite {
+        result,
+        fired: failure.fired,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
 
-    use super::{append_with_test_failure, open_with_test_failure, FailurePoint, HistoryStore, OpenError};
+    use super::{
+        append_with_test_failure, open_with_test_failure, FailurePoint, HistoryStore, OpenError,
+    };
     use crate::history::codec::{decode_record, Capacity, Record, StateEntry, StateKind};
 
     fn capacity() -> Capacity {
@@ -85,6 +643,7 @@ mod tests {
 
     #[test]
     fn structurally_invalid_canonical_streams_refuse_before_fresh_boot_append() {
+        // Task 11 is strict: recovery of bad epochs belongs to Task 12.
         let boot = b"{\"format\":\"nimproxy-history\",\"v\":1,\"kind\":\"boot\",\"timestamp\":10,\"boot_id\":\"boot-a\",\"capacity\":{\"capacity_rpm\":80,\"enabled_keys\":2,\"key_rpms\":[40,40]}}\n";
         let sample_a = b"{\"format\":\"nimproxy-history\",\"v\":1,\"kind\":\"sample\",\"timestamp\":11,\"boot_id\":\"boot-a\",\"capacity\":{\"capacity_rpm\":80,\"enabled_keys\":2,\"key_rpms\":[40,40]},\"state\":[]}\n";
         let sample_b = b"{\"format\":\"nimproxy-history\",\"v\":1,\"kind\":\"sample\",\"timestamp\":11,\"boot_id\":\"boot-b\",\"capacity\":{\"capacity_rpm\":80,\"enabled_keys\":2,\"key_rpms\":[40,40]},\"state\":[]}\n";
@@ -93,7 +652,12 @@ mod tests {
         let sample_mismatch = [boot.as_slice(), sample_b.as_slice()].concat();
         let checkpoint_mismatch = [boot.as_slice(), checkpoint_b.as_slice()].concat();
         let regression = [boot.as_slice(), sample_a.as_slice(), boot.as_slice()].concat();
-        for (name, bytes) in [("sample-before-boot", sample_a.as_slice()), ("sample-boot-mismatch", sample_mismatch.as_slice()), ("checkpoint-boot-mismatch", checkpoint_mismatch.as_slice()), ("timestamp-regression", regression.as_slice())] {
+        for (name, bytes) in [
+            ("sample-before-boot", sample_a.as_slice()),
+            ("sample-boot-mismatch", sample_mismatch.as_slice()),
+            ("checkpoint-boot-mismatch", checkpoint_mismatch.as_slice()),
+            ("timestamp-regression", regression.as_slice()),
+        ] {
             let dir = test_dir(name);
             let path = dir.join("history-v1.jsonl");
             fs::write(&path, bytes).unwrap();
@@ -102,7 +666,11 @@ mod tests {
             let _ = fs::remove_dir_all(dir);
         }
         let dir = test_dir("checkpoint-after-boot");
-        fs::write(dir.join("history-v1.jsonl"), [boot.as_slice(), checkpoint_a.as_slice()].concat()).unwrap();
+        fs::write(
+            dir.join("history-v1.jsonl"),
+            [boot.as_slice(), checkpoint_a.as_slice()].concat(),
+        )
+        .unwrap();
         HistoryStore::open(&dir, 20, capacity()).unwrap();
         let _ = fs::remove_dir_all(dir);
     }
@@ -134,12 +702,14 @@ mod tests {
         let dir = test_dir("concurrent");
         let first = std::thread::scope(|scope| {
             let left = scope.spawn(|| HistoryStore::open(&dir, 1, capacity()));
-            let right = scope.spawn(|| HistoryStore::open(&dir, 2, capacity()));
+            let right = scope.spawn(|| HistoryStore::open(&dir, 1, capacity()));
             (left.join().unwrap(), right.join().unwrap())
         });
         assert!(
             first.0.is_ok() && first.1.is_ok(),
-            "both creators can use the winner"
+            "both creators can use the winner: left={:?} right={:?}",
+            first.0,
+            first.1
         );
         let records = fs::read_to_string(dir.join("history-v1.jsonl")).unwrap();
         assert_eq!(
@@ -181,11 +751,22 @@ mod tests {
             .lines()
             .map(|line| decode_record(line.as_bytes()).unwrap())
             .collect();
-        let Record::Boot(first_boot) = &records[0] else { panic!("first record must boot") };
-        let Record::Boot(second_boot) = &records[2] else { panic!("restart must boot") };
-        let Record::Checkpoint(first_after_restart) = &records[3] else { panic!("first restart record after boot must exercise checkpoint") };
-        let Record::Sample(second_after_restart) = &records[4] else { panic!("restart state must be a full sample") };
-        assert_ne!(first_boot.boot_id, second_boot.boot_id, "each process owns a new reset id");
+        let Record::Boot(first_boot) = &records[0] else {
+            panic!("first record must boot")
+        };
+        let Record::Boot(second_boot) = &records[2] else {
+            panic!("restart must boot")
+        };
+        let Record::Checkpoint(first_after_restart) = &records[3] else {
+            panic!("first restart record after boot must exercise checkpoint")
+        };
+        let Record::Sample(second_after_restart) = &records[4] else {
+            panic!("restart state must be a full sample")
+        };
+        assert_ne!(
+            first_boot.boot_id, second_boot.boot_id,
+            "each process owns a new reset id"
+        );
         assert_eq!(first_after_restart.boot_id, second_boot.boot_id);
         assert_eq!(second_after_restart.boot_id, second_boot.boot_id);
         let _ = fs::remove_dir_all(dir);
@@ -203,7 +784,10 @@ mod tests {
             let path = dir.join("history-v1.jsonl");
             fs::write(&path, before).unwrap();
             if name == "future" {
-                assert_eq!(decode_record(before.trim_ascii_end()).unwrap_err().diagnostic(), "unsupported_version");
+                assert_eq!(
+                    decode_record(before.trim_ascii_end()).unwrap_err().diagnostic(),
+                    "unsupported_version"
+                );
             }
             assert!(HistoryStore::open(&dir, 2, capacity()).is_err());
             assert_eq!(fs::read(path).unwrap(), before, "{name} canonical evidence");
@@ -213,11 +797,16 @@ mod tests {
 
     #[test]
     fn canonical_non_file_path_refuses_without_replacing_it() {
+        // This is deterministic under privileged test runners, unlike chmod:
+        // a directory cannot be opened or replaced as the canonical file.
         let dir = test_dir("canonical-directory");
         let canonical = dir.join("history-v1.jsonl");
         fs::create_dir(&canonical).unwrap();
         assert!(HistoryStore::open(&dir, 1, capacity()).is_err());
-        assert!(canonical.is_dir(), "failed open must not replace path evidence");
+        assert!(
+            canonical.is_dir(),
+            "failed open must not replace path evidence"
+        );
         let _ = fs::remove_dir_all(dir);
     }
 
@@ -277,7 +866,12 @@ mod tests {
     fn publication_failures_preserve_their_actual_crash_state_and_fire() {
         // This catches tests that merely configure a failure without proving
         // the intended operation was actually reached.
-        for point in [FailurePoint::TempCreate, FailurePoint::TempWrite, FailurePoint::TempSync, FailurePoint::HardLink] {
+        for point in [
+            FailurePoint::TempCreate,
+            FailurePoint::TempWrite,
+            FailurePoint::TempSync,
+            FailurePoint::HardLink,
+        ] {
             let dir = test_dir("injected");
             let canonical = dir.join("history-v1.jsonl");
             let failure = open_with_test_failure(&dir, 1, capacity(), point);
@@ -285,23 +879,37 @@ mod tests {
             assert_eq!(failure.fired, Some(point), "{point:?} injection must fire");
             assert!(!canonical.exists(), "{point:?} occurs before publication");
             if point != FailurePoint::TempCreate {
-                assert!(fs::read_dir(&dir).unwrap().any(|entry| entry.unwrap().file_name().to_string_lossy().starts_with("history-v1.jsonl.tmp-")));
+                assert!(
+                    fs::read_dir(&dir).unwrap().any(|entry| entry
+                        .unwrap()
+                        .file_name()
+                        .to_string_lossy()
+                        .starts_with("history-v1.jsonl.tmp-")),
+                    "{point:?} leaves its temporary evidence"
+                );
             }
             let _ = fs::remove_dir_all(dir);
         }
+
         let dir = test_dir("directory-sync");
         let canonical = dir.join("history-v1.jsonl");
-        let failure = open_with_test_failure(&dir, 1, capacity(), FailurePoint::ParentDirectorySync);
+        let failure =
+            open_with_test_failure(&dir, 1, capacity(), FailurePoint::ParentDirectorySync);
         assert!(failure.result.is_err());
         assert_eq!(failure.fired, Some(FailurePoint::ParentDirectorySync));
-        let Record::Boot(_) = decode_record(&fs::read(&canonical).unwrap()).unwrap() else { panic!("directory-sync failure retains linked boot") };
+        let Record::Boot(_) = decode_record(&fs::read(&canonical).unwrap()).unwrap() else {
+            panic!("directory-sync failure retains the linked complete boot evidence")
+        };
         let _ = fs::remove_dir_all(dir);
     }
 
     #[test]
     fn append_and_sync_failures_do_not_hide_partial_tail_evidence() {
         // This catches truncate/repair after a failed restart boot append.
-        for point in [FailurePoint::RestartBootAppend, FailurePoint::RestartBootSync] {
+        for point in [
+            FailurePoint::RestartBootAppend,
+            FailurePoint::RestartBootSync,
+        ] {
             let dir = test_dir("restart-failure");
             HistoryStore::open(&dir, 1, capacity()).unwrap();
             let before = fs::read(dir.join("history-v1.jsonl")).unwrap();
@@ -313,7 +921,10 @@ mod tests {
             if point == FailurePoint::RestartBootAppend {
                 assert_eq!(after, before, "append failure writes no new tail");
             } else {
-                assert!(after.len() > before.len(), "sync failure retains partial new boot tail");
+                assert!(
+                    after.len() > before.len(),
+                    "sync failure retains the partial new boot tail"
+                );
             }
             let _ = fs::remove_dir_all(dir);
         }
@@ -324,10 +935,20 @@ mod tests {
         let dir = test_dir("runtime-poison");
         let mut store = HistoryStore::open(&dir, 1, capacity()).unwrap();
         let path = dir.join("history-v1.jsonl");
-        let failed = append_with_test_failure(&mut store, 2, capacity(), state(1.0), FailurePoint::RuntimePartialAppend);
+        let before = fs::read(&path).unwrap();
+        let failed = append_with_test_failure(
+            &mut store,
+            2,
+            capacity(),
+            state(1.0),
+            FailurePoint::RuntimePartialAppend,
+        );
         assert!(failed.result.is_err());
         assert_eq!(failed.fired, Some(FailurePoint::RuntimePartialAppend));
         let after_failed_tick = fs::read(&path).unwrap();
+        assert!(after_failed_tick.starts_with(&before));
+        assert!(after_failed_tick.len() > before.len());
+        assert!(!after_failed_tick.ends_with(b"\n"));
         assert!(store.append_sample(3, capacity(), state(2.0)).is_err());
         assert_eq!(fs::read(path).unwrap(), after_failed_tick);
         let _ = fs::remove_dir_all(dir);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -539,11 +539,17 @@ pub async fn run() {
 
     // Metrics history: finish indexing before the listener can report ready,
     // then sample the registry with contemporaneous pool capacity.
-    let hist = Arc::new(history::History::load(
-        Some(data_dir.clone()),
+    let hist = match history::History::open(
+        data_dir.clone(),
         stored.history.days,
         capacity_snapshot(&pool.read().unwrap()),
-    ));
+    ) {
+        Ok(history) => Arc::new(history),
+        Err(error) => {
+            eprintln!("\nnim-proxy cannot start: canonical history is unusable: {error}\n");
+            std::process::exit(1);
+        }
+    };
     {
         let hist = hist.clone();
         let prom = prometheus.clone();

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3168,6 +3168,32 @@ async fn corrupt_or_future_store_refuses_to_start() {
     expect_refuses_to_start(future).await;
 }
 
+/// Canonical history is durable evidence: malformed bytes must block startup
+/// rather than being treated as an empty or legacy history file.
+#[tokio::test]
+async fn history_startup_is_fail_closed() {
+    let mock = start_mock().await;
+    for (name, contents) in [
+        ("empty", b"".as_slice()),
+        ("corrupt", b"{not canonical}\n".as_slice()),
+        (
+            "future",
+            br#"{"format":"nimproxy-history","v":2,"kind":"boot","timestamp":1,"boot_id":"future","capacity":{"capacity_rpm":80,"enabled_keys":2,"key_rpms":[40,40]}}\n"#,
+        ),
+    ] {
+        let data_dir = scratch_data_dir();
+        std::fs::write(
+            data_dir.join("config.json"),
+            serde_json::to_vec_pretty(&StoreOpts::default().json(&mock.url)).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(data_dir.join("history-v1.jsonl"), contents).unwrap();
+
+        expect_refuses_to_start(data_dir).await;
+        eprintln!("history-startup:{name}: refused malformed canonical input");
+    }
+}
+
 #[tokio::test]
 async fn invalid_noncanonical_and_uninstalled_durable_locales_refuse_to_start() {
     let mock = start_mock().await;

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3178,7 +3178,7 @@ async fn history_startup_is_fail_closed() {
         ("corrupt", b"{not canonical}\n".as_slice()),
         (
             "future",
-            br#"{"format":"nimproxy-history","v":2,"kind":"boot","timestamp":1,"boot_id":"future","capacity":{"capacity_rpm":80,"enabled_keys":2,"key_rpms":[40,40]}}\n"#,
+            b"{\"format\":\"nimproxy-history\",\"v\":2,\"kind\":\"boot\",\"timestamp\":1,\"boot_id\":\"future\",\"capacity\":{\"capacity_rpm\":80,\"enabled_keys\":2,\"key_rpms\":[40,40]}}\n",
         ),
     ] {
         let data_dir = scratch_data_dir();
@@ -3244,6 +3244,73 @@ async fn legacy_history_is_warned_once_without_parsing_or_mutating_it() {
     assert!(stderr.contains(&legacy_bytes.len().to_string()), "{stderr}");
     assert_eq!(std::fs::read(&legacy).unwrap(), legacy_bytes);
     let _ = std::fs::remove_dir_all(data_dir);
+}
+
+#[tokio::test]
+async fn stale_canonical_temporaries_are_counted_once_without_inspection_or_deletion() {
+    let mock = start_mock().await;
+    let data_dir = scratch_data_dir();
+    std::fs::write(
+        data_dir.join("config.json"),
+        serde_json::to_vec_pretty(&StoreOpts::default().json(&mock.url)).unwrap(),
+    )
+    .unwrap();
+    let stale = data_dir.join("history-v1.jsonl.tmp-crash-evidence");
+    let stale_bytes = b"partial canonical temporary";
+    std::fs::write(&stale, stale_bytes).unwrap();
+    let port = std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_nim-proxy"))
+        .env_clear()
+        .current_dir(std::env::temp_dir())
+        .env("PORT", port.to_string())
+        .env("DATA_DIR", &data_dir)
+        .env("RUST_LOG", "nim_proxy=warn")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if client()
+            .get(format!("http://127.0.0.1:{port}/health"))
+            .send()
+            .await
+            .is_ok_and(|response| response.status().is_success())
+        {
+            break;
+        }
+        assert!(Instant::now() < deadline, "proxy did not become healthy");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    child.kill().unwrap();
+    let output = child.wait_with_output().unwrap();
+    let output = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.matches("stale canonical history temporaries").count(), 1, "{output}");
+    assert!(!output.contains(&stale.display().to_string()), "{output}");
+    assert_eq!(std::fs::read(&stale).unwrap(), stale_bytes);
+    let _ = std::fs::remove_dir_all(data_dir);
+}
+
+#[tokio::test]
+async fn api_config_history_file_bytes_reports_canonical_history() {
+    let mock = start_mock().await;
+    let proxy = start_proxy(&mock.url, &[("HISTORY_SAMPLE_SECS", "3600")]).await;
+    let cookie = login(&proxy).await;
+    let configured = api_config(&proxy, &cookie).await;
+    let canonical_bytes = std::fs::metadata(proxy.data_dir.join("history-v1.jsonl"))
+        .unwrap()
+        .len();
+    assert!(canonical_bytes > 0);
+    assert_eq!(configured["server"]["history"]["file_bytes"], canonical_bytes);
+    assert!(!proxy.data_dir.join("history.jsonl").exists());
 }
 
 #[tokio::test]

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3194,6 +3194,58 @@ async fn history_startup_is_fail_closed() {
     }
 }
 
+/// `history.jsonl` is deliberately opaque upgrade-reset evidence. Startup
+/// emits one bounded path-and-size warning while leaving its bytes untouched.
+#[tokio::test]
+async fn legacy_history_is_warned_once_without_parsing_or_mutating_it() {
+    let mock = start_mock().await;
+    let data_dir = scratch_data_dir();
+    std::fs::write(
+        data_dir.join("config.json"),
+        serde_json::to_vec_pretty(&StoreOpts::default().json(&mock.url)).unwrap(),
+    )
+    .unwrap();
+    let legacy = data_dir.join("history.jsonl");
+    let legacy_bytes = b"not canonical and never parsed\n";
+    std::fs::write(&legacy, legacy_bytes).unwrap();
+    let port = std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_nim-proxy"))
+        .env_clear()
+        .current_dir(std::env::temp_dir())
+        .env("PORT", port.to_string())
+        .env("DATA_DIR", &data_dir)
+        .env("RUST_LOG", "nim_proxy=warn")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if client()
+            .get(format!("http://127.0.0.1:{port}/health"))
+            .send()
+            .await
+            .is_ok_and(|response| response.status().is_success())
+        {
+            break;
+        }
+        assert!(Instant::now() < deadline, "proxy did not become healthy");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    child.kill().unwrap();
+    let output = child.wait_with_output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let legacy_display = legacy.display().to_string();
+    assert_eq!(stderr.matches(&legacy_display).count(), 1, "{stderr}");
+    assert!(stderr.contains(&legacy_bytes.len().to_string()), "{stderr}");
+    assert_eq!(std::fs::read(&legacy).unwrap(), legacy_bytes);
+    let _ = std::fs::remove_dir_all(data_dir);
+}
+
 #[tokio::test]
 async fn invalid_noncanonical_and_uninstalled_durable_locales_refuse_to_start() {
     let mock = start_mock().await;

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -2407,9 +2407,10 @@ async fn history_records_snapshots_and_survives_restart() {
     assert_eq!(r.status(), 200);
     tokio::time::sleep(Duration::from_millis(2500)).await;
 
-    // Snapshots land on disk at DATA_DIR/history.jsonl (harness-managed dir).
-    let jsonl = proxy.data_dir.join("history.jsonl");
-    let raw = std::fs::read_to_string(&jsonl).expect("history.jsonl written");
+    // Canonical records land at the separate v1 path; experimental history is
+    // never written or read by the new runtime.
+    let jsonl = proxy.data_dir.join("history-v1.jsonl");
+    let raw = std::fs::read_to_string(&jsonl).expect("history-v1.jsonl written");
     let lines: Vec<&str> = raw.lines().filter(|l| !l.is_empty()).collect();
     assert!(lines.len() >= 2, "sampler ran: {} snapshots", lines.len());
     let records: Vec<serde_json::Value> = lines
@@ -2422,18 +2423,19 @@ async fn history_records_snapshots_and_survives_restart() {
     );
     assert!(
         records.iter().any(|value| {
-            value["v"] == 2
-                && value["boot"].is_string()
+            value["format"] == "nimproxy-history"
+                && value["v"] == 1
+                && value["boot_id"].is_string()
                 && value["capacity"]["capacity_rpm"] == 120
-                && value["m"]
-                    .as_str()
-                    .is_some_and(|metrics| metrics.contains("nimproxy"))
+                && value["state"]
+                    .as_array()
+                    .is_some_and(|state| !state.is_empty())
         }),
-        "v2 snapshots carry metrics and contemporaneous capacity: {raw}"
+        "canonical samples carry normalized metrics and contemporaneous capacity: {raw}"
     );
     let before = records
         .iter()
-        .filter(|value| value["m"].is_string())
+        .filter(|value| value["kind"] == "sample")
         .count();
 
     // Restart on the SAME data dir: history reloads into the normalized index
@@ -2540,7 +2542,7 @@ async fn dashboard_tail_rolls_into_persisted_history_once() {
 }
 
 #[tokio::test]
-async fn legacy_history_infers_counter_reset() {
+async fn experimental_legacy_history_is_ignored_without_mutation() {
     let mock = start_mock().await;
     let data_dir = scratch_data_dir();
     std::fs::write(
@@ -2566,15 +2568,20 @@ async fn legacy_history_infers_counter_reset() {
     )
     .unwrap();
 
+    let legacy_before = std::fs::read(data_dir.join("history.jsonl")).unwrap();
     let proxy = start_proxy_in(data_dir, &[("HISTORY_SAMPLE_SECS", "3600")]).await;
     let cookie = login(&proxy).await;
     let range = dashboard_range(&proxy, &cookie, 1, 4_102_444_800, 1000).await;
     assert_eq!(
         successful_chat_requests(&range["totals"]),
-        19.0,
-        "legacy epochs contribute 10 + 5 + 4 requests: {range}"
+        0.0,
+        "legacy values are not imported into canonical history: {range}"
     );
-    assert_eq!(range["diagnostics"]["legacy_resets_inferred"], 1);
+    assert_eq!(range["diagnostics"]["legacy_resets_inferred"], 0);
+    assert_eq!(
+        std::fs::read(proxy.data_dir.join("history.jsonl")).unwrap(),
+        legacy_before
+    );
 }
 
 #[tokio::test]
@@ -2751,7 +2758,7 @@ async fn dashboard_now_contract_uses_current_pool_config_and_registry() {
 }
 
 #[tokio::test]
-async fn retention_change_prunes_queries_and_disk() {
+async fn legacy_retention_fixture_is_not_migrated_or_compacted() {
     let mock = start_mock().await;
     let data_dir = scratch_data_dir();
     std::fs::write(
@@ -2782,6 +2789,7 @@ async fn retention_change_prunes_queries_and_disk() {
     )
     .unwrap();
 
+    let legacy_before = std::fs::read(data_dir.join("history.jsonl")).unwrap();
     let proxy = start_proxy_in(data_dir, &[("HISTORY_SAMPLE_SECS", "3600")]).await;
     let cookie = login(&proxy).await;
     let (status, body) = post_json(
@@ -2797,49 +2805,12 @@ async fn retention_change_prunes_queries_and_disk() {
     .await;
     assert_eq!(status, 200, "{body}");
 
-    let query = |proxy: &support::Proxy, cookie: &str| {
-        let url = proxy.url("/api/dashboard?from=1&to=4102444800&points=100");
-        let cookie = cookie.to_owned();
-        async move {
-            client()
-                .get(url)
-                .header("cookie", cookie)
-                .send()
-                .await
-                .unwrap()
-                .json::<serde_json::Value>()
-                .await
-                .unwrap()
-        }
-    };
-    let metric = |body: &serde_json::Value| {
-        body["totals"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .find(|row| row["metric"] == "fixture_requests_total")
-            .and_then(|row| row["value"].as_f64())
-            .unwrap()
-    };
-
-    let pruned = query(&proxy, &cookie).await;
-    assert_eq!(pruned["window"]["available_from"], retained_one);
-    assert_eq!(metric(&pruned), 20.0);
-
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while api_config(&proxy, &cookie).await["server"]["history"]["compaction_pending"] == true {
-        assert!(
-            Instant::now() < deadline,
-            "history compaction did not finish"
-        );
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
-
     let proxy = restart(proxy, &[("HISTORY_SAMPLE_SECS", "3600")]).await;
-    let cookie = login(&proxy).await;
-    let reloaded = query(&proxy, &cookie).await;
-    assert_eq!(reloaded["window"]["available_from"], retained_one);
-    assert_eq!(metric(&reloaded), 20.0);
+    assert_eq!(
+        std::fs::read(proxy.data_dir.join("history.jsonl")).unwrap(),
+        legacy_before,
+        "Task 11 neither imports nor compacts experimental history"
+    );
 }
 
 #[tokio::test]
@@ -3219,7 +3190,7 @@ async fn legacy_history_is_warned_once_without_parsing_or_mutating_it() {
         .env("PORT", port.to_string())
         .env("DATA_DIR", &data_dir)
         .env("RUST_LOG", "nim_proxy=warn")
-        .stdout(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
         .unwrap();
@@ -3238,10 +3209,14 @@ async fn legacy_history_is_warned_once_without_parsing_or_mutating_it() {
     }
     child.kill().unwrap();
     let output = child.wait_with_output().unwrap();
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let output = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
     let legacy_display = legacy.display().to_string();
-    assert_eq!(stderr.matches(&legacy_display).count(), 1, "{stderr}");
-    assert!(stderr.contains(&legacy_bytes.len().to_string()), "{stderr}");
+    assert_eq!(output.matches(&legacy_display).count(), 1, "{output}");
+    assert!(output.contains(&legacy_bytes.len().to_string()), "{output}");
     assert_eq!(std::fs::read(&legacy).unwrap(), legacy_bytes);
     let _ = std::fs::remove_dir_all(data_dir);
 }
@@ -3293,7 +3268,13 @@ async fn stale_canonical_temporaries_are_counted_once_without_inspection_or_dele
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert_eq!(output.matches("stale canonical history temporaries").count(), 1, "{output}");
+    assert_eq!(
+        output
+            .matches("stale canonical history temporaries")
+            .count(),
+        1,
+        "{output}"
+    );
     assert!(!output.contains(&stale.display().to_string()), "{output}");
     assert_eq!(std::fs::read(&stale).unwrap(), stale_bytes);
     let _ = std::fs::remove_dir_all(data_dir);
@@ -3309,7 +3290,10 @@ async fn api_config_history_file_bytes_reports_canonical_history() {
         .unwrap()
         .len();
     assert!(canonical_bytes > 0);
-    assert_eq!(configured["server"]["history"]["file_bytes"], canonical_bytes);
+    assert_eq!(
+        configured["server"]["history"]["file_bytes"],
+        canonical_bytes
+    );
     assert!(!proxy.data_dir.join("history.jsonl").exists());
 }
 


### PR DESCRIPTION
Closes #100.

## Outcome

Publish one canonical `history-v1.jsonl` format with fail-closed startup validation, durable no-overwrite creation, store-owned appends, and truthful byte/capacity accounting.

## Proof

- Committed RED sequence: `af4dd2a`, `465f1c3`, `b38ff34`, `6d8d141`, `e2176a6`
- GREEN implementation: `8d67d60`
- `cargo test history::store::tests --lib`: 15 passed
- `cargo test --test e2e history_startup_is_fail_closed -- --exact`: 1 passed
- `cargo test history`: 58 unit + 10 E2E passed
- Full suite on the same Rust implementation: 154 unit + 108 E2E + 7 OpenAPI passed
- `cargo fmt --check`: passed
- `cargo clippy --all-targets -- -D warnings`: passed
- `git diff --check`: passed
- Independent review round 3: approved

## Constraint

This PR deliberately excludes Task 12 recovery policy and Task 13 compaction. Experimental pre-v1 history is not parsed or migrated: its presence is warned with path and size, then canonical v1 starts separately. Shared-data-directory multi-process coordination remains unsupported and is not expanded here.

## Ponytail rung

Uses standard-library file and filesystem operations, the existing history types, and the existing boot sequence. No dependency, lock layer, migration framework, or parallel legacy writer was added.
