### PR TITLE
feat: bound and compact metrics history

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Environment variables cover container-level concerns only:
 | Variable | Default | Purpose |
 |---|---|---|
 | `HOST` / `PORT` | `0.0.0.0` / `8000` | Bind address and port |
-| `DATA_DIR` | `data` (`/data` in Docker) | Where the config store and `history.jsonl` live; must be writable (an unwritable dir is a hard boot error) |
+| `DATA_DIR` | `data` (`/data` in Docker) | Where the config store and canonical `history-v1.jsonl` live; must be writable (an unwritable dir is a hard boot error) |
 | `TRUST_PROXY` | `false` | Trust `X-Forwarded-Proto` and mark the session cookie `Secure` (set behind a TLS-terminating reverse proxy) |
 | `RUST_LOG` | `nim_proxy=info` | Log filter |
 

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -3604,6 +3604,19 @@ provided by the native filesystem boundary.
   `CompactionOutcome`, `compact_inner`, and `compact` interface. Steps 1–2
   remain open until the orchestration-level `compaction_pending` and restart
   RED contracts are also committed.
+- 2026-08-01: Phase A store GREEN owns canonical replacement inside
+  `HistoryStore`: it revalidates under the exclusive writer, defers unsafe
+  horizons, retains exact epoch context in physical order, proves the synced
+  temporary is the exact selected stream, renames atomically, and moves the
+  already-open append-capable replacement handle into live state before the
+  only post-commit fallible step. The first GREEN review rejected a fallible
+  reopen after rename and recovery-valid rather than exact temporary
+  validation. Fix round 1 removed the reopen and requires exact records with
+  no recovery indicators; scoped re-review approved both findings. Fresh
+  proof: focused compaction 5/5 and full store 32/32 passed; formatting and
+  diff checks passed. One expected test-build warning remains until Phase B
+  consumes the `CommittedSyncPending` error payload in orchestration rather
+  than discarding or suppressing it.
 
 **Files:**
 

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -3708,17 +3708,25 @@ provided by the native filesystem boundary.
   `knowledge/decisions/ui-managed-config-store.md` still named experimental
   `history.jsonl` as the live volume/history sibling. Historical vulnerability
   prose remains unchanged. No behavior or decision changes.
+- 2026-08-01: the final whole-range review added a fourth path-only correction
+  after catching the previously omitted active
+  `history.jsonl` path in the public `README.md`. The minimum documentation-only
+  correction names canonical `history-v1.jsonl` and adds the README to this
+  task's declared file and staging scope; the runtime and wire contract are
+  unchanged.
 - 2026-08-01: Step 6 Query → Ingest → Lint now records selection math,
   recovery deferral, replacement/race/failure semantics, deterministic bound,
   and release load measurements on their governing pages. Contradiction and
   synonym searches found no remaining active future-compaction claim; every
   remaining `history.jsonl` mention is explicitly experimental/opaque or
   historical context. All local links resolve, diff hygiene passes, no index
-  update is required, and frozen-file independent review approved all 10
-  plan/knowledge files with no Critical or Important finding.
+  update is required. Frozen-file independent review approved the original 10
+  plan/knowledge files; final whole-range review then found and repaired the
+  omitted public README contradiction.
 
 **Files:**
 
+- Modify: `README.md`
 - Modify: `src/history/store.rs`
 - Modify: `src/history.rs`
 - Modify: `src/lib.rs`
@@ -3814,7 +3822,7 @@ post-restart byte assertions.
 - [x] **Step 7: Commit**
 
 ```sh
-git add src/history/store.rs src/history.rs src/lib.rs scripts/loadtest.py \
+git add README.md src/history/store.rs src/history.rs src/lib.rs scripts/loadtest.py \
   tests/e2e.rs \
   knowledge/architecture/metrics-history.md \
   knowledge/decisions/history-retention-days-not-size.md \

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -3617,6 +3617,17 @@ provided by the native filesystem boundary.
   diff checks passed. One expected test-build warning remains until Phase B
   consumes the `CommittedSyncPending` error payload in orchestration rather
   than discarding or suppressing it.
+- 2026-08-01: Phase B orchestration RED adds two real canonical paths: clean
+  startup retention debt through compaction/restart, and intersecting recovery
+  evidence that remains byte-identical until a shorter horizon places its gap
+  endpoint exactly at the cutoff. The first review rejected substring-only
+  evidence checks; the correction constructs the exact post-append canonical
+  bytes through the production codec and proves removal of both corrupt and
+  old valid outside-horizon rows. Live samples use the equal startup timestamp
+  so immediate restart cannot fail on a synthetic future clock. Independent
+  re-review approved both paths. Fresh focused RED compiles two tests and both
+  fail immediately only because canonical startup debt is not yet exposed as
+  `compaction_pending`.
 
 **Files:**
 
@@ -3645,7 +3656,7 @@ provided by the native filesystem boundary.
   resumes append from the replacement inode. The legacy file is never a
   compaction input or target.
 
-- [ ] **Step 1: Write failure-matrix tests**
+- [x] **Step 1: Write failure-matrix tests**
 
 Cover retention boundary exactly at/before/after cutoff, multiple epochs,
 partial epochs, corruption inside and outside the retained horizon, no valid
@@ -3655,7 +3666,7 @@ old bytes or complete new bytes at every observable point, never a hybrid/
 truncated file. Assert completeness and `compaction_pending` before and after
 restart.
 
-- [ ] **Step 2: Observe the red proof**
+- [x] **Step 2: Observe the red proof**
 
 ```sh
 cargo test history::store::tests::compaction_ --lib -- --nocapture

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -3572,6 +3572,39 @@ git commit -m "feat: expose recoverable history completeness"
 
 **GitHub issue title:** `v0.6.6: make history retention atomic and bounded`
 
+#### Execution record
+
+**Outcome:** bounded canonical history that retains the exact context needed
+for correct rollups and survives every replacement crash point as either the
+complete old file or the complete new file. **Proof:** a committed RED
+retention/failure matrix followed by focused store/restart tests, deterministic
+two-horizon load/idle proof, the complete Rust suite, and independent review.
+**Constraint:** the exclusive history writer owns compaction; intersecting
+recovery evidence defers replacement; legacy history and the request/rate-
+limiter hot path remain untouched. **Ponytail Rung:** 4 — use same-directory
+temporary-file, rename, file sync, and directory sync primitives already
+provided by the native filesystem boundary.
+
+- 2026-08-01: Task 12 PR #121 merged into `release/v0.6.6` at
+  `c22525a17d95d2b31c0eadf1da4c81320329eb47`; all 11 GitHub checks passed and
+  issue #101/project item are Done.
+- 2026-08-01: Task 13 kickoff in
+  `work/v0.6.6-task-13-history-compaction`. Scope delta: none.
+- 2026-08-01: Phase A store RED adds five test-only compaction contracts for
+  retained selection, recovery deferral, every replacement crash point,
+  restart/rollup/inode continuity, and deterministic writer serialization.
+  The first independent review rejected an incorrect rollup interval, a
+  no-sample case confounded by a recovery gap, and a concurrency signal that
+  did not prove lock contention. The corrected tests query the baseline-
+  dependent interval, isolate an unsampled fresh boot with no intersecting
+  recovery gap, and observe `try_lock` contention before releasing the
+  compactor. Independent re-review approved both spec and test quality. Fresh
+  `cargo test history::store::tests::compaction_ --lib -- --nocapture` fails
+  with exactly seven errors, all for the deliberately absent store-owned
+  `CompactionOutcome`, `compact_inner`, and `compact` interface. Steps 1–2
+  remain open until the orchestration-level `compaction_pending` and restart
+  RED contracts are also committed.
+
 **Files:**
 
 - Modify: `src/history/store.rs`

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -3714,6 +3714,15 @@ provided by the native filesystem boundary.
   correction names canonical `history-v1.jsonl` and adds the README to this
   task's declared file and staging scope; the runtime and wire contract are
   unchanged.
+- 2026-08-01: PR #122's combined check reproduced a test-only scheduling race
+  in `canonical_compaction_review_reschedules_newer_generation_after_sync_failure`:
+  the idle helper could observe the intentional running-state handoff before
+  the superseding worker claimed it. A local repeated RED reproduced the same
+  two-versus-three pass count on iteration 16. The complete suite then exposed
+  the same transient-idle assertion race in the adjacent durable-supersession
+  proof. The minimum repairs use each test's existing hook and channel to await
+  the exact successor pass before final idle; they add no sleep or production
+  change and retain or strengthen the exact assertions.
 - 2026-08-01: Step 6 Query → Ingest → Lint now records selection math,
   recovery deferral, replacement/race/failure semantics, deterministic bound,
   and release load measurements on their governing pages. Contradiction and

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -3652,6 +3652,70 @@ provided by the native filesystem boundary.
   scoped review verified round 2 from SHA-256
   `9ac694ae4fb417d7373756a9f64576b1fe1e6e05eac81d51d7db2e6b2a01657b`
   and approved it with no Critical or Important finding.
+- 2026-08-01: Phase C fast proof commit `702c588` validates a hand-written
+  ordered v1 seed through real-binary readiness, settles compaction before
+  idle observation, adds exactly one checkpoint and zero samples with selected
+  request/scheduling metrics fixed, and preserves the same authenticated range
+  totals, completeness, and bounds after restart. It also proves physical
+  order, owning boot, pre-cutoff baseline, retained horizon, fresh epoch,
+  ancient-row removal, and no legacy-path creation. A temporary totals mutation
+  failed the exact restart assertion; three review rounds closed query, owning-
+  boot, compaction-race, and polling-spin weaknesses before commit.
+- 2026-08-01: release measurement commit `d1138e9` adds an optional all-or-none
+  history/PID/report mode to the existing stdlib load harness. Twenty-three
+  service-free controls cover CLI ordering, regular/symlink/FIFO history
+  classification, malformed and changing Linux RSS, sampler teardown and
+  thread errors, plus every report publication boundary. The report is
+  same-directory atomic and is written before client/rate failure evaluation;
+  invalid measurement emits no report. Two independent review rounds closed
+  lifecycle, inode-race, temporary cleanup, malformed `/proc`, CLI bypass, and
+  symlink/FIFO findings; the final frozen review was clean.
+- 2026-08-01: ignored release proof commit `124cf2f` separates three exact
+  one-second idle checkpoints from three no-chat 3,600-second restart epochs.
+  The first class member establishes each positive allowance before later
+  members; every restart preserves the exact prior raw-byte prefix and appends
+  only a unique `boot`/`sample` pair. The final checked bound is computed from
+  the pre-cycle base and declared counts. Review rejected an earlier bundled
+  traffic/timer allowance and duplicated fixture; two repairs produced shared
+  fixture/settle/final helpers, exact row kinds, no masked shrink, and byte-
+  prefix proof. A tail-kind mutation failed
+  `release-restart-idle-history:restart-row-kinds`; frozen re-review approved.
+- 2026-08-01: test-only wrapper commit `f743359` removed the non-test dead-code
+  warning without changing the production authorized compaction path. The
+  first complete gate then exposed seven Task 13 Clippy iterator/boolean/type-
+  shape findings. Minimum no-suppression repair `593cdff` retained cutoff
+  selection and orchestration semantics; independent review and Clippy were
+  clean.
+- 2026-08-01: fresh Step 5 gate passed 23 load selftests, 32 store tests, the
+  2.12-second fast restart proof, the 4.34-second ignored release proof, 83
+  history tests, and the complete 179 unit / 110 E2E / 7 OpenAPI suites.
+  `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and
+  `git diff --check` passed. A temporary reverted observation measured the
+  deterministic release fixture at a 6,469-byte settled base, 195-byte first
+  checkpoint allowance, 391-byte first restart allowance, and the exact
+  independent/final bound of 8,227 bytes.
+- 2026-08-01: Step 6 knowledge lint scope delta adds only
+  `knowledge/ops/configure-env.md` and the two governing retention decisions,
+  `knowledge/decisions/history-retention-days-not-size.md` and
+  `knowledge/decisions/reset-aware-dashboard-history.md`. They still named the
+  experimental path or promised unconditional replacement. The corrections
+  preserve the approved day-based/reset-aware choices while recording
+  canonical pending/deferred/finite/unlimited behavior; no operator procedure
+  or product contract changes.
+- 2026-08-01: the same Step 6 synonym search adds three path-only corrections:
+  `knowledge/ops/deploy-docker.md`,
+  `knowledge/decisions/lane-cooldown-naming.md`, and
+  `knowledge/decisions/ui-managed-config-store.md` still named experimental
+  `history.jsonl` as the live volume/history sibling. Historical vulnerability
+  prose remains unchanged. No behavior or decision changes.
+- 2026-08-01: Step 6 Query → Ingest → Lint now records selection math,
+  recovery deferral, replacement/race/failure semantics, deterministic bound,
+  and release load measurements on their governing pages. Contradiction and
+  synonym searches found no remaining active future-compaction claim; every
+  remaining `history.jsonl` mention is explicitly experimental/opaque or
+  historical context. All local links resolve, diff hygiene passes, no index
+  update is required, and frozen-file independent review approved all 10
+  plan/knowledge files with no Critical or Important finding.
 
 **Files:**
 
@@ -3661,6 +3725,12 @@ provided by the native filesystem boundary.
 - Modify: `scripts/loadtest.py`
 - Modify: `tests/e2e.rs`
 - Modify: `knowledge/architecture/metrics-history.md`
+- Modify: `knowledge/decisions/history-retention-days-not-size.md`
+- Modify: `knowledge/decisions/lane-cooldown-naming.md`
+- Modify: `knowledge/decisions/reset-aware-dashboard-history.md`
+- Modify: `knowledge/decisions/ui-managed-config-store.md`
+- Modify: `knowledge/ops/configure-env.md`
+- Modify: `knowledge/ops/deploy-docker.md`
 - Modify: `knowledge/testing/test-strategy.md`
 - Modify: `knowledge/log.md`
 
@@ -3704,10 +3774,11 @@ failure guarantees.
 First refuse/defer if invalid history intersects the retained horizon. Build
 the otherwise safe retained set from validated records including its boot and
 preceding full-sample baseline, write and validate the replacement before
-rename, then reopen append state. Do not compact on the request/rate-limiter
+rename, then adopt the already-open replacement handle as append state. Do not
+compact on the request/rate-limiter
 hot path. Emit bounded operational logs without record content.
 
-- [ ] **Step 4: Prove bounded long-run behavior**
+- [x] **Step 4: Prove bounded long-run behavior**
 
 Run a deterministic accelerated clock/load test spanning more than two
 retention horizons. Assert maximum file growth from the configured sampling
@@ -3720,7 +3791,7 @@ new measurement fails closed on a seeded bad input; it does not start services.
 Commit the long-form orchestration as the ignored E2E case
 `release_restart_and_idle_history`; Task 17 reruns that exact case.
 
-- [ ] **Step 5: Run proof**
+- [x] **Step 5: Run proof**
 
 ```sh
 python3 scripts/loadtest.py --selftest
@@ -3734,18 +3805,23 @@ cargo fmt --check
 git diff --check
 ```
 
-- [ ] **Step 6: Ingest and review before commit**
+- [x] **Step 6: Ingest and review before commit**
 
 Document retention mathematics, retained context, replacement protocol,
 failure semantics, and observed long-run bound. Review all crash points and
 post-restart byte assertions.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```sh
 git add src/history/store.rs src/history.rs src/lib.rs scripts/loadtest.py \
   tests/e2e.rs \
   knowledge/architecture/metrics-history.md \
+  knowledge/decisions/history-retention-days-not-size.md \
+  knowledge/decisions/lane-cooldown-naming.md \
+  knowledge/decisions/reset-aware-dashboard-history.md \
+  knowledge/decisions/ui-managed-config-store.md \
+  knowledge/ops/configure-env.md knowledge/ops/deploy-docker.md \
   knowledge/testing/test-strategy.md knowledge/log.md
 git commit -m "feat: bound and compact metrics history"
 ```

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -3628,6 +3628,30 @@ provided by the native filesystem boundary.
   re-review approved both paths. Fresh focused RED compiles two tests and both
   fail immediately only because canonical startup debt is not yet exposed as
   `compaction_pending`.
+- 2026-08-01: Phase B GREEN exposes startup debt, schedules canonical
+  compaction outside request/rate-limiter hot paths, installs committed replay
+  only after releasing the store, and keeps deferred or sync-uncertain work
+  pending without spinning. Initial review found three Important concurrency
+  defects: pending clear could lose a newer generation, replay install could
+  overwrite a concurrent append's diagnostics/events, and days=0 could allow
+  stale finite work to rename. Three deterministic regressions were observed
+  failing at their named state assertions before the repair.
+- 2026-08-01: fix round 1 adds post-clear generation recovery, conservative
+  revision-guarded replay installation followed by the production superseding
+  pass, and a generation-control authorization held across the final rename.
+  Review accepted all three and isolated one reachable remainder:
+  `CommittedSyncPending` could strand a newer finite generation. The round-2
+  regression observed exactly two passes instead of the required three after
+  the worker was idle. The minimum repair restarts only when generation
+  changed, retention remains finite, and pending is true; an unchanged
+  directory-sync failure remains pending without a retry loop.
+- 2026-08-01: fresh controller proof on the reviewed Phase B tree passed the
+  four `canonical_compaction_review_` races (4/4), the startup-debt and
+  gap-deferral contracts (1/1 each), all history tests (83/83), and all store
+  tests (32/32), plus `cargo fmt --check` and `git diff --check`. Independent
+  scoped review verified round 2 from SHA-256
+  `9ac694ae4fb417d7373756a9f64576b1fe1e6e05eac81d51d7db2e6b2a01657b`
+  and approved it with no Critical or Important finding.
 
 **Files:**
 
@@ -3675,7 +3699,7 @@ cargo test history::store::tests::compaction_ --lib -- --nocapture
 Expected: current retention does not meet the locked canonical replacement and
 failure guarantees.
 
-- [ ] **Step 3: Implement compaction behind the exclusive writer**
+- [x] **Step 3: Implement compaction behind the exclusive writer**
 
 First refuse/defer if invalid history intersects the retained horizon. Build
 the otherwise safe retained set from validated records including its boot and

--- a/knowledge/architecture/metrics-history.md
+++ b/knowledge/architecture/metrics-history.md
@@ -56,7 +56,8 @@ evidence; startup emits at most one warning containing their count, and never
 their names or contents. File order is authoritative and equal timestamps are
 valid. A runtime encode/write/flush/sync failure poisons the writer, so later
 ticks cannot append after partial evidence. `file_bytes` is live metadata from
-the canonical writer. Task 13 owns compaction.
+the canonical writer. Finite-retention compaction applies only to this
+canonical destination and follows the protocol below.
 
 ## Recovery and completeness
 
@@ -158,9 +159,57 @@ range revision, so a newly persisted sample cannot be double-counted.
 long as the default dashboard window.
 
 Changing retention in Settings validates and persists the complete config,
-then immediately trims the visible in-memory index. Task 11 deliberately does
-not compact canonical history; Task 13 owns the atomic replacement protocol
-and its recovery proof. A canonical history-file write failure warns and
-leaves the in-memory index operating, but poisons further durable writes for
-that process; an unusable `DATA_DIR` or config store is still a hard boot error
+then immediately trims the visible in-memory index. A finite canonical cutoff
+is `now - history.days * 86,400`, using saturating arithmetic. Existing
+retention debt is exposed as `compaction_pending` at startup; the first full
+sampler append schedules it. A live finite-retention change schedules work
+immediately. Setting `history.days` to `0` invalidates the finite generation,
+clears pending work, and prevents a stale worker from renaming its candidate.
+Compaction runs on a blocking worker behind the canonical store mutex, never
+on the request dispatcher or rate-limiter path.
+
+For each eligible epoch, canonical compaction retains the epoch boot, the
+latest full sample strictly before the cutoff as its boundary baseline, and
+every record at or after the cutoff, all in original physical order. An epoch
+is eligible when it has a retained observation or is the usable live epoch.
+A checkpoint carries no state of its own and therefore cannot replace the
+pre-cutoff full-sample baseline. This is the minimum context that preserves
+counter deltas, gauges, capacity, completeness, and effective bounds after a
+restart.
+
+The store revalidates the current path while holding its exclusive writer. If
+a recovery gap ends after the cutoff, or the live epoch has no full sample,
+replacement is deferred and `compaction_pending` remains true. A gap ending
+exactly at the cutoff is outside the retained window and may be discarded.
+This rule prevents validated-row rewriting from erasing evidence that still
+makes a retained query incomplete.
+
+For a safe stream, the writer creates a unique same-directory temporary,
+writes the selected canonical records, flushes and syncs it, and requires the
+temporary to decode as exactly that selected stream with no recovery evidence.
+Generation authorization is then held through the atomic rename. The already
+open append-capable temporary handle becomes the live writer after rename; no
+fallible reopen separates replacement from subsequent append. The parent
+directory is synced last. Failures before rename leave the old path complete
+(and may leave an opaque stale temporary); rename produces the complete new
+path. A directory-sync failure after rename is reported as committed but
+durability-uncertain, installs the replacement replay, and leaves cleanup
+pending. Superseding retention generations are rescheduled without overwriting
+newer append diagnostics or events.
+
+The accelerated release proof seeds slightly more than two 30-day horizons,
+then observes three idle checkpoints followed by three no-traffic restart
+epochs. Idle intervals append exactly one checkpoint and zero full samples;
+each 3,600-second restart appends an exact `boot`/`sample` pair while preserving
+the prior raw-byte prefix and range results. In the deterministic fixture the
+settled base was 6,469 bytes, the first checkpoint allowance was 195 bytes, the
+first restart allowance was 391 bytes, and the independent linear bound
+`6,469 + 3*195 + 3*391 = 8,227` bytes equaled the final file. These byte values
+describe the fixed synthetic fixture, not a universal workload-size promise;
+the durable guarantee is bounded retained context and small idle checkpoints
+instead of repeated full idle snapshots.
+
+A canonical history-file write failure warns and leaves the in-memory index
+operating, but poisons further durable writes for that process; an unusable
+`DATA_DIR` or config store is still a hard boot error
 ([configuration](../ops/configure-env.md)).

--- a/knowledge/decisions/history-retention-days-not-size.md
+++ b/knowledge/decisions/history-retention-days-not-size.md
@@ -43,15 +43,19 @@ a fixed bytes-per-day ratio.
 
 ## Consequences
 
-- `history.jsonl` lives in `DATA_DIR` (the Docker volume). If history-file
-  persistence fails after the config store is usable, the index can continue
-  in memory with a warning; an unusable config/data directory remains a hard
-  boot error.
+- Canonical `history-v1.jsonl` lives in `DATA_DIR` (the Docker volume).
+  Experimental `history.jsonl` remains opaque legacy evidence and is never a
+  retention input or target. If canonical persistence fails after the config
+  store is usable, the index can continue in memory with a warning; an
+  unusable config/data directory remains a hard boot error.
 - The knob lives in the [config store](ui-managed-config-store.md), not the
   retired `HISTORY_DAYS` env var, and is tunable live in Settings.
-- Lowering retention trims the visible index immediately and atomically
-  compacts the file in the background, preserving the pre-cutoff baseline and
-  boot marker required for exact first-window deltas.
+- Lowering finite retention trims the visible index immediately and schedules
+  atomic background compaction. Safe replacement preserves the pre-cutoff full
+  sample and owning boot required for exact first-window deltas. Recovery
+  evidence intersecting the retained window, or a live epoch without a full
+  sample, defers replacement and keeps it pending; `0` cancels finite work and
+  retains canonical history without a cutoff.
 - Five-minute samples bound event-time precision. The dashboard combines
   persisted rollups with a revision-bound current tail rather than a
   browser-only recent-history ring

--- a/knowledge/decisions/lane-cooldown-naming.md
+++ b/knowledge/decisions/lane-cooldown-naming.md
@@ -52,16 +52,11 @@ the time, and rewriting them would be dishonest.
 
 - **Breaking for anything scraping the old series.** Dashboards, alerts, or
   recording rules referencing `nimproxy_lane_benched_total` must be updated.
-- **Retained history shows a gap.** `history.jsonl` persists the metric name
-  verbatim, so points recorded before the upgrade stay under the old key while
-  the dashboard queries the new one. Lane-cooldown charts are blank for
-  pre-upgrade points and return to full fidelity one retention window
-  (`history.days`) after upgrading.
-
-  This was a deliberate choice over a read-time alias in `history.rs`. The
-  alias would work, but it is a permanent compatibility shim carried forever to
-  smooth a one-time bounded gap in a homelab tool — precisely the kind of
-  prototype-phase residue this release exists to remove. The gap is visible,
-  self-healing, and documented.
+- **History receives no compatibility alias.** v0.6.6 deliberately starts the
+  canonical `history-v1.jsonl` contract without importing experimental
+  `history.jsonl`, so pre-upgrade points do not enter the new index under
+  either name. New canonical records persist the cooldown metric verbatim.
+  Adding a permanent read-time alias to smooth a one-time pre-1.0 reset would
+  be precisely the prototype-phase residue this release exists to remove.
 - The vocabulary is now recognizable without explanation, which is what makes
   the labels machine-translatable in the same release.

--- a/knowledge/decisions/reset-aware-dashboard-history.md
+++ b/knowledge/decisions/reset-aware-dashboard-history.md
@@ -89,9 +89,11 @@ Choose option 5.
 - Page rendering stays frontend-owned, avoiding a matrix of page caches and
   invalidation rules. History and config revisions provide the only
   invalidation boundaries the browser needs.
-- Lowering retention changes visible bounds immediately and performs atomic
-  background compaction while preserving the hidden boundary baseline and
-  relevant boot marker
+- Lowering finite retention changes visible bounds immediately and schedules
+  atomic background compaction while preserving the hidden full-sample
+  boundary baseline and relevant boot marker. Replacement remains pending when
+  intersecting recovery evidence would otherwise be erased; unlimited
+  retention cancels stale finite work
   ([retention decision](history-retention-days-not-size.md)).
 - The old `/api/history` and `/dash/config.json` dashboard transports are
   removed. Prometheus `/metrics` remains for authenticated scrapers.

--- a/knowledge/decisions/ui-managed-config-store.md
+++ b/knowledge/decisions/ui-managed-config-store.md
@@ -53,7 +53,7 @@ And one risk to accept or design around: an unconfigured instance is
 
 ### JSON file, not SQLite
 
-`DATA_DIR/config.json` (sibling of `history.jsonl` — the compose volume
+`DATA_DIR/config.json` (sibling of canonical `history-v1.jsonl` — the compose volume
 already covers it, zero compose changes). The store is **kilobytes,
 read-mostly, single-writer** (the settings handlers), and fully
 **snapshot-cached in memory** (`RwLock<Arc<Config>>`, one snapshot per
@@ -114,11 +114,11 @@ identity mechanics.
 
 ### No encryption at rest
 
-The **`/data` volume is the trust boundary.** NIM keys already sat there in
-`history.jsonl`'s directory and in `.env` in plaintext; anyone who can read the
-volume already had the keys. Encrypting the store would need a key to live
-*somewhere* — another env var, another file on the same volume — which moves
-the problem without solving it. The proportionate hardening is **0600
+The **`/data` volume is the trust boundary.** The same deployment principal
+controls that volume and the `.env` where NIM keys previously lived in
+plaintext. Encrypting the store would need a key to live *somewhere* — another
+env var or another file under the same deployment boundary — which moves the
+problem without solving it. The proportionate hardening is **0600
 permissions + atomic writes** (tmp + `fsync` + `rename` + dir `fsync`), which
 the credential store needs anyway (unlike telemetry, a torn write here loses
 logins). Client API-key secrets get defense-in-depth for free: they're

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,25 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-08-01] component — bounded atomic canonical history retention
+
+Task 13 compacts only `history-v1.jsonl` behind its exclusive writer. It keeps
+each retained epoch's boot, latest strictly pre-cutoff full-sample baseline,
+and physical-order records at or after the cutoff; checkpoints never stand in
+for state. Intersecting recovery evidence or a live epoch without a full
+sample defers replacement. Safe candidates are synced and exactly revalidated
+in the same directory, generation-authorized through rename, adopted through
+the already-open replacement handle, and followed by directory sync. Pre-
+rename failures preserve the old path; post-rename directory-sync uncertainty
+keeps the complete new path pending. Deterministic real-binary proof spans
+more than two horizons, three zero-sample idle checkpoints, and three exact
+restart epochs with an independently established 8,227-byte fixture bound.
+The load harness can atomically report history growth and native Linux peak
+RSS while retaining its zero-client-failure and zero-rate-violation exit
+contract. See [metrics history](architecture/metrics-history.md), the
+[test strategy](testing/test-strategy.md), and the
+[Task 13 plan](../docs/plans/v0.6.6-foundation-implementation.md).
+
 ## [2026-07-31] component — recoverable canonical history completeness
 
 Task 12 replaces the strict intermediate canonical reader with one file-order

--- a/knowledge/ops/configure-env.md
+++ b/knowledge/ops/configure-env.md
@@ -58,9 +58,13 @@ default to 30 days. The default window must be at least one day. Retention `0`
 is unlimited; finite retention must be at least the default window. The SLO
 must be a finite percentage greater than 0 and at most 100. A combined save is
 all-or-nothing: any invalid field leaves the persisted and live configuration
-unchanged. Reducing retention trims the visible index immediately. Task 11
-does not compact canonical `history-v1.jsonl` or experimental `history.jsonl`;
-Task 13 owns the atomic canonical-compaction protocol.
+unchanged. Reducing finite retention trims the visible index immediately and
+schedules atomic canonical `history-v1.jsonl` compaction; startup debt remains
+visible as `compaction_pending` until safe replacement completes. Recovery
+evidence intersecting the retained window defers replacement. Setting
+retention to `0` keeps canonical history unlimited and cancels stale finite
+work. Experimental `history.jsonl` is never a compaction input or target (see
+[metrics history](../architecture/metrics-history.md)).
 
 **Legacy env vars are ignored.** `NIM_API_KEYS`, `PROXY_API_KEYS`,
 `ADMIN_PASSWORD`, `INSECURE_NO_AUTH`, `NIM_BASE_URL`, `RPM_PER_KEY`,

--- a/knowledge/ops/deploy-docker.md
+++ b/knowledge/ops/deploy-docker.md
@@ -53,9 +53,10 @@ What the compose file gives you (see
   with an ignored `.env` override (`PUBLISH_HOST`) for intentional exposure.
 - `read_only: true`, `cap_drop: [ALL]`, `no-new-privileges` — writes go only
   to the named `history` volume mounted at `/data`, which now holds both
-  `history.jsonl` **and `config.json` (credentials, 0600)**. A volume backup
-  therefore contains the password hashes and NIM keys — treat backups as
-  secrets. Total-lockout recovery is a volume edit of `config.json`
+  canonical `history-v1.jsonl` **and `config.json` (credentials, 0600)**;
+  opaque experimental history or stale canonical temporaries may also remain.
+  A volume backup therefore contains the password hashes and NIM keys — treat
+  backups as secrets. Total-lockout recovery is a volume edit of `config.json`
   ([configure-env](configure-env.md)).
 - `HEALTHCHECK` via `nim-proxy --health` (the binary probes itself; there is
   no shell in the image).

--- a/knowledge/testing/test-strategy.md
+++ b/knowledge/testing/test-strategy.md
@@ -54,6 +54,19 @@ that proof.
   revision at point budgets 2 and 1000. `cargo test --test e2e
   dashboard_history_reports_completeness -- --exact` proves raw ASCII field
   order plus partial and unavailable API states through the real binary.
+- **Canonical history retention:** `cargo test history::store::tests --lib`
+  proves cutoff selection, the owning boot and full-sample baseline, recovery
+  deferral, every pre/post-rename failure point, replacement-inode append, and
+  writer serialization. `cargo test --test e2e
+  history_retention_survives_restart -- --exact` is the fast real-binary
+  compaction/restart equivalence proof. `cargo test --test e2e
+  release_restart_and_idle_history -- --ignored --exact` seeds more than two
+  30-day horizons and classifies three exact idle checkpoints plus three exact
+  no-traffic restart epochs. Its byte allowances are established from the
+  first member of each class before later cycles; the fixed fixture measured a
+  6,469-byte base, 195-byte checkpoint allowance, 391-byte restart allowance,
+  and 8,227-byte final bound/file. Those values validate the proof fixture,
+  not arbitrary metric cardinality or workload payload size.
 - **Handlers or wire types:** `UPDATE_OPENAPI=1 cargo test --test openapi`,
   then verify that `openapi.json` has only the deliberate diff.
 - **HTTP trust boundaries:** `cargo test routes::tests --lib` proves the
@@ -276,6 +289,24 @@ cargo run --release &     # boots into first-run setup (no app-level env vars)
 # keys, set the API mode to open (or mint a client key for --proxy-keys)
 python3 scripts/loadtest.py --clients 100 --requests 3
 ```
+
+For a release run, provide all three measurement options or none:
+
+```sh
+python3 scripts/loadtest.py --clients 100 --requests 3 \
+  --history-path /absolute/data/history-v1.jsonl \
+  --proxy-pid "$PROXY_PID" \
+  --report-json /absolute/run/load-report.json
+```
+
+The atomic JSON report records start/end history bytes, sampled peak RSS from
+Linux `/proc/<pid>/status`, completed/client/upstream counts, worker
+exhaustions, and rate violations. It is published before client- or
+rate-failure exit evaluation, but invalid history/RSS measurement produces no
+report. `python3 scripts/loadtest.py --selftest` is service-free and fails
+closed across incomplete CLI options, relative/missing/non-file/symlink/FIFO
+history paths, dead/malformed/changing RSS, sampler lifecycle/thread failure,
+and report write/fsync/replace/directory-sync crash points.
 
 This layer earned its keep on day one: it caught ~2% boundary-jitter
 violations that unit and e2e tests structurally cannot see, leading to

--- a/scripts/loadtest.py
+++ b/scripts/loadtest.py
@@ -26,8 +26,15 @@ sampling params, so the v0.4.0 request-shape / response-quality code paths are
 exercised under concurrency (not just the rate limiter).
 """
 import argparse
+import errno
 import json
+import os
+from pathlib import Path
+import stat
 import statistics
+import subprocess
+import sys
+import tempfile
 import threading
 import time
 import urllib.request
@@ -40,6 +47,272 @@ MODELS = [
 
 results = []
 results_lock = threading.Lock()
+
+
+class MeasurementError(Exception):
+    def __init__(self, check_id):
+        super().__init__(check_id)
+        self.check_id = check_id
+
+
+def require_measurement_options(args):
+    supplied = [args.history_path, args.proxy_pid, args.report_json]
+    if any(value is not None for value in supplied) and not all(value is not None for value in supplied):
+        raise MeasurementError("loadtest:measurement-options:incomplete")
+
+
+def history_bytes(path, ending=False):
+    path = Path(path)
+    if not path.is_absolute():
+        raise MeasurementError("loadtest:history-path:relative")
+    try:
+        descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    except OSError as error:
+        if error.errno == errno.ELOOP:
+            raise MeasurementError("loadtest:history-path:not-file") from None
+        raise MeasurementError("loadtest:history-path:disappeared" if ending else "loadtest:history-path:missing") from None
+    try:
+        history = os.fstat(descriptor)
+        if not stat.S_ISREG(history.st_mode):
+            return _history_not_file(path)
+        return history.st_size
+    finally:
+        os.close(descriptor)
+
+
+def _history_not_file(_path):
+    raise MeasurementError("loadtest:history-path:not-file")
+
+
+def parse_rss(pid, proc_root=Path("/proc")):
+    if not isinstance(pid, int) or pid <= 0:
+        raise MeasurementError("loadtest:proxy-pid:invalid")
+    try:
+        lines = (Path(proc_root) / str(pid) / "status").read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        raise MeasurementError("loadtest:proxy-pid:dead") from None
+    except (OSError, UnicodeError):
+        raise MeasurementError("loadtest:proxy-pid:proc-malformed") from None
+    values = [line.split() for line in lines if line.startswith("VmRSS:")]
+    if len(values) != 1 or len(values[0]) != 3 or values[0][2] != "kB":
+        raise MeasurementError("loadtest:proxy-pid:proc-malformed")
+    try:
+        kb = int(values[0][1])
+    except ValueError:
+        raise MeasurementError("loadtest:proxy-pid:rss-invalid") from None
+    if kb < 0:
+        raise MeasurementError("loadtest:proxy-pid:rss-invalid")
+    return kb * 1024
+
+
+class RssSampler:
+    def __init__(self, pid, proc_root=Path("/proc"), interval=0.05):
+        self.pid, self.proc_root, self.interval = pid, proc_root, max(interval, 0.05)
+        self.stop = threading.Event()
+        self.error = None
+        self.peak = None
+        self.thread = threading.Thread(target=self._run)
+
+    def sample(self):
+        value = parse_rss(self.pid, self.proc_root)
+        self.peak = value if self.peak is None else max(self.peak, value)
+
+    def _run(self):
+        while not self.stop.wait(self.interval):
+            try:
+                self.sample()
+            except MeasurementError as error:
+                self.error = error
+                return
+            except Exception as error:
+                self.error = MeasurementError("loadtest:proxy-pid:proc-malformed")
+                self.error.__cause__ = error
+                return
+
+    def start(self):
+        self.sample()
+        self.thread.start()
+
+    def finish(self):
+        self.stop.set()
+        self.thread.join()
+        self.sample()
+        if self.error:
+            raise self.error
+        if self.peak is None:
+            raise MeasurementError("loadtest:proxy-pid:rss-invalid")
+        return self.peak
+
+
+def publish_report(path, report, replace=os.replace):
+    path = Path(path)
+    if not path.is_absolute():
+        raise MeasurementError("loadtest:report-json:relative")
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent,
+                                         prefix=f".{path.name}.tmp-", delete=False) as output:
+            temporary = Path(output.name)
+            json.dump(report, output, sort_keys=True)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+    except Exception as error:
+        if temporary is not None:
+            try:
+                temporary.unlink()
+            except OSError:
+                pass
+        if isinstance(error, OSError):
+            raise MeasurementError("loadtest:report-json:unwritable") from None
+        raise
+    try:
+        replace(temporary, path)
+    except Exception as error:
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+        if isinstance(error, OSError):
+            raise MeasurementError("loadtest:report-json:non-atomic") from None
+        raise
+    try:
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except OSError:
+        raise MeasurementError("loadtest:report-json:non-atomic") from None
+
+
+def run_selftest():
+    cases = 0
+    def expect(check_id, call):
+        nonlocal cases
+        cases += 1
+        try:
+            call()
+        except MeasurementError as error:
+            if error.check_id != check_id:
+                raise AssertionError(f"{check_id}: got {error.check_id}")
+            return
+        raise AssertionError(check_id)
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        history = root / "history-v1.jsonl"
+        history.write_bytes(b"abc")
+        assert history_bytes(history) == 3
+        expect("loadtest:history-path:missing", lambda: history_bytes(root / "missing"))
+        expect("loadtest:history-path:relative", lambda: history_bytes(Path("history-v1.jsonl")))
+        expect("loadtest:history-path:not-file", lambda: history_bytes(root))
+        history_link = root / "history-link"
+        history_link.symlink_to(history)
+        expect("loadtest:history-path:not-file", lambda: history_bytes(history_link))
+        history_fifo = root / "history-fifo"
+        os.mkfifo(history_fifo)
+        expect("loadtest:history-path:not-file", lambda: history_bytes(history_fifo))
+        history.unlink()
+        expect("loadtest:history-path:disappeared", lambda: history_bytes(history, ending=True))
+        history.write_bytes(b"replacement")
+        history.unlink()
+        history.mkdir()
+        expect("loadtest:history-path:not-file", lambda: history_bytes(history, ending=True))
+        history.rmdir()
+        expect("loadtest:proxy-pid:invalid", lambda: parse_rss(0, root))
+        expect("loadtest:proxy-pid:dead", lambda: parse_rss(7, root))
+        proc = root / "7"; proc.mkdir(); (proc / "status").write_text("VmRSS: nope kB\n")
+        expect("loadtest:proxy-pid:rss-invalid", lambda: parse_rss(7, root))
+        (proc / "status").write_text("VmRSS: 1 B\n")
+        expect("loadtest:proxy-pid:proc-malformed", lambda: parse_rss(7, root))
+        (proc / "status").write_text("Name:\ttest\n")
+        expect("loadtest:proxy-pid:proc-malformed", lambda: parse_rss(7, root))
+        (proc / "status").write_text("VmRSS:\t12 kB\nVmRSS:\t20 kB\n")
+        expect("loadtest:proxy-pid:proc-malformed", lambda: parse_rss(7, root))
+        (proc / "status").write_bytes(b"VmRSS:\t\xff kB\n")
+        expect("loadtest:proxy-pid:proc-malformed", lambda: parse_rss(7, root))
+        (proc / "status").write_text("VmRSS:\t12 kB\n")
+        assert parse_rss(7, root) == 12 * 1024
+        sampler = RssSampler(7, root); sampler.start()
+        (proc / "status").write_text("VmRSS:\t20 kB\n")
+        deadline = time.monotonic() + 1
+        while sampler.peak != 20 * 1024 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert sampler.finish() == 20 * 1024
+        assert not sampler.thread.is_alive()
+        (proc / "status").write_text("VmRSS:\t12 kB\n")
+        sampler = RssSampler(7, root)
+        sampler.start()
+        original_parse_rss = parse_rss
+        sampled = threading.Event()
+        def unexpected_sample(*_args):
+            sampled.set()
+            raise RuntimeError("selftest")
+        globals()["parse_rss"] = unexpected_sample
+        try:
+            assert sampled.wait(1)
+        finally:
+            globals()["parse_rss"] = original_parse_rss
+        expect("loadtest:proxy-pid:proc-malformed", sampler.finish)
+        def sampler_lifecycle_control(phase_error):
+            sampler = RssSampler(7, root)
+            sampler.start()
+            try:
+                if phase_error:
+                    raise MeasurementError("loadtest:selftest:measurement-phase")
+            finally:
+                sampler.finish()
+                assert not sampler.thread.is_alive()
+            return sampler.peak
+        assert sampler_lifecycle_control(False) == 12 * 1024
+        expect("loadtest:selftest:measurement-phase", lambda: sampler_lifecycle_control(True))
+        expect("loadtest:report-json:relative", lambda: publish_report(Path("report.json"), {}))
+        blocked = root / "blocked"; blocked.write_text("x")
+        expect("loadtest:report-json:unwritable", lambda: publish_report(blocked / "report.json", {}))
+        report = root / "report.json"; publish_report(report, {"a": 1}); assert report.read_text() == '{"a": 1}\n'
+        expect("loadtest:report-json:non-atomic", lambda: publish_report(root / "bad.json", {}, lambda *_: (_ for _ in ()).throw(OSError())))
+        assert not list(root.glob(".bad.json.tmp-*"))
+        try:
+            publish_report(root / "programmer-error.json", {}, lambda *_: (_ for _ in ()).throw(RuntimeError("selftest")))
+        except RuntimeError as error:
+            assert str(error) == "selftest"
+        else:
+            raise AssertionError("replace RuntimeError was relabeled")
+        assert not list(root.glob(".programmer-error.json.tmp-*"))
+        old_report = b"old report\n"
+        report.write_bytes(old_report)
+        original_fsync = os.fsync
+        os.fsync = lambda _fd: (_ for _ in ()).throw(OSError())
+        try:
+            expect("loadtest:report-json:unwritable", lambda: publish_report(report, {"a": 2}))
+        finally:
+            os.fsync = original_fsync
+        assert report.read_bytes() == old_report
+        assert not list(root.glob(".report.json.tmp-*"))
+        fsync_calls = 0
+        def fail_directory_sync(fd):
+            nonlocal fsync_calls
+            fsync_calls += 1
+            if fsync_calls == 2:
+                raise OSError()
+            return original_fsync(fd)
+        os.fsync = fail_directory_sync
+        try:
+            expect("loadtest:report-json:non-atomic", lambda: publish_report(report, {"a": 3}))
+        finally:
+            os.fsync = original_fsync
+        assert report.read_text() == '{"a": 3}\n'
+    incomplete = argparse.Namespace(history_path="x", proxy_pid=None, report_json="x")
+    expect("loadtest:measurement-options:incomplete", lambda: require_measurement_options(incomplete))
+    cases += 1
+    incomplete_cli = subprocess.run(
+        [sys.executable, __file__, "--selftest", "--history-path", str(root / "history-v1.jsonl")],
+        capture_output=True, text=True)
+    assert incomplete_cli.returncode != 0
+    assert incomplete_cli.stdout == ""
+    assert incomplete_cli.stderr == "loadtest:measurement-options:incomplete\n"
+    print(f"loadtest selftest: {cases} cases passed")
 
 
 def one_request(args, client_id, seq):
@@ -107,20 +380,55 @@ def main():
     p.add_argument("--timeout", type=float, default=900)
     p.add_argument("--proxy-keys", default="",
                    help="comma-separated proxy bearer tokens (empty = local mode)")
+    p.add_argument("--history-path")
+    p.add_argument("--proxy-pid", type=int)
+    p.add_argument("--report-json")
+    p.add_argument("--selftest", action="store_true")
     args = p.parse_args()
+    try:
+        require_measurement_options(args)
+    except MeasurementError as error:
+        raise SystemExit(error.check_id)
+    if args.selftest:
+        run_selftest()
+        return
+    try:
+        history_start = history_bytes(args.history_path) if args.history_path else None
+        sampler = RssSampler(args.proxy_pid) if args.proxy_pid else None
+    except MeasurementError as error:
+        raise SystemExit(error.check_id)
     args.tokens = args.proxy_keys.split(",") if args.proxy_keys else [""]
 
     before = fetch_json(f"{args.mock}/control/stats")
     print(f"driving {args.clients} clients x {args.requests} requests "
           f"({args.clients * args.requests} total) ...", flush=True)
     started = time.monotonic()
-    threads = [threading.Thread(target=client_loop, args=(args, i), daemon=True)
-               for i in range(args.clients)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-    wall = time.monotonic() - started
+    with results_lock:
+        results.clear()
+    sampler_started = False
+    sampler_finished = False
+    try:
+        if sampler:
+            sampler.start()
+            sampler_started = True
+        threads = [threading.Thread(target=client_loop, args=(args, i), daemon=True)
+                   for i in range(args.clients)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        wall = time.monotonic() - started
+        peak_rss = sampler.finish() if sampler else None
+        sampler_finished = True
+        history_end = history_bytes(args.history_path, ending=True) if args.history_path else None
+    except MeasurementError as error:
+        raise SystemExit(error.check_id)
+    finally:
+        if sampler_started and not sampler_finished:
+            try:
+                sampler.finish()
+            except MeasurementError:
+                pass
 
     after = fetch_json(f"{args.mock}/control/stats")
     violations = after["violations"] - before["violations"]
@@ -133,6 +441,17 @@ def main():
     lat = sorted(r["secs"] for r in results)
     p50 = statistics.median(lat)
     p95 = lat[int(len(lat) * 0.95) - 1]
+
+    if args.report_json:
+        try:
+            publish_report(args.report_json, {"client_failures": len(failed), "clients": args.clients,
+                "completed_requests": len(results), "duration_seconds": wall,
+                "history_end_bytes": history_end, "history_start_bytes": history_start,
+                "peak_rss_bytes": peak_rss, "rate_violations": violations,
+                "requests_per_client": args.requests, "upstream_requests": upstream_hits,
+                "worker_exhaustions": exhausted})
+        except MeasurementError as error:
+            raise SystemExit(error.check_id)
 
     print(f"""
 === nim-proxy load test report ===

--- a/src/history.rs
+++ b/src/history.rs
@@ -1677,20 +1677,255 @@ nimproxy_ttft_seconds_count{model="z-ai/glm-5.2"} 4
         assert_eq!(value(&rollup.data.totals, "requests_total"), 15.0);
     }
 
+    async fn wait_for_canonical_compaction_idle(history: &Arc<History>, label: &str) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while history.compaction_running.load(Ordering::SeqCst) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "{label}: canonical compaction did not become idle"
+            );
+            tokio::task::yield_now().await;
+        }
+    }
+
     #[tokio::test]
-    async fn canonical_history_never_schedules_legacy_compaction() {
+    async fn canonical_compaction_tracks_startup_debt_through_restart() {
         let dir = TestDir::new();
-        let history = Arc::new(History::open(dir.0.clone(), 1, capacity(40)).unwrap());
-        *history.dropped_since_compact.lock().unwrap() = COMPACT_AFTER_EXPIRED_SAMPLES + 1;
+        let now = unix_now();
+        let day = 86_400_u64;
+        let cutoff = now.saturating_sub(day);
+        let capacity = canonical_capacity(&[40]);
+        let initial = canonical_snapshot(&capacity);
+        let old_boot = cutoff.saturating_sub(500);
+        let old_sample = cutoff.saturating_sub(400);
+        let baseline = cutoff.saturating_sub(100);
+        let retained = cutoff.saturating_add(60);
+        let records = [
+            canonical_boot(old_boot, "boot-a", &capacity),
+            canonical_sample(old_sample, "boot-a", &capacity, 10.0, 1.0),
+            canonical_sample(baseline, "boot-a", &capacity, 20.0, 1.0),
+            canonical_sample(retained, "boot-a", &capacity, 30.0, 2.0),
+        ];
+        let mut bytes = Vec::new();
+        for record in &records {
+            bytes.extend(codec::encode_record(record).unwrap());
+            bytes.push(b'\n');
+        }
+        let canonical = dir.0.join("history-v1.jsonl");
+        let legacy = dir.0.join("history.jsonl");
+        fs::write(&canonical, bytes).unwrap();
 
-        history.append(unix_now(), SNAPSHOT, capacity(40));
-
-        assert_eq!(
-            history.compaction_generation.load(Ordering::SeqCst),
-            0,
-            "canonical history must not schedule the legacy compactor"
+        let history = Arc::new(History::open(dir.0.clone(), 1, initial.clone()).unwrap());
+        let startup = history.rollup(cutoff, history.boot_t, 100);
+        assert!(
+            startup.complete,
+            "clean retained history is complete at startup"
         );
-        assert!(!history.compaction_pending.load(Ordering::SeqCst));
+        assert_eq!(
+            value(&startup.data.totals, "nimproxy_requests_total"),
+            10.0,
+            "the hidden full-sample baseline preserves the retained counter delta"
+        );
+        assert!(
+            history.status().compaction_pending,
+            "durable canonical retention debt is visible at startup"
+        );
+
+        let runtime = history.boot_t;
+        history.append(
+            runtime,
+            "# TYPE nimproxy_requests_total counter\n\
+             nimproxy_requests_total{client=\"equivalence\"} 40\n\
+             # TYPE nimproxy_active_requests gauge\n\
+             nimproxy_active_requests{client=\"equivalence\"} 4\n",
+            initial.clone(),
+        );
+        wait_for_canonical_compaction_idle(&history, "startup debt").await;
+        assert!(
+            !history.status().compaction_pending,
+            "compaction clears durable retention debt after the fresh full sample"
+        );
+        let compacted = fs::read_to_string(&canonical).unwrap();
+        assert!(
+            !compacted.contains(&format!("\"timestamp\":{old_sample},")),
+            "the unnecessary older sample is removed"
+        );
+        for timestamp in [old_boot, baseline, retained, history.boot_t, runtime] {
+            assert!(
+                compacted.contains(&format!("\"timestamp\":{timestamp},")),
+                "required boot, baseline, retained, and live context is preserved at {timestamp}"
+            );
+        }
+        assert!(
+            compacted
+                .lines()
+                .all(|line| codec::decode_record(line.as_bytes()).is_ok()),
+            "compaction leaves only valid canonical rows"
+        );
+        assert!(
+            !legacy.exists(),
+            "canonical compaction never touches legacy history"
+        );
+
+        drop(history);
+        let reopened = Arc::new(History::open(dir.0.clone(), 1, initial).unwrap());
+        assert!(
+            !reopened.status().compaction_pending,
+            "the required pre-cutoff baseline is not new restart debt"
+        );
+        let after_restart = reopened.rollup(cutoff, reopened.boot_t, 100);
+        assert!(
+            after_restart.complete,
+            "retained history remains complete after restart"
+        );
+        assert_eq!(
+            value(&after_restart.data.totals, "nimproxy_requests_total"),
+            50.0,
+            "the compacted baseline and retained/live samples preserve totals after restart"
+        );
+        assert!(
+            fs::read_to_string(&canonical)
+                .unwrap()
+                .lines()
+                .all(|line| codec::decode_record(line.as_bytes()).is_ok()),
+            "restart keeps canonical bytes valid"
+        );
+        assert!(!legacy.exists(), "restart never creates legacy history");
+    }
+
+    #[tokio::test]
+    async fn canonical_compaction_defers_recovery_until_gap_leaves_horizon() {
+        let dir = TestDir::new();
+        let now = unix_now();
+        let day = 86_400_u64;
+        let cutoff_two_days = now.saturating_sub(day.saturating_mul(2));
+        let cutoff_one_day = now.saturating_sub(day);
+        let old_boot = cutoff_two_days.saturating_sub(100);
+        let old_sample = cutoff_two_days.saturating_sub(50);
+        let corrupt_at = cutoff_two_days.saturating_add(100);
+        let recovery_sample = cutoff_one_day.saturating_add(10);
+        let capacity = canonical_capacity(&[40]);
+        let initial = canonical_snapshot(&capacity);
+        let corrupt = format!(
+            r#"{{"format":"nimproxy-history","v":1,"kind":"sample","timestamp":{corrupt_at},"broken":true}}"#
+        );
+        let records = [
+            canonical_boot(old_boot, "boot-a", &capacity),
+            canonical_sample(old_sample, "boot-a", &capacity, 10.0, 1.0),
+            canonical_boot(cutoff_one_day, "boot-b", &capacity),
+            canonical_sample(recovery_sample, "boot-b", &capacity, 5.0, 2.0),
+        ];
+        let canonical = dir.0.join("history-v1.jsonl");
+        let legacy = dir.0.join("history.jsonl");
+        let mut bytes = Vec::new();
+        for (index, record) in records.iter().enumerate() {
+            if index == 2 {
+                bytes.extend(corrupt.as_bytes());
+                bytes.push(b'\n');
+            }
+            bytes.extend(codec::encode_record(record).unwrap());
+            bytes.push(b'\n');
+        }
+        fs::write(&canonical, bytes).unwrap();
+
+        let history = Arc::new(History::open(dir.0.clone(), 2, initial.clone()).unwrap());
+        let crossing = history.rollup(corrupt_at.saturating_sub(1), recovery_sample, 100);
+        assert!(
+            !crossing.complete,
+            "a query crossing supported-v1 recovery evidence is incomplete"
+        );
+        assert!(
+            history.status().compaction_pending,
+            "intersecting recovery evidence remains visible as canonical compaction debt"
+        );
+
+        let runtime = history.boot_t;
+        let mut expected_after_live_append = fs::read(&canonical).unwrap();
+        expected_after_live_append.extend(
+            codec::encode_record(&canonical_sample(
+                runtime,
+                &history.boot_id,
+                &capacity,
+                9.0,
+                4.0,
+            ))
+            .unwrap(),
+        );
+        expected_after_live_append.push(b'\n');
+        history.append(
+            runtime,
+            "# TYPE nimproxy_requests_total counter\n\
+             nimproxy_requests_total{client=\"equivalence\"} 9\n\
+             # TYPE nimproxy_active_requests gauge\n\
+             nimproxy_active_requests{client=\"equivalence\"} 4\n",
+            initial.clone(),
+        );
+        wait_for_canonical_compaction_idle(&history, "intersecting recovery gap").await;
+        assert!(
+            history.status().compaction_pending,
+            "deferred compaction remains pending while the recovery gap intersects retention"
+        );
+        assert_eq!(
+            fs::read(&canonical).unwrap(),
+            expected_after_live_append,
+            "deferred compaction preserves all canonical evidence byte-for-byte after the live append"
+        );
+
+        history.clone().reconfigure_retention(1, now);
+        wait_for_canonical_compaction_idle(&history, "safe recovery gap").await;
+        assert!(
+            !history.status().compaction_pending,
+            "a gap ending exactly at the cutoff is safe to compact"
+        );
+        let compacted = fs::read_to_string(&canonical).unwrap();
+        assert!(
+            !compacted.contains(&corrupt),
+            "safe compaction removes corrupt and outside evidence"
+        );
+        for timestamp in [old_boot, old_sample] {
+            assert!(
+                !compacted.contains(&format!("\"timestamp\":{timestamp},")),
+                "safe compaction removes outside-horizon record at {timestamp}"
+            );
+        }
+        assert!(
+            compacted
+                .lines()
+                .all(|line| codec::decode_record(line.as_bytes()).is_ok()),
+            "safe compaction leaves valid canonical bytes"
+        );
+        assert!(
+            !legacy.exists(),
+            "canonical compaction never touches legacy history"
+        );
+        let current = history.rollup(cutoff_one_day, runtime, 100);
+        assert!(
+            current.complete,
+            "the retained query is complete after safe compaction"
+        );
+        assert_eq!(
+            value(&current.data.totals, "nimproxy_requests_total"),
+            14.0,
+            "the recovery epoch and live reset preserve retained totals"
+        );
+
+        drop(history);
+        let reopened = Arc::new(History::open(dir.0.clone(), 1, initial).unwrap());
+        assert!(
+            !reopened.status().compaction_pending,
+            "safe compacted recovery history has no restart debt"
+        );
+        let after_restart = reopened.rollup(cutoff_one_day, reopened.boot_t, 100);
+        assert!(
+            after_restart.complete,
+            "safe retained history stays complete after restart"
+        );
+        assert_eq!(
+            value(&after_restart.data.totals, "nimproxy_requests_total"),
+            14.0,
+            "restart preserves safe-compaction totals"
+        );
+        assert!(!legacy.exists(), "restart never creates legacy history");
     }
 
     /// A unique per-test scratch dir (std-only; removed on drop).

--- a/src/history.rs
+++ b/src/history.rs
@@ -2120,8 +2120,8 @@ nimproxy_ttft_seconds_count{model="z-ai/glm-5.2"} 4
         *history.compaction_test_hook.lock().unwrap() = Some(Arc::new(move |point| {
             if point == CompactionTestPoint::BeforeCanonicalPendingClear {
                 let pass = hook_passes.fetch_add(1, Ordering::SeqCst) + 1;
+                entered_tx.send(pass).unwrap();
                 if pass == 1 {
-                    entered_tx.send(()).unwrap();
                     hook_release.lock().unwrap().recv().unwrap();
                 }
             }
@@ -2136,18 +2136,28 @@ nimproxy_ttft_seconds_count{model="z-ai/glm-5.2"} 4
              nimproxy_active_requests{client=\"equivalence\"} 4\n",
             initial,
         );
-        entered_rx
-            .recv_timeout(Duration::from_secs(5))
-            .expect("first canonical durable pass reaches the generation-clear hook");
+        assert_eq!(
+            entered_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("first canonical durable pass reaches the generation-clear hook"),
+            1
+        );
         assert!(history.compaction_running.load(Ordering::SeqCst));
         let superseding_cutoff = runtime.saturating_sub(day.saturating_sub(1));
         history.request_compaction(superseding_cutoff);
         let superseding_generation = history.compaction_generation.load(Ordering::SeqCst);
         release_tx.send(()).unwrap();
+        assert_eq!(
+            entered_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("the superseding generation reaches the generation-clear hook"),
+            2
+        );
         wait_for_canonical_compaction_idle(&history, "superseding generation").await;
 
-        assert!(
-            passes.load(Ordering::SeqCst) >= 2,
+        assert_eq!(
+            passes.load(Ordering::SeqCst),
+            2,
             "a superseding generation starts a second canonical compaction pass"
         );
         assert!(!history.status().compaction_pending);
@@ -2301,8 +2311,8 @@ nimproxy_ttft_seconds_count{model="z-ai/glm-5.2"} 4
         *history.compaction_test_hook.lock().unwrap() = Some(Arc::new(move |point| {
             if point == CompactionTestPoint::CanonicalReplayCaptured {
                 let pass = hook_passes.fetch_add(1, Ordering::SeqCst) + 1;
+                entered_tx.send(pass).unwrap();
                 if pass <= 2 {
-                    entered_tx.send(pass).unwrap();
                     hook_release.lock().unwrap().recv().unwrap();
                 }
             }
@@ -2365,6 +2375,12 @@ nimproxy_ttft_seconds_count{model="z-ai/glm-5.2"} 4
         history.request_compaction(superseding_cutoff);
         let superseding_generation = history.compaction_generation.load(Ordering::SeqCst);
         release_tx.send(()).unwrap();
+        assert_eq!(
+            entered_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("the superseding generation reaches replay capture"),
+            3
+        );
         wait_for_canonical_compaction_idle(&history, "sync-failure superseding generation").await;
 
         assert_eq!(

--- a/src/history.rs
+++ b/src/history.rs
@@ -561,6 +561,9 @@ enum CompactionTestPoint {
     BeforeCanonicalPendingClear,
 }
 
+#[cfg(test)]
+type CompactionTestHook = Arc<dyn Fn(CompactionTestPoint) + Send + Sync>;
+
 pub struct History {
     inner: Mutex<HistoryInner>,
     file: Option<PathBuf>,
@@ -579,7 +582,7 @@ pub struct History {
     initial_capacity: CapacitySnapshot,
     canonical: Option<Mutex<store::HistoryStore>>,
     #[cfg(test)]
-    compaction_test_hook: Mutex<Option<Arc<dyn Fn(CompactionTestPoint) + Send + Sync>>>,
+    compaction_test_hook: Mutex<Option<CompactionTestHook>>,
 }
 
 impl History {
@@ -973,9 +976,9 @@ impl History {
 
         if days > 0 && self.canonical.is_some() {
             let cutoff = t.saturating_sub(days.saturating_mul(86_400));
-            if self.compaction_pending.load(Ordering::SeqCst) {
-                self.request_compaction(cutoff);
-            } else if *self.dropped_since_compact.lock().unwrap() > COMPACT_AFTER_EXPIRED_SAMPLES {
+            if self.compaction_pending.load(Ordering::SeqCst)
+                || *self.dropped_since_compact.lock().unwrap() > COMPACT_AFTER_EXPIRED_SAMPLES
+            {
                 self.request_compaction(cutoff);
             }
         }
@@ -1191,10 +1194,10 @@ impl History {
         let cutoff = history.compaction_cutoff.load(Ordering::SeqCst);
         let claimed_drops = *history.dropped_since_compact.lock().unwrap();
         tokio::task::spawn_blocking(move || {
-            if history.canonical.is_some() {
+            if let Some(canonical) = &history.canonical {
                 let inner_revision = history.inner.lock().unwrap().revision;
                 let (result, replay) = {
-                    let mut store = history.canonical.as_ref().unwrap().lock().unwrap();
+                    let mut store = canonical.lock().unwrap();
                     let result = store.compact_if_authorized(cutoff, || {
                         let control = history.compaction_control.lock().unwrap();
                         (control.generation == generation

--- a/src/history.rs
+++ b/src/history.rs
@@ -550,6 +550,17 @@ enum CompactionOutcome {
     CommittedSyncPending(std::io::Error),
 }
 
+struct CompactionControl {
+    generation: u64,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CompactionTestPoint {
+    CanonicalReplayCaptured,
+    BeforeCanonicalPendingClear,
+}
+
 pub struct History {
     inner: Mutex<HistoryInner>,
     file: Option<PathBuf>,
@@ -562,10 +573,13 @@ pub struct History {
     compaction_running: AtomicBool,
     compaction_cutoff: AtomicU64,
     compaction_generation: AtomicU64,
+    compaction_control: Mutex<CompactionControl>,
     boot_id: String,
     boot_t: u64,
     initial_capacity: CapacitySnapshot,
     canonical: Option<Mutex<store::HistoryStore>>,
+    #[cfg(test)]
+    compaction_test_hook: Mutex<Option<Arc<dyn Fn(CompactionTestPoint) + Send + Sync>>>,
 }
 
 impl History {
@@ -579,12 +593,14 @@ impl History {
     ) -> Result<Self, store::OpenError> {
         let timestamp = unix_now();
         let capacity = canonical_capacity(&initial_capacity);
+        let cutoff = (days > 0).then(|| timestamp.saturating_sub(days.saturating_mul(86_400)));
         if let Ok(count) = store::stale_temporary_count(&dir) {
             if count > 0 {
                 tracing::warn!("stale canonical history temporaries: count={count}");
             }
         }
         let mut canonical = store::HistoryStore::open(&dir, timestamp, capacity)?;
+        let compaction_pending = cutoff.is_some_and(|cutoff| canonical.compaction_needed(cutoff));
         let legacy = dir.join("history.jsonl");
         if let Ok(metadata) = fs::metadata(&legacy) {
             tracing::warn!(
@@ -595,7 +611,7 @@ impl History {
         }
         let mut history = Self::load(None, days, initial_capacity);
         let replay = canonical.take_replay();
-        history.load_canonical(&replay.records, days);
+        history.load_canonical(&replay.records, cutoff);
         {
             let mut inner = history.inner.lock().unwrap();
             inner.diagnostics = replay.diagnostics;
@@ -606,11 +622,28 @@ impl History {
         history.boot_id = canonical.boot_id().to_owned();
         history.boot_t = timestamp;
         history.canonical = Some(Mutex::new(canonical));
+        history
+            .compaction_pending
+            .store(compaction_pending, Ordering::SeqCst);
+        history
+            .compaction_cutoff
+            .store(cutoff.unwrap_or(0), Ordering::SeqCst);
+        history
+            .compaction_generation
+            .store(u64::from(compaction_pending), Ordering::SeqCst);
+        history.compaction_control.lock().unwrap().generation = u64::from(compaction_pending);
         Ok(history)
     }
 
-    fn load_canonical(&mut self, records: &[codec::Record], days: u64) {
-        let cutoff = (days > 0).then(|| unix_now().saturating_sub(days.saturating_mul(86_400)));
+    #[cfg(test)]
+    fn invoke_compaction_test_hook(&self, point: CompactionTestPoint) {
+        let hook = self.compaction_test_hook.lock().unwrap().clone();
+        if let Some(hook) = hook {
+            hook(point);
+        }
+    }
+
+    fn load_canonical(&mut self, records: &[codec::Record], cutoff: Option<u64>) {
         let mut current_boot = None;
         let mut current_state = None;
         let mut inner = self.inner.lock().unwrap();
@@ -771,10 +804,15 @@ impl History {
             compaction_running: AtomicBool::new(false),
             compaction_cutoff: AtomicU64::new(cutoff.unwrap_or(0)),
             compaction_generation: AtomicU64::new(u64::from(compaction_pending)),
+            compaction_control: Mutex::new(CompactionControl {
+                generation: u64::from(compaction_pending),
+            }),
             boot_id,
             boot_t,
             initial_capacity,
             canonical: None,
+            #[cfg(test)]
+            compaction_test_hook: Mutex::new(None),
         };
         history.persist_boot_marker();
         let inner = history.inner.lock().unwrap();
@@ -801,10 +839,18 @@ impl History {
     /// Retune retention live. Visible queries prune synchronously; durable
     /// compaction is serialized with appends and runs off the async executor.
     pub fn reconfigure_retention(self: &Arc<Self>, days: u64, now: u64) {
-        self.days.store(days, Ordering::Relaxed);
         if days == 0 {
+            let mut control = self.compaction_control.lock().unwrap();
+            self.days.store(0, Ordering::Relaxed);
+            let generation = self
+                .compaction_generation
+                .fetch_add(1, Ordering::SeqCst)
+                .wrapping_add(1);
+            control.generation = generation;
+            self.compaction_pending.store(false, Ordering::SeqCst);
             return;
         }
+        self.days.store(days, Ordering::Relaxed);
 
         let cutoff = now.saturating_sub(days.saturating_mul(86_400));
         let mut inner = self.inner.lock().unwrap();
@@ -819,7 +865,7 @@ impl History {
         inner.available_to = inner.points.last().map(|point| point.t);
         drop(inner);
 
-        if self.file.is_some() {
+        if self.canonical.is_some() || self.file.is_some() {
             self.request_compaction(cutoff);
         }
     }
@@ -922,6 +968,15 @@ impl History {
                 canonical_state,
             ) {
                 tracing::warn!("canonical history append failed: {error}");
+            }
+        }
+
+        if days > 0 && self.canonical.is_some() {
+            let cutoff = t.saturating_sub(days.saturating_mul(86_400));
+            if self.compaction_pending.load(Ordering::SeqCst) {
+                self.request_compaction(cutoff);
+            } else if *self.dropped_since_compact.lock().unwrap() > COMPACT_AFTER_EXPIRED_SAMPLES {
+                self.request_compaction(cutoff);
             }
         }
 
@@ -1108,9 +1163,16 @@ impl History {
     }
 
     fn request_compaction(self: &Arc<Self>, cutoff: u64) {
-        self.compaction_cutoff.store(cutoff, Ordering::SeqCst);
-        self.compaction_generation.fetch_add(1, Ordering::SeqCst);
-        self.compaction_pending.store(true, Ordering::SeqCst);
+        {
+            let mut control = self.compaction_control.lock().unwrap();
+            self.compaction_cutoff.store(cutoff, Ordering::SeqCst);
+            let generation = self
+                .compaction_generation
+                .fetch_add(1, Ordering::SeqCst)
+                .wrapping_add(1);
+            control.generation = generation;
+            self.compaction_pending.store(true, Ordering::SeqCst);
+        }
         self.start_pending_compaction();
     }
 
@@ -1129,6 +1191,96 @@ impl History {
         let cutoff = history.compaction_cutoff.load(Ordering::SeqCst);
         let claimed_drops = *history.dropped_since_compact.lock().unwrap();
         tokio::task::spawn_blocking(move || {
+            if history.canonical.is_some() {
+                let inner_revision = history.inner.lock().unwrap().revision;
+                let (result, replay) = {
+                    let mut store = history.canonical.as_ref().unwrap().lock().unwrap();
+                    let result = store.compact_if_authorized(cutoff, || {
+                        let control = history.compaction_control.lock().unwrap();
+                        (control.generation == generation
+                            && history.compaction_generation.load(Ordering::SeqCst) == generation
+                            && history.compaction_pending.load(Ordering::SeqCst)
+                            && history.days.load(Ordering::Relaxed) > 0)
+                            .then_some(control)
+                    });
+                    let replay = matches!(
+                        &result,
+                        Ok(store::CompactionOutcome::Durable)
+                            | Ok(store::CompactionOutcome::CommittedSyncPending(_))
+                    )
+                    .then(|| store.take_replay());
+                    (result, replay)
+                };
+                let mut durable = false;
+                let mut superseded = false;
+                let mut sync_pending = false;
+                match result {
+                    Ok(store::CompactionOutcome::Durable) => {
+                        #[cfg(test)]
+                        history.invoke_compaction_test_hook(
+                            CompactionTestPoint::CanonicalReplayCaptured,
+                        );
+                        history.install_canonical_replay_if_unchanged(
+                            replay.expect("committed canonical replacement has replay"),
+                            inner_revision,
+                        );
+                        durable = true;
+                        let mut dropped = history.dropped_since_compact.lock().unwrap();
+                        *dropped = dropped.saturating_sub(claimed_drops);
+                        drop(dropped);
+                        if history.compaction_generation.load(Ordering::SeqCst) == generation {
+                            #[cfg(test)]
+                            history.invoke_compaction_test_hook(
+                                CompactionTestPoint::BeforeCanonicalPendingClear,
+                            );
+                            history.compaction_pending.store(false, Ordering::SeqCst);
+                            if history.compaction_generation.load(Ordering::SeqCst) != generation
+                                && history.days.load(Ordering::Relaxed) > 0
+                            {
+                                history.compaction_pending.store(true, Ordering::SeqCst);
+                            }
+                        }
+                    }
+                    Ok(store::CompactionOutcome::Deferred) => {}
+                    Ok(store::CompactionOutcome::Superseded) => {
+                        superseded = true;
+                    }
+                    Ok(store::CompactionOutcome::CommittedSyncPending(error)) => {
+                        sync_pending = true;
+                        #[cfg(test)]
+                        history.invoke_compaction_test_hook(
+                            CompactionTestPoint::CanonicalReplayCaptured,
+                        );
+                        history.install_canonical_replay_if_unchanged(
+                            replay.expect("committed canonical replacement has replay"),
+                            inner_revision,
+                        );
+                        tracing::warn!(
+                            "canonical history compaction was atomically renamed, but directory sync failed; \
+                             durability is uncertain and cleanup remains pending: {error}"
+                        );
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            "canonical history compaction failed before replacement; original path is unchanged: \
+                             {error}"
+                        );
+                    }
+                }
+
+                history.compaction_running.store(false, Ordering::SeqCst);
+                let newer_sync_pending = sync_pending
+                    && history.compaction_generation.load(Ordering::SeqCst) != generation
+                    && history.days.load(Ordering::Relaxed) > 0
+                    && history.compaction_pending.load(Ordering::SeqCst);
+                if (durable || superseded || newer_sync_pending)
+                    && history.compaction_pending.load(Ordering::SeqCst)
+                {
+                    history.start_pending_compaction();
+                }
+                return;
+            }
+
             let result = history.compact_file(cutoff);
             let durable = matches!(&result, Ok(CompactionOutcome::Durable));
             match result {
@@ -1166,6 +1318,18 @@ impl History {
                 history.start_pending_compaction();
             }
         });
+    }
+
+    fn install_canonical_replay_if_unchanged(&self, replay: store::Replay, expected_revision: u64) {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.revision != expected_revision {
+            return;
+        }
+        inner.diagnostics = replay.diagnostics;
+        inner.recovery_gaps = replay.gaps;
+        inner.recovery_events = replay.diagnostic_events;
+        inner.recovery_events_complete = true;
+        inner.revision = inner.revision.wrapping_add(1);
     }
 
     fn compact_file(&self, cutoff: u64) -> std::io::Result<CompactionOutcome> {
@@ -1417,10 +1581,12 @@ mod tests {
             compaction_running: AtomicBool::new(false),
             compaction_cutoff: AtomicU64::new(0),
             compaction_generation: AtomicU64::new(0),
+            compaction_control: Mutex::new(CompactionControl { generation: 0 }),
             boot_id: "00000000000000000000000000000000".to_owned(),
             boot_t: 0,
             initial_capacity: capacity(40),
             canonical: None,
+            compaction_test_hook: Mutex::new(None),
         })
     }
 
@@ -1926,6 +2092,292 @@ nimproxy_ttft_seconds_count{model="z-ai/glm-5.2"} 4
             "restart preserves safe-compaction totals"
         );
         assert!(!legacy.exists(), "restart never creates legacy history");
+    }
+
+    #[tokio::test]
+    async fn canonical_compaction_review_preserves_a_superseding_generation() {
+        let now = unix_now();
+        let day = 86_400_u64;
+        let cutoff = now.saturating_sub(day);
+        let capacity = canonical_capacity(&[40]);
+        let initial = canonical_snapshot(&capacity);
+        let records = [
+            canonical_boot(cutoff.saturating_sub(500), "boot-a", &capacity),
+            canonical_sample(cutoff.saturating_sub(400), "boot-a", &capacity, 10.0, 1.0),
+            canonical_sample(cutoff.saturating_sub(100), "boot-a", &capacity, 20.0, 1.0),
+            canonical_sample(cutoff.saturating_add(60), "boot-a", &capacity, 30.0, 2.0),
+        ];
+        let (_dir, history) = open_canonical_equivalence_history(&records, 1, initial.clone());
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let release_rx = Arc::new(Mutex::new(release_rx));
+        let passes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hook_passes = Arc::clone(&passes);
+        let hook_release = Arc::clone(&release_rx);
+        *history.compaction_test_hook.lock().unwrap() = Some(Arc::new(move |point| {
+            if point == CompactionTestPoint::BeforeCanonicalPendingClear {
+                let pass = hook_passes.fetch_add(1, Ordering::SeqCst) + 1;
+                if pass == 1 {
+                    entered_tx.send(()).unwrap();
+                    hook_release.lock().unwrap().recv().unwrap();
+                }
+            }
+        }));
+
+        let runtime = history.boot_t;
+        history.append(
+            runtime,
+            "# TYPE nimproxy_requests_total counter\n\
+             nimproxy_requests_total{client=\"equivalence\"} 40\n\
+             # TYPE nimproxy_active_requests gauge\n\
+             nimproxy_active_requests{client=\"equivalence\"} 4\n",
+            initial,
+        );
+        entered_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("first canonical durable pass reaches the generation-clear hook");
+        assert!(history.compaction_running.load(Ordering::SeqCst));
+        let superseding_cutoff = runtime.saturating_sub(day.saturating_sub(1));
+        history.request_compaction(superseding_cutoff);
+        let superseding_generation = history.compaction_generation.load(Ordering::SeqCst);
+        release_tx.send(()).unwrap();
+        wait_for_canonical_compaction_idle(&history, "superseding generation").await;
+
+        assert!(
+            passes.load(Ordering::SeqCst) >= 2,
+            "a superseding generation starts a second canonical compaction pass"
+        );
+        assert!(!history.status().compaction_pending);
+        assert_eq!(
+            history.compaction_generation.load(Ordering::SeqCst),
+            superseding_generation
+        );
+        assert_eq!(
+            history.compaction_cutoff.load(Ordering::SeqCst),
+            superseding_cutoff
+        );
+    }
+
+    #[tokio::test]
+    async fn canonical_compaction_review_preserves_concurrent_append_diagnostics_and_events() {
+        let now = unix_now();
+        let day = 86_400_u64;
+        let cutoff = now.saturating_sub(day);
+        let capacity = canonical_capacity(&[40]);
+        let initial = canonical_snapshot(&capacity);
+        let records = [
+            canonical_boot(cutoff.saturating_sub(500), "boot-a", &capacity),
+            canonical_sample(cutoff.saturating_sub(400), "boot-a", &capacity, 10.0, 1.0),
+            canonical_sample(cutoff.saturating_sub(100), "boot-a", &capacity, 20.0, 1.0),
+            canonical_sample(cutoff.saturating_add(60), "boot-a", &capacity, 30.0, 2.0),
+        ];
+        let (_dir, history) = open_canonical_equivalence_history(&records, 1, initial.clone());
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let release_rx = Arc::new(Mutex::new(release_rx));
+        *history.compaction_test_hook.lock().unwrap() = Some(Arc::new(move |point| {
+            if point == CompactionTestPoint::CanonicalReplayCaptured {
+                entered_tx.send(()).unwrap();
+                release_rx.lock().unwrap().recv().unwrap();
+            }
+        }));
+
+        let runtime = history.boot_t;
+        history.append(
+            runtime,
+            "# TYPE nimproxy_requests_total counter\n\
+             nimproxy_requests_total{client=\"equivalence\"} 40\n\
+             # TYPE nimproxy_active_requests gauge\n\
+             nimproxy_active_requests{client=\"equivalence\"} 4\n",
+            initial.clone(),
+        );
+        entered_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("canonical replay capture releases the store before installation");
+        history.compaction_pending.store(false, Ordering::SeqCst);
+        history.append(
+            runtime,
+            "# TYPE nimproxy_requests_total counter\n\
+             nimproxy_requests_total{client=\"equivalence\"} 50\n\
+             # TYPE nimproxy_active_requests gauge\n\
+             nimproxy_active_requests{client=\"equivalence\"} 5\n",
+            initial,
+        );
+        let (diagnostics, recovery_events, revision) = {
+            let inner = history.inner.lock().unwrap();
+            (
+                inner.diagnostics.clone(),
+                inner.recovery_events.len(),
+                inner.revision,
+            )
+        };
+        release_tx.send(()).unwrap();
+        wait_for_canonical_compaction_idle(&history, "concurrent append replay install").await;
+        let after = history.inner.lock().unwrap();
+        assert!(
+            after.diagnostics.valid_samples >= diagnostics.valid_samples
+                && after.diagnostics.normalized_series >= diagnostics.normalized_series
+                && after.recovery_events.len() >= recovery_events
+                && after.revision >= revision,
+            "canonical replay installation preserves concurrent append diagnostics, events, and revision"
+        );
+        drop(after);
+        assert!(
+            value(
+                &history.rollup(cutoff, runtime, 100).data.totals,
+                "nimproxy_requests_total"
+            ) >= 10.0,
+            "the concurrent appended counter delta remains in the rollup"
+        );
+    }
+
+    #[tokio::test]
+    async fn canonical_compaction_review_unlimited_transition_cancels_stale_finite_work() {
+        let now = unix_now();
+        let capacity = canonical_capacity(&[40]);
+        let initial = canonical_snapshot(&capacity);
+        let records = [
+            canonical_boot(now.saturating_sub(90_000), "boot-a", &capacity),
+            canonical_sample(now.saturating_sub(89_000), "boot-a", &capacity, 10.0, 1.0),
+            canonical_sample(now.saturating_sub(100), "boot-a", &capacity, 20.0, 2.0),
+        ];
+        let (dir, history) = open_canonical_equivalence_history(&records, 0, initial);
+        let canonical = dir.0.join("history-v1.jsonl");
+        let legacy = dir.0.join("history.jsonl");
+        let before = fs::read(&canonical).unwrap();
+        let store = history.canonical.as_ref().unwrap().lock().unwrap();
+        history.clone().reconfigure_retention(1, now);
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while !history.compaction_running.load(Ordering::SeqCst) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "finite canonical compaction did not claim the running state"
+            );
+            std::thread::yield_now();
+        }
+        history.clone().reconfigure_retention(0, now);
+        drop(store);
+        wait_for_canonical_compaction_idle(&history, "unlimited retention transition").await;
+
+        assert_eq!(history.days.load(Ordering::Relaxed), 0);
+        assert!(
+            !history.status().compaction_pending,
+            "unlimited retention cancels pending finite canonical compaction"
+        );
+        assert_eq!(
+            fs::read(&canonical).unwrap(),
+            before,
+            "unlimited retention leaves canonical bytes unchanged"
+        );
+        assert!(
+            !legacy.exists(),
+            "canonical compaction never touches legacy history"
+        );
+    }
+
+    #[tokio::test]
+    async fn canonical_compaction_review_reschedules_newer_generation_after_sync_failure() {
+        let now = unix_now();
+        let day = 86_400_u64;
+        let cutoff = now.saturating_sub(day);
+        let capacity = canonical_capacity(&[40]);
+        let initial = canonical_snapshot(&capacity);
+        let records = [
+            canonical_boot(cutoff.saturating_sub(500), "boot-a", &capacity),
+            canonical_sample(cutoff.saturating_sub(400), "boot-a", &capacity, 10.0, 1.0),
+            canonical_sample(cutoff.saturating_sub(100), "boot-a", &capacity, 20.0, 1.0),
+            canonical_sample(cutoff.saturating_add(60), "boot-a", &capacity, 30.0, 2.0),
+        ];
+        let (_dir, history) = open_canonical_equivalence_history(&records, 1, initial.clone());
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(2);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(2);
+        let release_rx = Arc::new(Mutex::new(release_rx));
+        let passes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let hook_passes = Arc::clone(&passes);
+        let hook_release = Arc::clone(&release_rx);
+        *history.compaction_test_hook.lock().unwrap() = Some(Arc::new(move |point| {
+            if point == CompactionTestPoint::CanonicalReplayCaptured {
+                let pass = hook_passes.fetch_add(1, Ordering::SeqCst) + 1;
+                if pass <= 2 {
+                    entered_tx.send(pass).unwrap();
+                    hook_release.lock().unwrap().recv().unwrap();
+                }
+            }
+        }));
+
+        history
+            .canonical
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .inject_test_compaction_directory_sync_failure();
+        let runtime = history.boot_t;
+        history.append(
+            runtime,
+            "# TYPE nimproxy_requests_total counter\n\
+             nimproxy_requests_total{client=\"equivalence\"} 40\n\
+             # TYPE nimproxy_active_requests gauge\n\
+             nimproxy_active_requests{client=\"equivalence\"} 4\n",
+            initial.clone(),
+        );
+        assert_eq!(
+            entered_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("the injected directory-sync failure reaches replay capture"),
+            1
+        );
+        assert_eq!(
+            passes.load(Ordering::SeqCst),
+            1,
+            "the unchanged sync-failure generation has one committed pass"
+        );
+        release_tx.send(()).unwrap();
+        wait_for_canonical_compaction_idle(&history, "unchanged sync failure").await;
+        assert_eq!(
+            passes.load(Ordering::SeqCst),
+            1,
+            "the unchanged sync-failure generation is not retried"
+        );
+        assert!(
+            history.status().compaction_pending,
+            "the unsynced committed generation remains pending without a retry spin"
+        );
+
+        history
+            .canonical
+            .as_ref()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .inject_test_compaction_directory_sync_failure();
+        history.request_compaction(cutoff);
+        assert_eq!(
+            entered_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("the second injected directory-sync failure reaches replay capture"),
+            2
+        );
+        let superseding_cutoff = runtime.saturating_sub(day.saturating_sub(1));
+        history.request_compaction(superseding_cutoff);
+        let superseding_generation = history.compaction_generation.load(Ordering::SeqCst);
+        release_tx.send(()).unwrap();
+        wait_for_canonical_compaction_idle(&history, "sync-failure superseding generation").await;
+
+        assert_eq!(
+            passes.load(Ordering::SeqCst),
+            3,
+            "a newer finite generation starts and completes after the sync-failure worker releases"
+        );
+        assert!(!history.status().compaction_pending);
+        assert_eq!(
+            history.compaction_generation.load(Ordering::SeqCst),
+            superseding_generation
+        );
+        assert_eq!(
+            history.compaction_cutoff.load(Ordering::SeqCst),
+            superseding_cutoff
+        );
     }
 
     /// A unique per-test scratch dir (std-only; removed on drop).

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -835,15 +835,20 @@ fn retained_compaction_records(
             let baseline = epoch
                 .iter()
                 .enumerate()
-                .filter_map(|(index, record)| match record {
-                    Record::Sample(sample) if sample.timestamp < cutoff => Some(index),
-                    Record::Boot(_) | Record::Sample(_) | Record::Checkpoint(_) => None,
+                .filter(|(_, record)| {
+                    matches!(record, Record::Sample(sample) if sample.timestamp < cutoff)
                 })
-                .last();
-            retained.extend(epoch.iter().enumerate().filter_map(|(index, record)| {
-                (index == 0 || Some(index) == baseline || record_timestamp(record) >= cutoff)
-                    .then(|| record.clone())
-            }));
+                .map(|(index, _)| index)
+                .next_back();
+            retained.extend(
+                epoch
+                    .iter()
+                    .enumerate()
+                    .filter(|&(index, record)| {
+                        index == 0 || Some(index) == baseline || record_timestamp(record) >= cutoff
+                    })
+                    .map(|(_, record)| record.clone()),
+            );
         }
         start = end;
     }
@@ -2393,7 +2398,7 @@ mod tests {
                 Record::Sample(sample) if sample.timestamp < cutoff => Some(sample),
                 Record::Boot(_) | Record::Checkpoint(_) | Record::Sample(_) => None,
             })
-            .last()
+            .next_back()
             .unwrap_or_else(|| panic!("{name}: pre-cutoff full-sample baseline is required"));
         assert_eq!(
             baseline.state,
@@ -2514,7 +2519,9 @@ mod tests {
 
     #[test]
     fn compaction_recovery_safety_defers_intersecting_evidence_and_discards_only_outside_gaps() {
-        let cases: [(&str, u64, u64, String, bool, bool, Option<String>); 3] = [
+        type RecoveryCase = (&'static str, u64, u64, String, bool, bool, Option<String>);
+
+        let cases: [RecoveryCase; 3] = [
             (
                 "damage-intersects-retained-horizon",
                 13,

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -268,6 +268,7 @@ impl HistoryStore {
         self.checkpoint_inner(timestamp, capacity, None)
     }
 
+    #[cfg(test)]
     pub(crate) fn compact(&mut self, cutoff: u64) -> io::Result<CompactionOutcome> {
         self.compact_inner(cutoff, None)
     }
@@ -319,6 +320,7 @@ impl HistoryStore {
         retained != self.replay.records
     }
 
+    #[cfg(test)]
     fn compact_inner(
         &mut self,
         cutoff: u64,

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -16,6 +16,7 @@ const TEMP_PREFIX: &str = "history-v1.jsonl.tmp-";
 #[derive(Debug)]
 pub struct HistoryStore {
     file: File,
+    path: PathBuf,
     boot_id: String,
     last_state: Option<Vec<StateEntry>>,
     replay: Replay,
@@ -108,6 +109,13 @@ pub enum WriteError {
     TimestampRegression,
 }
 
+#[derive(Debug)]
+pub(crate) enum CompactionOutcome {
+    Durable,
+    Deferred,
+    CommittedSyncPending(io::Error),
+}
+
 impl std::fmt::Display for WriteError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -156,6 +164,7 @@ impl HistoryStore {
                 let last_timestamp = replay.records.last().map(record_timestamp);
                 Ok(Self {
                     file,
+                    path: path.clone(),
                     boot_id,
                     last_state: None,
                     replay,
@@ -171,6 +180,7 @@ impl HistoryStore {
                         let last_timestamp = Some(record_timestamp(&boot));
                         Ok(Self {
                             file,
+                            path: path.clone(),
                             boot_id,
                             last_state: None,
                             replay: Replay {
@@ -192,6 +202,7 @@ impl HistoryStore {
                         let last_timestamp = replay.records.last().map(record_timestamp);
                         Ok(Self {
                             file,
+                            path: path.clone(),
                             boot_id,
                             last_state: None,
                             replay,
@@ -246,6 +257,82 @@ impl HistoryStore {
 
     pub fn checkpoint(&mut self, timestamp: u64, capacity: Capacity) -> Result<(), WriteError> {
         self.checkpoint_inner(timestamp, capacity, None)
+    }
+
+    pub(crate) fn compact(&mut self, cutoff: u64) -> io::Result<CompactionOutcome> {
+        self.compact_inner(cutoff, None)
+    }
+
+    fn compact_inner(
+        &mut self,
+        cutoff: u64,
+        mut failure: Option<&mut FailureSwitch>,
+    ) -> io::Result<CompactionOutcome> {
+        let replay = validate_canonical(&self.path).map_err(open_error_to_io)?;
+        if replay.gaps.iter().any(|gap| gap.to > cutoff) || self.last_state.is_none() {
+            return Ok(CompactionOutcome::Deferred);
+        }
+
+        let retained = retained_compaction_records(
+            &replay.records,
+            cutoff,
+            &self.boot_id,
+            self.last_state.is_some(),
+        );
+        let directory = self
+            .path
+            .parent()
+            .ok_or_else(|| io::Error::other("history path has no parent"))?
+            .to_path_buf();
+        let (temporary, mut output) =
+            create_temporary(&directory, &mut failure, FailurePoint::CompactionTempCreate)?;
+        for record in &retained {
+            write_record(
+                &mut output,
+                record,
+                failure.as_deref_mut(),
+                Some(FailurePoint::CompactionTempWrite),
+            )
+            .map_err(write_error_to_io)?;
+        }
+        output.flush()?;
+        fail(&mut failure, FailurePoint::CompactionTempSync)?;
+        output.sync_all()?;
+
+        let replacement_replay = validate_canonical(&temporary).map_err(open_error_to_io)?;
+        if replacement_replay.records != retained
+            || !replacement_replay.gaps.is_empty()
+            || replacement_replay.needs_separator
+            || replacement_replay.diagnostics.excluded_epochs != 0
+            || replacement_replay.diagnostics.excluded_records != 0
+        {
+            return Err(io::Error::other(
+                "compaction replacement does not exactly validate as retained canonical history",
+            ));
+        }
+        fail(&mut failure, FailurePoint::CompactionRename)?;
+        fs::rename(&temporary, &self.path)?;
+
+        self.file = output;
+        self.last_timestamp = replacement_replay.records.last().map(record_timestamp);
+        self.last_state = replacement_replay
+            .records
+            .iter()
+            .rev()
+            .find_map(|record| match record {
+                Record::Sample(sample) if sample.boot_id == self.boot_id => {
+                    Some(sample.state.clone())
+                }
+                Record::Boot(_) | Record::Sample(_) | Record::Checkpoint(_) => None,
+            });
+        self.replay = replacement_replay;
+
+        match fail(&mut failure, FailurePoint::CompactionDirectorySync)
+            .and_then(|()| sync_directory(&directory))
+        {
+            Ok(()) => Ok(CompactionOutcome::Durable),
+            Err(error) => Ok(CompactionOutcome::CommittedSyncPending(error)),
+        }
     }
 
     fn checkpoint_inner(
@@ -613,7 +700,8 @@ fn publish_first_boot(
     let directory = path
         .parent()
         .ok_or_else(|| io::Error::other("history path has no parent"))?;
-    let (temporary, mut file) = create_temporary(directory, &mut failure)?;
+    let (temporary, mut file) =
+        create_temporary(directory, &mut failure, FailurePoint::TempCreate)?;
     write_record(
         &mut file,
         boot,
@@ -634,11 +722,12 @@ fn publish_first_boot(
 fn create_temporary(
     directory: &Path,
     failure: &mut Option<&mut FailureSwitch>,
+    failure_point: FailurePoint,
 ) -> io::Result<(PathBuf, File)> {
     for _ in 0..32 {
         let path = directory.join(format!("{TEMP_PREFIX}{}", new_boot_id()));
-        fail(failure, FailurePoint::TempCreate)?;
-        match OpenOptions::new().write(true).create_new(true).open(&path) {
+        fail(failure, failure_point)?;
+        match OpenOptions::new().append(true).create_new(true).open(&path) {
             Ok(file) => return Ok((path, file)),
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
             Err(error) => return Err(error),
@@ -648,6 +737,44 @@ fn create_temporary(
         io::ErrorKind::AlreadyExists,
         "unique history temporary unavailable",
     ))
+}
+
+fn retained_compaction_records(
+    records: &[Record],
+    cutoff: u64,
+    live_boot_id: &str,
+    live_epoch_usable: bool,
+) -> Vec<Record> {
+    let mut retained = Vec::new();
+    let mut start = 0;
+    while start < records.len() {
+        let end = records[start + 1..]
+            .iter()
+            .position(|record| matches!(record, Record::Boot(_)))
+            .map_or(records.len(), |offset| start + 1 + offset);
+        let epoch = &records[start..end];
+        let is_live_epoch = live_epoch_usable
+            && matches!(epoch.first(), Some(Record::Boot(boot)) if boot.boot_id == live_boot_id);
+        let has_retained_observation = epoch
+            .iter()
+            .any(|record| record_timestamp(record) >= cutoff);
+        if is_live_epoch || has_retained_observation {
+            let baseline = epoch
+                .iter()
+                .enumerate()
+                .filter_map(|(index, record)| match record {
+                    Record::Sample(sample) if sample.timestamp < cutoff => Some(index),
+                    Record::Boot(_) | Record::Sample(_) | Record::Checkpoint(_) => None,
+                })
+                .last();
+            retained.extend(epoch.iter().enumerate().filter_map(|(index, record)| {
+                (index == 0 || Some(index) == baseline || record_timestamp(record) >= cutoff)
+                    .then(|| record.clone())
+            }));
+        }
+        start = end;
+    }
+    retained
 }
 
 fn append_record(
@@ -713,6 +840,13 @@ fn write_error_to_io(error: WriteError) -> io::Error {
     }
 }
 
+fn open_error_to_io(error: OpenError) -> io::Error {
+    match error {
+        OpenError::Io(error) => error,
+        error => io::Error::other(error.to_string()),
+    }
+}
+
 #[cfg(unix)]
 fn sync_directory(directory: &Path) -> io::Result<()> {
     File::open(directory)?.sync_all()
@@ -758,6 +892,11 @@ enum FailurePoint {
     TempCreate,
     TempWrite,
     TempSync,
+    CompactionTempCreate,
+    CompactionTempWrite,
+    CompactionTempSync,
+    CompactionRename,
+    CompactionDirectorySync,
     HardLink,
     ParentDirectorySync,
     RestartBootAppend,
@@ -857,7 +996,10 @@ mod tests {
         ScannerState,
     };
     use crate::history::{
-        codec::{decode_record, Capacity, DecodeError, Record, StateEntry, StateKind},
+        codec::{
+            decode_record, BootRecord, Capacity, DecodeError, Record, SampleRecord, StateEntry,
+            StateKind,
+        },
         CapacitySnapshot, History, HistoryWindow, MetricValue,
     };
 
@@ -876,6 +1018,15 @@ mod tests {
             labels: Default::default(),
             value,
         }]
+    }
+
+    fn runtime_sample(timestamp: u64, boot_id: &str, value: f64) -> Record {
+        Record::Sample(SampleRecord {
+            timestamp,
+            boot_id: boot_id.to_owned(),
+            capacity: capacity(),
+            state: state(value),
+        })
     }
 
     fn test_dir(label: &str) -> std::path::PathBuf {
@@ -2173,7 +2324,14 @@ mod tests {
             .unwrap_or_else(|| panic!("{name}: pre-cutoff full-sample baseline is required"));
         assert_eq!(
             baseline.state,
-            state(expected_value),
+            vec![StateEntry {
+                kind: StateKind::Counter,
+                metric: "nimproxy_requests_total".into(),
+                labels: [("client".to_owned(), "synthetic-client".to_owned())]
+                    .into_iter()
+                    .collect(),
+                value: expected_value,
+            }],
             "{name}: the latest strictly pre-cutoff full sample, not a checkpoint, is retained"
         );
     }
@@ -2335,10 +2493,11 @@ mod tests {
             let path = dir.join("history-v1.jsonl");
             fs::write(&path, source).unwrap();
             let mut store = HistoryStore::open(&dir, opened_at, capacity()).unwrap();
-            let live_boot = canonical_records(&fs::read(&path).unwrap())
-                .last()
-                .cloned()
-                .expect("open appends its fresh boot");
+            let live_boot = Record::Boot(BootRecord {
+                timestamp: opened_at,
+                boot_id: store.boot_id().to_owned(),
+                capacity: capacity(),
+            });
 
             if sample_fresh_boot {
                 store
@@ -2352,12 +2511,8 @@ mod tests {
                 );
             }
             let before = fs::read(&path).unwrap();
-            let live_sample = expect_durable.then(|| {
-                canonical_records(&before)
-                    .last()
-                    .cloned()
-                    .expect("durable compaction has a full sample for its fresh runtime boot")
-            });
+            let live_sample =
+                expect_durable.then(|| runtime_sample(opened_at + 1, store.boot_id(), 9.0));
 
             let outcome = store.compact(cutoff).unwrap();
             if !expect_durable {
@@ -2605,8 +2760,8 @@ mod tests {
             records_from_fixture(&sample(11, "boot-a", 1.0))[0].clone(),
             records_from_fixture(&sample(13, "boot-a", 2.0))[0].clone(),
             records_from_fixture(&boot(20, &live_boot_id))[0].clone(),
-            records_from_fixture(&sample(21, &live_boot_id, 7.0))[0].clone(),
-            records_from_fixture(&sample(22, &live_boot_id, 9.0))[0].clone(),
+            runtime_sample(21, &live_boot_id, 7.0),
+            runtime_sample(22, &live_boot_id, 9.0),
         ];
         assert_complete_canonical_path(&path, &expected, "serialized append");
         assert_eq!(

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -740,6 +740,11 @@ enum FailurePoint {
     TempCreate,
     TempWrite,
     TempSync,
+    CompactionTempCreate,
+    CompactionTempWrite,
+    CompactionTempSync,
+    CompactionRename,
+    CompactionDirectorySync,
     HardLink,
     ParentDirectorySync,
     RestartBootAppend,
@@ -822,13 +827,34 @@ fn append_with_test_failure(
 }
 
 #[cfg(test)]
+struct InjectedCompaction {
+    result: io::Result<CompactionOutcome>,
+    fired: Option<FailurePoint>,
+}
+
+#[cfg(test)]
+fn compact_with_test_failure(
+    store: &mut HistoryStore,
+    cutoff: u64,
+    point: FailurePoint,
+) -> InjectedCompaction {
+    let mut failure = FailureSwitch { point, fired: None };
+    let result = store.compact_inner(cutoff, Some(&mut failure));
+    InjectedCompaction {
+        result,
+        fired: failure.fired,
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use std::fs;
-    use std::sync::Arc;
+    use std::sync::{mpsc, Arc, Mutex, TryLockError};
 
     use super::{
-        add_sample, append_with_test_failure, open_with_test_failure, validate_canonical, Epoch,
-        FailurePoint, HistoryStore, OpenError, ScannerState,
+        add_sample, append_with_test_failure, compact_with_test_failure, open_with_test_failure,
+        validate_canonical, CompactionOutcome, Epoch, FailurePoint, HistoryStore, OpenError,
+        ScannerState,
     };
     use crate::history::{
         codec::{decode_record, Capacity, DecodeError, Record, StateEntry, StateKind},
@@ -2088,6 +2114,514 @@ mod tests {
         assert!(!after_failed_tick.ends_with(b"\n"));
         assert!(store.append_sample(3, capacity(), state(2.0)).is_err());
         assert_eq!(fs::read(path).unwrap(), after_failed_tick);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    fn canonical_records(bytes: &[u8]) -> Vec<Record> {
+        bytes
+            .split(|byte| *byte == b'\n')
+            .filter(|line| !line.is_empty())
+            .map(|line| decode_record(line).expect("test canonical fixture must decode"))
+            .collect()
+    }
+
+    fn canonical_bytes(records: &[Record]) -> Vec<u8> {
+        records
+            .iter()
+            .flat_map(|record| {
+                let mut line = super::encode_record(record).expect("test record must encode");
+                line.push(b'\n');
+                line
+            })
+            .collect()
+    }
+
+    fn records_from_fixture(bytes: &str) -> Vec<Record> {
+        canonical_records(bytes.as_bytes())
+    }
+
+    fn assert_complete_canonical_path(path: &std::path::Path, expected: &[Record], name: &str) {
+        let actual_bytes = fs::read(path).unwrap();
+        assert_eq!(
+            canonical_records(&actual_bytes),
+            expected,
+            "{name}: canonical records retain exact kinds, timestamps, values, and physical order"
+        );
+        assert_eq!(
+            actual_bytes,
+            canonical_bytes(expected),
+            "{name}: canonical path contains exactly the complete expected bytes"
+        );
+        validate_canonical(path).unwrap_or_else(|error| {
+            panic!("{name}: observable canonical path must revalidate: {error}")
+        });
+    }
+
+    fn assert_full_sample_baseline_is_not_omitted_or_replaced_by_checkpoint(
+        records: &[Record],
+        cutoff: u64,
+        expected_value: f64,
+        name: &str,
+    ) {
+        let baseline = records
+            .iter()
+            .filter_map(|record| match record {
+                Record::Sample(sample) if sample.timestamp < cutoff => Some(sample),
+                Record::Boot(_) | Record::Checkpoint(_) | Record::Sample(_) => None,
+            })
+            .last()
+            .unwrap_or_else(|| panic!("{name}: pre-cutoff full-sample baseline is required"));
+        assert_eq!(
+            baseline.state,
+            state(expected_value),
+            "{name}: the latest strictly pre-cutoff full sample, not a checkpoint, is retained"
+        );
+    }
+
+    #[test]
+    fn compaction_selection_keeps_boot_full_baseline_and_retained_physical_order() {
+        // This table is intentionally physical: a selected checkpoint may
+        // follow a same-timestamp sample, but it can never replace the latest
+        // full sample that precedes the cutoff.
+        let cases = [
+            (
+                "boundary-equal-timestamp-and-multiple-epochs",
+                13,
+                30,
+                format!(
+                    "{}{}{}{}{}{}{}{}{}{}",
+                    boot(9, "boot-a"),
+                    sample(10, "boot-a", 1.0),
+                    checkpoint(11, "boot-a"),
+                    sample(12, "boot-a", 2.0),
+                    sample(13, "boot-a", 3.0),
+                    checkpoint(13, "boot-a"),
+                    sample(14, "boot-a", 4.0),
+                    boot(15, "boot-b"),
+                    sample(16, "boot-b", 5.0),
+                    checkpoint(16, "boot-b")
+                ),
+                format!(
+                    "{}{}{}{}{}{}{}{}",
+                    boot(9, "boot-a"),
+                    sample(12, "boot-a", 2.0),
+                    sample(13, "boot-a", 3.0),
+                    checkpoint(13, "boot-a"),
+                    sample(14, "boot-a", 4.0),
+                    boot(15, "boot-b"),
+                    sample(16, "boot-b", 5.0),
+                    checkpoint(16, "boot-b")
+                ),
+                2.0,
+            ),
+            (
+                "cutoff-owning-boot-and-latest-precutoff-sample",
+                40,
+                60,
+                format!(
+                    "{}{}{}{}{}{}",
+                    boot(30, "boot-c"),
+                    sample(31, "boot-c", 7.0),
+                    checkpoint(32, "boot-c"),
+                    sample(39, "boot-c", 8.0),
+                    sample(40, "boot-c", 9.0),
+                    sample(41, "boot-c", 10.0)
+                ),
+                format!(
+                    "{}{}{}{}",
+                    boot(30, "boot-c"),
+                    sample(39, "boot-c", 8.0),
+                    sample(40, "boot-c", 9.0),
+                    sample(41, "boot-c", 10.0)
+                ),
+                8.0,
+            ),
+        ];
+
+        for (name, cutoff, opened_at, source, retained, baseline_value) in cases {
+            let dir = test_dir(&format!("compaction-selection-{name}"));
+            let path = dir.join("history-v1.jsonl");
+            fs::write(&path, source).unwrap();
+            let mut store = HistoryStore::open(&dir, opened_at, capacity()).unwrap();
+            let live_boot = canonical_records(&fs::read(&path).unwrap())
+                .last()
+                .cloned()
+                .expect("open appends its fresh boot");
+            assert!(matches!(&live_boot, Record::Boot(boot) if boot.timestamp == opened_at));
+            store
+                .append_sample(opened_at + 1, capacity(), state(99.0))
+                .unwrap();
+            let before = fs::read(&path).unwrap();
+            let live_sample = canonical_records(&before)
+                .last()
+                .cloned()
+                .expect("fresh runtime boot receives a full sample before compaction");
+
+            assert!(matches!(
+                store.compact(cutoff).unwrap(),
+                CompactionOutcome::Durable
+            ));
+
+            let mut expected = records_from_fixture(&retained);
+            expected.push(live_boot);
+            expected.push(live_sample);
+            assert_complete_canonical_path(&path, &expected, name);
+            assert_full_sample_baseline_is_not_omitted_or_replaced_by_checkpoint(
+                &expected,
+                cutoff,
+                baseline_value,
+                name,
+            );
+            assert_ne!(
+                fs::read(&path).unwrap(),
+                before,
+                "{name}: old bytes are bounded away"
+            );
+            let _ = fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
+    fn compaction_recovery_safety_defers_intersecting_evidence_and_discards_only_outside_gaps() {
+        let cases: [(&str, u64, u64, String, bool, bool, Option<String>); 3] = [
+            (
+                "damage-intersects-retained-horizon",
+                13,
+                20,
+                format!(
+                    "{}{}{{not-json}}\n{}{}",
+                    boot(10, "boot-a"),
+                    sample(11, "boot-a", 1.0),
+                    boot(14, "boot-b"),
+                    sample(15, "boot-b", 2.0)
+                ),
+                false,
+                false,
+                None,
+            ),
+            (
+                "gap-ending-at-cutoff-is-outside-retained-horizon",
+                13,
+                20,
+                format!(
+                    "{}{}{{not-json}}\n{}{}",
+                    boot(10, "boot-a"),
+                    sample(11, "boot-a", 1.0),
+                    boot(13, "boot-b"),
+                    sample(14, "boot-b", 2.0)
+                ),
+                true,
+                true,
+                Some(format!(
+                    "{}{}",
+                    boot(13, "boot-b"),
+                    sample(14, "boot-b", 2.0)
+                )),
+            ),
+            (
+                "fresh-boot-without-full-sample",
+                13,
+                20,
+                format!("{}{}", boot(10, "boot-a"), sample(11, "boot-a", 1.0)),
+                false,
+                false,
+                None,
+            ),
+        ];
+
+        for (name, cutoff, opened_at, source, expect_durable, sample_fresh_boot, retained) in cases
+        {
+            let dir = test_dir(&format!("compaction-recovery-{name}"));
+            let path = dir.join("history-v1.jsonl");
+            fs::write(&path, source).unwrap();
+            let mut store = HistoryStore::open(&dir, opened_at, capacity()).unwrap();
+            let live_boot = canonical_records(&fs::read(&path).unwrap())
+                .last()
+                .cloned()
+                .expect("open appends its fresh boot");
+
+            if sample_fresh_boot {
+                store
+                    .append_sample(opened_at + 1, capacity(), state(9.0))
+                    .unwrap();
+            }
+            if name == "fresh-boot-without-full-sample" {
+                assert!(
+                    store.replay.gaps.iter().all(|gap| gap.to <= cutoff),
+                    "{name}: clean historical evidence has no recovery gap in the retained horizon"
+                );
+            }
+            let before = fs::read(&path).unwrap();
+            let live_sample = expect_durable.then(|| {
+                canonical_records(&before)
+                    .last()
+                    .cloned()
+                    .expect("durable compaction has a full sample for its fresh runtime boot")
+            });
+
+            let outcome = store.compact(cutoff).unwrap();
+            if !expect_durable {
+                assert!(matches!(outcome, CompactionOutcome::Deferred));
+                assert_eq!(
+                    fs::read(&path).unwrap(),
+                    before,
+                    "{name}: deferred compaction preserves incomplete evidence byte-for-byte"
+                );
+                validate_canonical(&path).unwrap();
+            } else {
+                assert!(matches!(outcome, CompactionOutcome::Durable));
+                let mut expected =
+                    records_from_fixture(&retained.expect("durable case retains rows"));
+                expected.push(live_boot);
+                expected.push(live_sample.expect("durable case has a live full sample"));
+                assert_complete_canonical_path(&path, &expected, name);
+                assert_ne!(
+                    fs::read(&path).unwrap(),
+                    before,
+                    "{name}: old gap bytes are removed"
+                );
+            }
+            let _ = fs::remove_dir_all(dir);
+        }
+    }
+
+    #[test]
+    fn compaction_crash_points_leave_only_old_or_complete_new_canonical_bytes() {
+        let source = format!(
+            "{}{}{}{}",
+            boot(10, "boot-a"),
+            sample(11, "boot-a", 1.0),
+            checkpoint(12, "boot-a"),
+            sample(13, "boot-a", 2.0)
+        );
+        let retained = format!(
+            "{}{}{}",
+            boot(10, "boot-a"),
+            sample(11, "boot-a", 1.0),
+            sample(13, "boot-a", 2.0)
+        );
+
+        for point in [
+            FailurePoint::CompactionTempCreate,
+            FailurePoint::CompactionTempWrite,
+            FailurePoint::CompactionTempSync,
+            FailurePoint::CompactionRename,
+        ] {
+            let dir = test_dir(&format!("compaction-crash-{point:?}"));
+            let path = dir.join("history-v1.jsonl");
+            fs::write(&path, &source).unwrap();
+            let mut store = HistoryStore::open(&dir, 20, capacity()).unwrap();
+            store.append_sample(21, capacity(), state(9.0)).unwrap();
+            let before = fs::read(&path).unwrap();
+
+            let injected = compact_with_test_failure(&mut store, 13, point);
+            assert!(
+                injected.result.is_err(),
+                "{point:?}: replacement must fail before commit"
+            );
+            assert_eq!(
+                injected.fired,
+                Some(point),
+                "{point:?}: the injected crash point must actually fire"
+            );
+            assert_eq!(
+                fs::read(&path).unwrap(),
+                before,
+                "{point:?}: canonical path remains the complete old bytes"
+            );
+            validate_canonical(&path).unwrap();
+            let _ = fs::remove_dir_all(dir);
+        }
+
+        let dir = test_dir("compaction-crash-directory-sync");
+        let path = dir.join("history-v1.jsonl");
+        fs::write(&path, source).unwrap();
+        let mut store = HistoryStore::open(&dir, 20, capacity()).unwrap();
+        let live_boot = canonical_records(&fs::read(&path).unwrap())
+            .last()
+            .cloned()
+            .expect("open appends its fresh boot");
+        store.append_sample(21, capacity(), state(9.0)).unwrap();
+        let before = fs::read(&path).unwrap();
+        let live_sample = canonical_records(&before)
+            .last()
+            .cloned()
+            .expect("fresh runtime boot receives a full sample before compaction");
+
+        let injected =
+            compact_with_test_failure(&mut store, 13, FailurePoint::CompactionDirectorySync);
+        assert!(matches!(
+            injected.result,
+            Ok(CompactionOutcome::CommittedSyncPending(_))
+        ));
+        assert_eq!(
+            injected.fired,
+            Some(FailurePoint::CompactionDirectorySync),
+            "directory-sync injection must fire after rename"
+        );
+        let mut expected = records_from_fixture(&retained);
+        expected.push(live_boot);
+        expected.push(live_sample);
+        assert_complete_canonical_path(&path, &expected, "directory-sync failure");
+        assert_ne!(
+            fs::read(&path).unwrap(),
+            before,
+            "directory sync follows committed rename"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn compaction_restart_rollup_and_subsequent_append_use_the_replacement_inode() {
+        let dir = test_dir("compaction-restart-replacement");
+        let path = dir.join("history-v1.jsonl");
+        fs::write(
+            &path,
+            format!(
+                "{}{}{}{}",
+                boot(10, "boot-a"),
+                sample(11, "boot-a", 1.0),
+                checkpoint(12, "boot-a"),
+                sample(13, "boot-a", 2.0)
+            ),
+        )
+        .unwrap();
+        let mut store = HistoryStore::open(&dir, 20, capacity()).unwrap();
+        store.append_sample(21, capacity(), state(9.0)).unwrap();
+        #[cfg(unix)]
+        let old_inode = {
+            use std::os::unix::fs::MetadataExt;
+            fs::metadata(&path).unwrap().ino()
+        };
+        let live_boot_id = store.boot_id().to_owned();
+
+        assert!(matches!(
+            store.compact(13).unwrap(),
+            CompactionOutcome::Durable
+        ));
+        #[cfg(unix)]
+        let replacement_inode = {
+            use std::os::unix::fs::MetadataExt;
+            let inode = fs::metadata(&path).unwrap().ino();
+            assert_ne!(
+                inode, old_inode,
+                "compaction atomically replaces the canonical inode"
+            );
+            inode
+        };
+        store.append_sample(22, capacity(), state(10.0)).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            assert_eq!(
+                fs::metadata(&path).unwrap().ino(),
+                replacement_inode,
+                "the post-compaction append remains on the replacement inode"
+            );
+        }
+        let records = canonical_records(&fs::read(&path).unwrap());
+        assert!(matches!(
+            records.last(),
+            Some(Record::Sample(sample))
+                if sample.timestamp == 22 && sample.boot_id == live_boot_id && sample.state == state(10.0)
+        ));
+        drop(store);
+
+        let reopened = HistoryStore::open(&dir, 23, capacity()).unwrap();
+        assert!(matches!(
+            canonical_records(&fs::read(&path).unwrap()).last(),
+            Some(Record::Boot(boot)) if boot.timestamp == 23
+        ));
+        drop(reopened);
+        let history = History::open(dir.clone(), 0, history_capacity()).unwrap();
+        assert_eq!(
+            history.rollup(12, 13, 1000).data.totals,
+            vec![metric_value("nimproxy_requests_total", 1.0)],
+            "the pre-window full-sample baseline still normalizes the compacted sample"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn compaction_serializes_an_append_requested_while_it_owns_the_store() {
+        let dir = test_dir("compaction-exclusive-writer");
+        let path = dir.join("history-v1.jsonl");
+        fs::write(
+            &path,
+            format!(
+                "{}{}{}{}",
+                boot(10, "boot-a"),
+                sample(11, "boot-a", 1.0),
+                checkpoint(12, "boot-a"),
+                sample(13, "boot-a", 2.0)
+            ),
+        )
+        .unwrap();
+        let mut store = HistoryStore::open(&dir, 20, capacity()).unwrap();
+        let live_boot_id = store.boot_id().to_owned();
+        store.append_sample(21, capacity(), state(7.0)).unwrap();
+        let shared = Arc::new(Mutex::new(store));
+        let (locked_tx, locked_rx) = mpsc::channel();
+        let (contention_tx, contention_rx) = mpsc::channel();
+        let (start_compaction_tx, start_compaction_rx) = mpsc::sync_channel(0);
+
+        std::thread::scope(|scope| {
+            let compacting = Arc::clone(&shared);
+            let compact = scope.spawn(move || {
+                let mut store = compacting.lock().unwrap();
+                locked_tx.send(()).unwrap();
+                start_compaction_rx.recv().unwrap();
+                store.compact(13)
+            });
+            locked_rx.recv().unwrap();
+
+            let appending = Arc::clone(&shared);
+            let append = scope.spawn(move || {
+                match appending.try_lock() {
+                    Err(TryLockError::WouldBlock) => {}
+                    Err(TryLockError::Poisoned(_)) => {
+                        panic!("the exclusive history writer must not poison the store mutex")
+                    }
+                    Ok(_) => panic!("append must contend while compaction owns the store"),
+                }
+                contention_tx.send(()).unwrap();
+                appending
+                    .lock()
+                    .unwrap()
+                    .append_sample(22, capacity(), state(9.0))
+            });
+            contention_rx.recv().unwrap();
+            start_compaction_tx.send(()).unwrap();
+
+            assert!(matches!(
+                compact.join().unwrap().unwrap(),
+                CompactionOutcome::Durable
+            ));
+            append.join().unwrap().unwrap();
+        });
+
+        let expected = vec![
+            records_from_fixture(&boot(10, "boot-a"))[0].clone(),
+            records_from_fixture(&sample(11, "boot-a", 1.0))[0].clone(),
+            records_from_fixture(&sample(13, "boot-a", 2.0))[0].clone(),
+            records_from_fixture(&boot(20, &live_boot_id))[0].clone(),
+            records_from_fixture(&sample(21, &live_boot_id, 7.0))[0].clone(),
+            records_from_fixture(&sample(22, &live_boot_id, 9.0))[0].clone(),
+        ];
+        assert_complete_canonical_path(&path, &expected, "serialized append");
+        assert_eq!(
+            canonical_records(&fs::read(&path).unwrap())
+                .iter()
+                .filter(|record| {
+                    matches!(record, Record::Sample(sample)
+                        if sample.timestamp == 22
+                            && sample.boot_id == live_boot_id
+                            && sample.state == state(9.0))
+                })
+                .count(),
+            1,
+            "the append requested during compaction appears exactly once after replacement"
+        );
         let _ = fs::remove_dir_all(dir);
     }
 }

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -22,6 +22,8 @@ pub struct HistoryStore {
     replay: Replay,
     last_timestamp: Option<u64>,
     poisoned: bool,
+    #[cfg(test)]
+    test_compaction_directory_sync_failure: bool,
 }
 
 #[derive(Debug, Default)]
@@ -113,6 +115,7 @@ pub enum WriteError {
 pub(crate) enum CompactionOutcome {
     Durable,
     Deferred,
+    Superseded,
     CommittedSyncPending(io::Error),
 }
 
@@ -170,6 +173,8 @@ impl HistoryStore {
                     replay,
                     last_timestamp,
                     poisoned: false,
+                    #[cfg(test)]
+                    test_compaction_directory_sync_failure: false,
                 })
             }
             Err(error) if error.kind() == io::ErrorKind::NotFound => {
@@ -189,6 +194,8 @@ impl HistoryStore {
                             },
                             last_timestamp,
                             poisoned: false,
+                            #[cfg(test)]
+                            test_compaction_directory_sync_failure: false,
                         })
                     }
                     Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
@@ -208,6 +215,8 @@ impl HistoryStore {
                             replay,
                             last_timestamp,
                             poisoned: false,
+                            #[cfg(test)]
+                            test_compaction_directory_sync_failure: false,
                         })
                     }
                     Err(error) => Err(error.into()),
@@ -263,10 +272,66 @@ impl HistoryStore {
         self.compact_inner(cutoff, None)
     }
 
+    pub(crate) fn compact_if_authorized<T>(
+        &mut self,
+        cutoff: u64,
+        authorize: impl FnOnce() -> Option<T>,
+    ) -> io::Result<CompactionOutcome> {
+        #[cfg(test)]
+        if std::mem::take(&mut self.test_compaction_directory_sync_failure) {
+            let mut failure = FailureSwitch {
+                point: FailurePoint::CompactionDirectorySync,
+                fired: None,
+            };
+            return self.compact_inner_if_authorized(cutoff, Some(&mut failure), authorize);
+        }
+        self.compact_inner_if_authorized(cutoff, None, authorize)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inject_test_compaction_directory_sync_failure(&mut self) {
+        self.test_compaction_directory_sync_failure = true;
+    }
+
+    pub(crate) fn compaction_needed(&self, cutoff: u64) -> bool {
+        if !self.replay.gaps.is_empty()
+            || self.replay.needs_separator
+            || self.replay.diagnostics.excluded_epochs != 0
+            || self.replay.diagnostics.excluded_records != 0
+        {
+            return true;
+        }
+        let (records, fresh_boot) = match self.replay.records.last() {
+            Some(Record::Boot(boot))
+                if boot.boot_id == self.boot_id && self.last_state.is_none() =>
+            {
+                (
+                    &self.replay.records[..self.replay.records.len() - 1],
+                    Some(boot.clone()),
+                )
+            }
+            Some(_) | None => (&self.replay.records[..], None),
+        };
+        let mut retained = retained_compaction_records(records, cutoff, &self.boot_id, false);
+        if let Some(boot) = fresh_boot {
+            retained.push(Record::Boot(boot));
+        }
+        retained != self.replay.records
+    }
+
     fn compact_inner(
         &mut self,
         cutoff: u64,
+        failure: Option<&mut FailureSwitch>,
+    ) -> io::Result<CompactionOutcome> {
+        self.compact_inner_if_authorized(cutoff, failure, || Some(()))
+    }
+
+    fn compact_inner_if_authorized<T>(
+        &mut self,
+        cutoff: u64,
         mut failure: Option<&mut FailureSwitch>,
+        authorize: impl FnOnce() -> Option<T>,
     ) -> io::Result<CompactionOutcome> {
         let replay = validate_canonical(&self.path).map_err(open_error_to_io)?;
         if replay.gaps.iter().any(|gap| gap.to > cutoff) || self.last_state.is_none() {
@@ -310,8 +375,14 @@ impl HistoryStore {
                 "compaction replacement does not exactly validate as retained canonical history",
             ));
         }
+        let Some(authorization) = authorize() else {
+            drop(output);
+            let _ = fs::remove_file(&temporary);
+            return Ok(CompactionOutcome::Superseded);
+        };
         fail(&mut failure, FailurePoint::CompactionRename)?;
         fs::rename(&temporary, &self.path)?;
+        drop(authorization);
 
         self.file = output;
         self.last_timestamp = replacement_replay.records.last().map(record_timestamp);

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -6,6 +6,7 @@
 
 mod support;
 
+use std::collections::BTreeMap;
 use std::os::unix::fs::PermissionsExt;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
@@ -1410,6 +1411,320 @@ async fn wait_for_persisted_chat_total(
         );
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum CanonicalFixtureKind {
+    Boot,
+    Sample,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum CanonicalFixtureStateKind {
+    Counter,
+}
+
+#[derive(serde::Serialize)]
+struct CanonicalFixtureCapacity {
+    capacity_rpm: usize,
+    enabled_keys: usize,
+    key_rpms: [usize; 3],
+}
+
+#[derive(serde::Serialize)]
+struct CanonicalFixtureState {
+    kind: CanonicalFixtureStateKind,
+    metric: &'static str,
+    labels: BTreeMap<String, String>,
+    value: f64,
+}
+
+#[derive(serde::Serialize)]
+struct CanonicalFixtureRow {
+    format: &'static str,
+    v: u8,
+    kind: CanonicalFixtureKind,
+    timestamp: u64,
+    boot_id: &'static str,
+    capacity: CanonicalFixtureCapacity,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state: Option<Vec<CanonicalFixtureState>>,
+}
+
+fn canonical_history_row(
+    kind: CanonicalFixtureKind,
+    timestamp: u64,
+    value: Option<f64>,
+) -> CanonicalFixtureRow {
+    let labels = [("client".to_owned(), "retention-seed".to_owned())]
+        .into_iter()
+        .collect();
+    CanonicalFixtureRow {
+        format: "nimproxy-history",
+        v: 1,
+        kind,
+        timestamp,
+        boot_id: "seed-boot",
+        capacity: CanonicalFixtureCapacity {
+            capacity_rpm: 120,
+            enabled_keys: 3,
+            key_rpms: [40, 40, 40],
+        },
+        state: value.map(|value| {
+            vec![CanonicalFixtureState {
+                kind: CanonicalFixtureStateKind::Counter,
+                metric: "nimproxy_seeded_requests_total",
+                labels,
+                value,
+            }]
+        }),
+    }
+}
+
+fn read_canonical_history(path: &std::path::Path) -> Vec<serde_json::Value> {
+    std::fs::read_to_string(path)
+        .expect("history-retention: canonical history remains readable")
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            let row: serde_json::Value = serde_json::from_str(line)
+                .expect("history-retention: canonical row remains valid JSON");
+            assert_eq!(row["format"], "nimproxy-history");
+            assert_eq!(row["v"], 1);
+            assert!(row["kind"].is_string());
+            assert!(row["timestamp"].is_u64());
+            assert!(row["boot_id"].is_string());
+            assert!(row["capacity"].is_object());
+            row
+        })
+        .collect()
+}
+
+fn idle_metric_snapshot(metrics: &str) -> Vec<&str> {
+    let mut rows: Vec<_> = metrics
+        .lines()
+        .filter(|line| {
+            line.starts_with("nimproxy_requests_total")
+                || line.starts_with("nimproxy_lane_requests_total")
+                || line.starts_with("nimproxy_queue_wait_seconds_count")
+                || line.starts_with("nimproxy_queue_wait_seconds_sum")
+        })
+        .collect();
+    rows.sort_unstable();
+    rows
+}
+
+async fn wait_for_idle_checkpoint(
+    canonical: &std::path::Path,
+    row_count: usize,
+    sample_count: usize,
+    checkpoint_count: usize,
+) -> Vec<serde_json::Value> {
+    let deadline = Instant::now() + Duration::from_secs(8);
+    loop {
+        let rows = read_canonical_history(canonical);
+        let samples = rows.iter().filter(|row| row["kind"] == "sample").count();
+        let checkpoints = rows
+            .iter()
+            .filter(|row| row["kind"] == "checkpoint")
+            .count();
+        if checkpoints > checkpoint_count {
+            assert_eq!(
+                samples, sample_count,
+                "history-retention:idle-samples: an idle interval added a full sample instead of a checkpoint"
+            );
+            assert_eq!(
+                checkpoints,
+                checkpoint_count + 1,
+                "history-retention:idle-checkpoints: idle cadence added more than one checkpoint"
+            );
+            assert_eq!(
+                rows.len(),
+                row_count + 1,
+                "history-retention:idle-rows: idle cadence added more than one canonical row"
+            );
+            return rows;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "history-retention:idle-checkpoint: sampler did not persist a checkpoint"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn exercise_history_retention_restarts() {
+    const HORIZON_DAYS: u64 = 30;
+    const HORIZON_SECONDS: u64 = HORIZON_DAYS * 86_400;
+
+    let mock = start_mock().await;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let cutoff = now.saturating_sub(HORIZON_SECONDS);
+    let seed_boot_timestamp = now.saturating_sub(HORIZON_SECONDS * 3);
+    let ancient_seed_sample_timestamp = now.saturating_sub(HORIZON_SECONDS * 3 - 1);
+    let data_dir = scratch_data_dir();
+    let mut config = StoreOpts::default().json(&mock.url);
+    config["history"] = serde_json::json!({"days": HORIZON_DAYS});
+    std::fs::write(
+        data_dir.join("config.json"),
+        serde_json::to_vec_pretty(&config).unwrap(),
+    )
+    .unwrap();
+
+    let seed = [
+        canonical_history_row(CanonicalFixtureKind::Boot, seed_boot_timestamp, None),
+        canonical_history_row(
+            CanonicalFixtureKind::Sample,
+            ancient_seed_sample_timestamp,
+            Some(1.0),
+        ),
+        canonical_history_row(
+            CanonicalFixtureKind::Sample,
+            cutoff.saturating_sub(1),
+            Some(2.0),
+        ),
+        canonical_history_row(
+            CanonicalFixtureKind::Sample,
+            cutoff.saturating_add(600),
+            Some(3.0),
+        ),
+    ];
+    let mut seed_bytes = Vec::new();
+    for row in seed {
+        let line = serde_json::to_vec(&row).unwrap();
+        seed_bytes.extend(line);
+        seed_bytes.push(b'\n');
+    }
+    // Readiness validates this raw seed with the private production codec;
+    // reopening the same directory validates every later replacement again.
+    let canonical = data_dir.join("history-v1.jsonl");
+    std::fs::write(&canonical, seed_bytes).unwrap();
+
+    let mut proxy = start_proxy_in(data_dir, &[("HISTORY_SAMPLE_SECS", "1")]).await;
+    let mut cookie = login(&proxy).await;
+    let initial = dashboard_range(&proxy, &cookie, cutoff, now.saturating_add(60), 1000).await;
+    send_successful_chats(&proxy, 1).await;
+    let _ = wait_for_persisted_chat_total(
+        &proxy,
+        &cookie,
+        initial["history_revision"].as_u64().unwrap(),
+        1.0,
+    )
+    .await;
+    let before_restart =
+        dashboard_range(&proxy, &cookie, cutoff, now.saturating_add(60), 1000).await;
+    let before_idle_metrics_text = metrics(&proxy).await;
+    let before_idle_metrics = idle_metric_snapshot(&before_idle_metrics_text);
+    let compaction_deadline = Instant::now() + Duration::from_secs(8);
+    loop {
+        let configured = api_config(&proxy, &cookie).await;
+        let compacted_rows = read_canonical_history(&canonical);
+        if configured["server"]["history"]["compaction_pending"] == false
+            && !compacted_rows
+                .iter()
+                .any(|row| row["timestamp"] == ancient_seed_sample_timestamp)
+        {
+            break;
+        }
+        assert!(
+            Instant::now() < compaction_deadline,
+            "history-retention:compaction-idle: canonical retention did not settle before idle cadence"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let before_idle_rows = read_canonical_history(&canonical);
+    let before_idle_samples = before_idle_rows
+        .iter()
+        .filter(|row| row["kind"] == "sample")
+        .count();
+    let before_idle_checkpoints = before_idle_rows
+        .iter()
+        .filter(|row| row["kind"] == "checkpoint")
+        .count();
+    let idle_rows = wait_for_idle_checkpoint(
+        &canonical,
+        before_idle_rows.len(),
+        before_idle_samples,
+        before_idle_checkpoints,
+    )
+    .await;
+    let after_idle_metrics_text = metrics(&proxy).await;
+    assert_eq!(
+        idle_metric_snapshot(&after_idle_metrics_text),
+        before_idle_metrics,
+        "history-retention:idle-metrics: requests and scheduling do not advance without traffic"
+    );
+
+    proxy = restart(proxy, &[("HISTORY_SAMPLE_SECS", "3600")]).await;
+    cookie = login(&proxy).await;
+    let after_restart =
+        dashboard_range(&proxy, &cookie, cutoff, now.saturating_add(60), 1000).await;
+    assert_eq!(
+        after_restart["totals"], before_restart["totals"],
+        "history-retention:restart-totals: retained counter totals survive restart"
+    );
+    assert_eq!(
+        after_restart["window"]["complete"], before_restart["window"]["complete"],
+        "history-retention:restart-complete: retained-window completeness survives restart"
+    );
+    assert_eq!(
+        after_restart["window"]["available_from"], before_restart["window"]["available_from"],
+        "history-retention:restart-bounds: retained-window lower bound survives restart"
+    );
+
+    let rows = read_canonical_history(&canonical);
+    assert!(
+        rows.windows(2).all(|pair| {
+            pair[0]["timestamp"].as_u64().unwrap() <= pair[1]["timestamp"].as_u64().unwrap()
+        }),
+        "history-retention:physical-order: canonical rows retain physical timestamp order"
+    );
+    assert!(
+        rows.iter()
+            .any(|row| row["timestamp"] == cutoff.saturating_sub(1)),
+        "history-retention:baseline: the preceding full-sample baseline is retained"
+    );
+    assert!(
+        rows.iter().any(|row| {
+            row["kind"] == "boot"
+                && row["boot_id"] == "seed-boot"
+                && row["timestamp"] == seed_boot_timestamp
+        }),
+        "history-retention:owning-boot: the baseline's owning boot is retained"
+    );
+    assert!(
+        rows.iter()
+            .any(|row| row["timestamp"] == cutoff.saturating_add(600)),
+        "history-retention:horizon: the configured retained horizon is present"
+    );
+    assert!(
+        rows.iter().any(|row| row["boot_id"] != "seed-boot"),
+        "history-retention:fresh-epoch: the fresh process epoch is retained"
+    );
+    assert!(
+        !rows
+            .iter()
+            .any(|row| row["timestamp"] == ancient_seed_sample_timestamp),
+        "history-retention:expired: rows older than the required baseline are removed"
+    );
+    assert!(
+        !proxy.data_dir.join("history.jsonl").exists(),
+        "history-retention:legacy: canonical retention does not create the legacy path"
+    );
+    assert!(
+        idle_rows.iter().any(|row| row["kind"] == "checkpoint"),
+        "history-retention:idle-checkpoint: idle cadence persists checkpoints"
+    );
+}
+
+#[tokio::test]
+async fn history_retention_survives_restart() {
+    exercise_history_retention_restarts().await;
 }
 
 #[tokio::test]

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -6,7 +6,7 @@
 
 mod support;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::os::unix::fs::PermissionsExt;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
@@ -1483,6 +1483,74 @@ fn canonical_history_row(
     }
 }
 
+struct RetentionFixture {
+    data_dir: std::path::PathBuf,
+    canonical: std::path::PathBuf,
+    now: u64,
+    cutoff: u64,
+    seed_boot_timestamp: u64,
+    ancient_seed_sample_timestamp: u64,
+}
+
+fn retention_fixture(upstream: &str) -> RetentionFixture {
+    const HORIZON_DAYS: u64 = 30;
+    const HORIZON_SECONDS: u64 = HORIZON_DAYS * 86_400;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let cutoff = now.saturating_sub(HORIZON_SECONDS);
+    let seed_boot_timestamp = now.saturating_sub(HORIZON_SECONDS * 3);
+    let ancient_seed_sample_timestamp = now.saturating_sub(HORIZON_SECONDS * 3 - 1);
+    let data_dir = scratch_data_dir();
+    let mut config = StoreOpts::default().json(upstream);
+    config["history"] = serde_json::json!({"days": HORIZON_DAYS});
+    std::fs::write(
+        data_dir.join("config.json"),
+        serde_json::to_vec_pretty(&config).unwrap(),
+    )
+    .unwrap();
+
+    let seed = [
+        canonical_history_row(CanonicalFixtureKind::Boot, seed_boot_timestamp, None),
+        canonical_history_row(
+            CanonicalFixtureKind::Sample,
+            ancient_seed_sample_timestamp,
+            Some(1.0),
+        ),
+        canonical_history_row(
+            CanonicalFixtureKind::Sample,
+            cutoff.saturating_sub(1),
+            Some(2.0),
+        ),
+        canonical_history_row(
+            CanonicalFixtureKind::Sample,
+            cutoff.saturating_add(600),
+            Some(3.0),
+        ),
+    ];
+    let mut seed_bytes = Vec::new();
+    for row in seed {
+        let line = serde_json::to_vec(&row).unwrap();
+        seed_bytes.extend(line);
+        seed_bytes.push(b'\n');
+    }
+    // Readiness validates this raw seed with the private production codec;
+    // reopening the same directory validates every later replacement again.
+    let canonical = data_dir.join("history-v1.jsonl");
+    std::fs::write(&canonical, seed_bytes).unwrap();
+
+    RetentionFixture {
+        data_dir,
+        canonical,
+        now,
+        cutoff,
+        seed_boot_timestamp,
+        ancient_seed_sample_timestamp,
+    }
+}
+
 fn read_canonical_history(path: &std::path::Path) -> Vec<serde_json::Value> {
     std::fs::read_to_string(path)
         .expect("history-retention: canonical history remains readable")
@@ -1555,59 +1623,81 @@ async fn wait_for_idle_checkpoint(
     }
 }
 
-async fn exercise_history_retention_restarts() {
-    const HORIZON_DAYS: u64 = 30;
-    const HORIZON_SECONDS: u64 = HORIZON_DAYS * 86_400;
-
-    let mock = start_mock().await;
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    let cutoff = now.saturating_sub(HORIZON_SECONDS);
-    let seed_boot_timestamp = now.saturating_sub(HORIZON_SECONDS * 3);
-    let ancient_seed_sample_timestamp = now.saturating_sub(HORIZON_SECONDS * 3 - 1);
-    let data_dir = scratch_data_dir();
-    let mut config = StoreOpts::default().json(&mock.url);
-    config["history"] = serde_json::json!({"days": HORIZON_DAYS});
-    std::fs::write(
-        data_dir.join("config.json"),
-        serde_json::to_vec_pretty(&config).unwrap(),
-    )
-    .unwrap();
-
-    let seed = [
-        canonical_history_row(CanonicalFixtureKind::Boot, seed_boot_timestamp, None),
-        canonical_history_row(
-            CanonicalFixtureKind::Sample,
-            ancient_seed_sample_timestamp,
-            Some(1.0),
-        ),
-        canonical_history_row(
-            CanonicalFixtureKind::Sample,
-            cutoff.saturating_sub(1),
-            Some(2.0),
-        ),
-        canonical_history_row(
-            CanonicalFixtureKind::Sample,
-            cutoff.saturating_add(600),
-            Some(3.0),
-        ),
-    ];
-    let mut seed_bytes = Vec::new();
-    for row in seed {
-        let line = serde_json::to_vec(&row).unwrap();
-        seed_bytes.extend(line);
-        seed_bytes.push(b'\n');
+async fn wait_for_retention_compaction(
+    proxy: &support::Proxy,
+    cookie: &str,
+    canonical: &std::path::Path,
+    ancient_seed_sample_timestamp: u64,
+) {
+    let deadline = Instant::now() + Duration::from_secs(8);
+    loop {
+        let configured = api_config(proxy, cookie).await;
+        let compacted_rows = read_canonical_history(canonical);
+        if configured["server"]["history"]["compaction_pending"] == false
+            && !compacted_rows
+                .iter()
+                .any(|row| row["timestamp"] == ancient_seed_sample_timestamp)
+        {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "history-retention:compaction-idle: canonical retention did not settle before idle cadence"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
     }
-    // Readiness validates this raw seed with the private production codec;
-    // reopening the same directory validates every later replacement again.
-    let canonical = data_dir.join("history-v1.jsonl");
-    std::fs::write(&canonical, seed_bytes).unwrap();
+}
 
-    let mut proxy = start_proxy_in(data_dir, &[("HISTORY_SAMPLE_SECS", "1")]).await;
+fn assert_retained_history_invariants(
+    rows: &[serde_json::Value],
+    proxy: &support::Proxy,
+    fixture: &RetentionFixture,
+) {
+    let has_timestamp = |timestamp| rows.iter().any(|row| row["timestamp"] == timestamp);
+    assert!(
+        rows.windows(2).all(|pair| {
+            pair[0]["timestamp"].as_u64().unwrap() <= pair[1]["timestamp"].as_u64().unwrap()
+        }),
+        "history-retention:physical-order: canonical rows retain physical timestamp order"
+    );
+    assert!(
+        has_timestamp(fixture.cutoff.saturating_sub(1)),
+        "history-retention:baseline: the preceding full-sample baseline is retained"
+    );
+    assert!(
+        rows.iter().any(|row| {
+            row["kind"] == "boot"
+                && row["boot_id"] == "seed-boot"
+                && row["timestamp"] == fixture.seed_boot_timestamp
+        }),
+        "history-retention:owning-boot: the baseline's owning boot is retained"
+    );
+    assert!(
+        has_timestamp(fixture.cutoff.saturating_add(600)),
+        "history-retention:horizon: the configured retained horizon is present"
+    );
+    assert!(
+        rows.iter().any(|row| row["boot_id"] != "seed-boot"),
+        "history-retention:fresh-epoch: a fresh process epoch is retained"
+    );
+    assert!(
+        !has_timestamp(fixture.ancient_seed_sample_timestamp),
+        "history-retention:expired: rows older than the required baseline are removed"
+    );
+    assert!(
+        !proxy.data_dir.join("history.jsonl").exists(),
+        "history-retention:legacy: canonical retention does not create the legacy path"
+    );
+}
+
+async fn exercise_history_retention_restarts() {
+    let mock = start_mock().await;
+    let fixture = retention_fixture(&mock.url);
+    let query_to = fixture.now.saturating_add(60);
+
+    let mut proxy = start_proxy_in(fixture.data_dir.clone(), &[("HISTORY_SAMPLE_SECS", "1")]).await;
     let mut cookie = login(&proxy).await;
-    let initial = dashboard_range(&proxy, &cookie, cutoff, now.saturating_add(60), 1000).await;
+    let initial = dashboard_range(&proxy, &cookie, fixture.cutoff, query_to, 1000).await;
     send_successful_chats(&proxy, 1).await;
     let _ = wait_for_persisted_chat_total(
         &proxy,
@@ -1616,28 +1706,17 @@ async fn exercise_history_retention_restarts() {
         1.0,
     )
     .await;
-    let before_restart =
-        dashboard_range(&proxy, &cookie, cutoff, now.saturating_add(60), 1000).await;
+    let before_restart = dashboard_range(&proxy, &cookie, fixture.cutoff, query_to, 1000).await;
     let before_idle_metrics_text = metrics(&proxy).await;
     let before_idle_metrics = idle_metric_snapshot(&before_idle_metrics_text);
-    let compaction_deadline = Instant::now() + Duration::from_secs(8);
-    loop {
-        let configured = api_config(&proxy, &cookie).await;
-        let compacted_rows = read_canonical_history(&canonical);
-        if configured["server"]["history"]["compaction_pending"] == false
-            && !compacted_rows
-                .iter()
-                .any(|row| row["timestamp"] == ancient_seed_sample_timestamp)
-        {
-            break;
-        }
-        assert!(
-            Instant::now() < compaction_deadline,
-            "history-retention:compaction-idle: canonical retention did not settle before idle cadence"
-        );
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-    let before_idle_rows = read_canonical_history(&canonical);
+    wait_for_retention_compaction(
+        &proxy,
+        &cookie,
+        &fixture.canonical,
+        fixture.ancient_seed_sample_timestamp,
+    )
+    .await;
+    let before_idle_rows = read_canonical_history(&fixture.canonical);
     let before_idle_samples = before_idle_rows
         .iter()
         .filter(|row| row["kind"] == "sample")
@@ -1647,7 +1726,7 @@ async fn exercise_history_retention_restarts() {
         .filter(|row| row["kind"] == "checkpoint")
         .count();
     let idle_rows = wait_for_idle_checkpoint(
-        &canonical,
+        &fixture.canonical,
         before_idle_rows.len(),
         before_idle_samples,
         before_idle_checkpoints,
@@ -1662,8 +1741,7 @@ async fn exercise_history_retention_restarts() {
 
     proxy = restart(proxy, &[("HISTORY_SAMPLE_SECS", "3600")]).await;
     cookie = login(&proxy).await;
-    let after_restart =
-        dashboard_range(&proxy, &cookie, cutoff, now.saturating_add(60), 1000).await;
+    let after_restart = dashboard_range(&proxy, &cookie, fixture.cutoff, query_to, 1000).await;
     assert_eq!(
         after_restart["totals"], before_restart["totals"],
         "history-retention:restart-totals: retained counter totals survive restart"
@@ -1677,45 +1755,8 @@ async fn exercise_history_retention_restarts() {
         "history-retention:restart-bounds: retained-window lower bound survives restart"
     );
 
-    let rows = read_canonical_history(&canonical);
-    assert!(
-        rows.windows(2).all(|pair| {
-            pair[0]["timestamp"].as_u64().unwrap() <= pair[1]["timestamp"].as_u64().unwrap()
-        }),
-        "history-retention:physical-order: canonical rows retain physical timestamp order"
-    );
-    assert!(
-        rows.iter()
-            .any(|row| row["timestamp"] == cutoff.saturating_sub(1)),
-        "history-retention:baseline: the preceding full-sample baseline is retained"
-    );
-    assert!(
-        rows.iter().any(|row| {
-            row["kind"] == "boot"
-                && row["boot_id"] == "seed-boot"
-                && row["timestamp"] == seed_boot_timestamp
-        }),
-        "history-retention:owning-boot: the baseline's owning boot is retained"
-    );
-    assert!(
-        rows.iter()
-            .any(|row| row["timestamp"] == cutoff.saturating_add(600)),
-        "history-retention:horizon: the configured retained horizon is present"
-    );
-    assert!(
-        rows.iter().any(|row| row["boot_id"] != "seed-boot"),
-        "history-retention:fresh-epoch: the fresh process epoch is retained"
-    );
-    assert!(
-        !rows
-            .iter()
-            .any(|row| row["timestamp"] == ancient_seed_sample_timestamp),
-        "history-retention:expired: rows older than the required baseline are removed"
-    );
-    assert!(
-        !proxy.data_dir.join("history.jsonl").exists(),
-        "history-retention:legacy: canonical retention does not create the legacy path"
-    );
+    let rows = read_canonical_history(&fixture.canonical);
+    assert_retained_history_invariants(&rows, &proxy, &fixture);
     assert!(
         idle_rows.iter().any(|row| row["kind"] == "checkpoint"),
         "history-retention:idle-checkpoint: idle cadence persists checkpoints"
@@ -1725,6 +1766,287 @@ async fn exercise_history_retention_restarts() {
 #[tokio::test]
 async fn history_retention_survives_restart() {
     exercise_history_retention_restarts().await;
+}
+
+/// Long-form release proof for bounded canonical retention. The seed spans
+/// more than two retention horizons without waiting for wall-clock history.
+#[tokio::test]
+#[ignore]
+async fn release_restart_and_idle_history() {
+    const RELEASE_CYCLES: u64 = 3;
+
+    let mock = start_mock().await;
+    let fixture = retention_fixture(&mock.url);
+    let query_to = fixture.now.saturating_add(60);
+    let mut proxy = start_proxy_in(fixture.data_dir.clone(), &[("HISTORY_SAMPLE_SECS", "1")]).await;
+    let mut cookie = login(&proxy).await;
+    let initial = dashboard_range(&proxy, &cookie, fixture.cutoff, query_to, 1000).await;
+    send_successful_chats(&proxy, 1).await;
+    let _ = wait_for_persisted_chat_total(
+        &proxy,
+        &cookie,
+        initial["history_revision"].as_u64().unwrap(),
+        1.0,
+    )
+    .await;
+    wait_for_retention_compaction(
+        &proxy,
+        &cookie,
+        &fixture.canonical,
+        fixture.ancient_seed_sample_timestamp,
+    )
+    .await;
+
+    let retained_before_restarts =
+        dashboard_range(&proxy, &cookie, fixture.cutoff, query_to, 1000).await;
+    let pre_idle_bytes = std::fs::metadata(&fixture.canonical)
+        .expect("release-restart-idle-history:pre-idle-bytes: canonical history remains present")
+        .len();
+    let mut checkpoint_byte_allowance = None;
+
+    for cycle in 0..RELEASE_CYCLES {
+        let before_rows = read_canonical_history(&fixture.canonical);
+        let before_samples = before_rows
+            .iter()
+            .filter(|row| row["kind"] == "sample")
+            .count();
+        let before_checkpoints = before_rows
+            .iter()
+            .filter(|row| row["kind"] == "checkpoint")
+            .count();
+        let before_bytes = std::fs::metadata(&fixture.canonical)
+            .expect("release-restart-idle-history:checkpoint-before-bytes: canonical history remains present")
+            .len();
+        let before_metrics_text = metrics(&proxy).await;
+        let before_metrics = idle_metric_snapshot(&before_metrics_text);
+        assert!(
+            [
+                "nimproxy_requests_total",
+                "nimproxy_lane_requests_total",
+                "nimproxy_queue_wait_seconds_count",
+                "nimproxy_queue_wait_seconds_sum",
+            ]
+            .iter()
+            .all(|metric| before_metrics.iter().any(|row| row.starts_with(metric))),
+            "release-restart-idle-history:idle-metric-rows: cycle {cycle} lacks a selected metric row"
+        );
+
+        let _ = wait_for_idle_checkpoint(
+            &fixture.canonical,
+            before_rows.len(),
+            before_samples,
+            before_checkpoints,
+        )
+        .await;
+        let after_bytes = std::fs::metadata(&fixture.canonical)
+            .expect("release-restart-idle-history:checkpoint-after-bytes: canonical history remains present")
+            .len();
+        let after_metrics_text = metrics(&proxy).await;
+        assert_eq!(
+            idle_metric_snapshot(&after_metrics_text),
+            before_metrics,
+            "release-restart-idle-history:idle-metrics: cycle {cycle} changed request or scheduling metrics without traffic"
+        );
+
+        let checkpoint_delta = after_bytes.checked_sub(before_bytes).expect(
+            "release-restart-idle-history:checkpoint-byte-delta: canonical bytes shrank during an idle checkpoint",
+        );
+        if cycle == 0 {
+            assert_eq!(
+                before_bytes, pre_idle_bytes,
+                "release-restart-idle-history:pre-idle-base: first idle cycle did not start at the recorded base"
+            );
+            assert!(
+                checkpoint_delta > 0,
+                "release-restart-idle-history:checkpoint-byte-allowance-positive: first checkpoint must establish a positive allowance"
+            );
+            checkpoint_byte_allowance = Some(checkpoint_delta);
+        } else {
+            assert!(
+                checkpoint_delta
+                    <= checkpoint_byte_allowance.expect(
+                        "release-restart-idle-history:checkpoint-byte-allowance: first cycle did not establish an allowance",
+                    ),
+                "release-restart-idle-history:checkpoint-byte-allowance: cycle {cycle} exceeded the first checkpoint allowance"
+            );
+        }
+    }
+
+    let post_idle_bytes = std::fs::metadata(&fixture.canonical)
+        .expect("release-restart-idle-history:post-idle-bytes: canonical history remains present")
+        .len();
+    let mut restart_byte_allowance = None;
+    let mut restart_boot_ids = BTreeSet::new();
+    let kind_counts = |rows: &[serde_json::Value]| {
+        ["boot", "sample", "checkpoint"]
+            .map(|kind| rows.iter().filter(|row| row["kind"] == kind).count())
+    };
+
+    for cycle in 0..RELEASE_CYCLES {
+        let before_rows = read_canonical_history(&fixture.canonical);
+        let before_file_bytes = std::fs::read(&fixture.canonical).expect(
+            "release-restart-idle-history:restart-before-bytes: canonical history remains readable",
+        );
+        let before_bytes = u64::try_from(before_file_bytes.len()).expect(
+            "release-restart-idle-history:restart-before-byte-length: canonical byte length exceeds u64",
+        );
+        if cycle == 0 {
+            assert_eq!(
+                before_bytes, post_idle_bytes,
+                "release-restart-idle-history:post-idle-base: first restart did not start at the post-idle byte snapshot"
+            );
+        }
+        let before_boot_ids: BTreeSet<_> = before_rows
+            .iter()
+            .filter(|row| row["kind"] == "boot")
+            .map(|row| {
+                row["boot_id"]
+                    .as_str()
+                    .expect("release-restart-idle-history:restart-boot-id: boot id is a string")
+                    .to_owned()
+            })
+            .collect();
+        let before_kind_counts = kind_counts(&before_rows);
+
+        proxy = restart(proxy, &[("HISTORY_SAMPLE_SECS", "3600")]).await;
+        let after_rows = read_canonical_history(&fixture.canonical);
+        let after_file_bytes = std::fs::read(&fixture.canonical).expect(
+            "release-restart-idle-history:restart-after-bytes: canonical history remains readable",
+        );
+        let after_bytes = u64::try_from(after_file_bytes.len()).expect(
+            "release-restart-idle-history:restart-after-byte-length: canonical byte length exceeds u64",
+        );
+        assert!(
+            after_file_bytes.starts_with(&before_file_bytes),
+            "release-restart-idle-history:restart-byte-prefix: cycle {cycle} changed pre-restart canonical bytes"
+        );
+        let expected_row_count = before_rows
+            .len()
+            .checked_add(2)
+            .expect("release-restart-idle-history:restart-row-kind-counts: row count overflowed");
+        assert_eq!(
+            after_rows.len(), expected_row_count,
+            "release-restart-idle-history:restart-row-kind-counts: cycle {cycle} did not append exactly two rows"
+        );
+        assert_eq!(
+            &after_rows[..before_rows.len()],
+            before_rows.as_slice(),
+            "release-restart-idle-history:restart-prefix: cycle {cycle} changed pre-restart canonical rows"
+        );
+        let tail = &after_rows[before_rows.len()..];
+        assert_eq!(
+            tail.iter()
+                .map(|row| row["kind"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            ["boot", "sample"],
+            "release-restart-idle-history:restart-row-kinds: cycle {cycle} tail is not boot then sample"
+        );
+        assert_eq!(
+            kind_counts(&after_rows),
+            [
+                before_kind_counts[0]
+                    .checked_add(1)
+                    .expect("release-restart-idle-history:restart-row-kind-counts: boot count overflowed"),
+                before_kind_counts[1]
+                    .checked_add(1)
+                    .expect("release-restart-idle-history:restart-row-kind-counts: sample count overflowed"),
+                before_kind_counts[2],
+            ],
+            "release-restart-idle-history:restart-row-kind-counts: cycle {cycle} did not add exactly one boot, one sample, and zero checkpoints"
+        );
+
+        let boot_id = tail[0]["boot_id"]
+            .as_str()
+            .expect("release-restart-idle-history:restart-boot-id: boot id is a string");
+        assert_eq!(
+            tail[1]["boot_id"], boot_id,
+            "release-restart-idle-history:restart-boot-id: cycle {cycle} boot and sample ids differ"
+        );
+        assert!(
+            !before_boot_ids.contains(boot_id),
+            "release-restart-idle-history:restart-boot-id: cycle {cycle} reused a pre-restart boot id"
+        );
+        assert!(
+            restart_boot_ids.insert(boot_id.to_owned()),
+            "release-restart-idle-history:restart-boot-id: cycle {cycle} reused a release restart boot id"
+        );
+
+        let restart_delta = after_bytes.checked_sub(before_bytes).expect(
+            "release-restart-idle-history:restart-byte-delta: canonical bytes shrank during restart",
+        );
+        if cycle == 0 {
+            assert!(
+                restart_delta > 0,
+                "release-restart-idle-history:restart-byte-allowance-positive: first restart must establish a positive allowance"
+            );
+            restart_byte_allowance = Some(restart_delta);
+        } else {
+            assert!(
+                restart_delta
+                    <= restart_byte_allowance.expect(
+                        "release-restart-idle-history:restart-byte-allowance: first restart did not establish an allowance",
+                    ),
+                "release-restart-idle-history:restart-byte-allowance: cycle {cycle} exceeded the first restart allowance"
+            );
+        }
+
+        cookie = login(&proxy).await;
+        let configured = api_config(&proxy, &cookie).await;
+        assert_eq!(
+            configured["server"]["history"]["compaction_pending"], false,
+            "release-restart-idle-history:restart-compaction: cycle {cycle} left unclassified compaction work"
+        );
+        let after_restart = dashboard_range(&proxy, &cookie, fixture.cutoff, query_to, 1000).await;
+        assert_eq!(
+            after_restart["totals"], retained_before_restarts["totals"],
+            "release-restart-idle-history:restart-totals: cycle {cycle} changed retained totals"
+        );
+        assert_eq!(
+            after_restart["window"]["complete"],
+            retained_before_restarts["window"]["complete"],
+            "release-restart-idle-history:restart-complete: cycle {cycle} changed retained completeness"
+        );
+        assert_eq!(
+            after_restart["window"]["available_from"],
+            retained_before_restarts["window"]["available_from"],
+            "release-restart-idle-history:restart-bounds: cycle {cycle} changed retained lower bound"
+        );
+    }
+
+    assert_eq!(
+        restart_boot_ids.len(),
+        usize::try_from(RELEASE_CYCLES)
+            .expect("release-restart-idle-history:restart-epoch-count: cycle count fits usize"),
+        "release-restart-idle-history:restart-epoch-count: every restart produced a unique boot id"
+    );
+    let checkpoint_byte_allowance = checkpoint_byte_allowance.expect(
+        "release-restart-idle-history:checkpoint-byte-allowance: first checkpoint did not establish an allowance",
+    );
+    let restart_byte_allowance = restart_byte_allowance.expect(
+        "release-restart-idle-history:restart-byte-allowance: first restart did not establish an allowance",
+    );
+    let final_byte_bound = pre_idle_bytes
+        .checked_add(
+            checkpoint_byte_allowance
+                .checked_mul(RELEASE_CYCLES)
+                .expect("release-restart-idle-history:final-byte-bound: checkpoint multiplication overflowed"),
+        )
+        .and_then(|bound| {
+            restart_byte_allowance
+                .checked_mul(RELEASE_CYCLES)
+                .and_then(|restart_bytes| bound.checked_add(restart_bytes))
+        })
+        .expect("release-restart-idle-history:final-byte-bound: allowance arithmetic overflowed");
+    let final_bytes = std::fs::metadata(&fixture.canonical)
+        .expect("release-restart-idle-history:final-bytes: canonical history remains present")
+        .len();
+    assert!(
+        final_bytes <= final_byte_bound,
+        "release-restart-idle-history:final-byte-bound: final canonical bytes {final_bytes} exceed independent bound {final_byte_bound}"
+    );
+
+    let rows = read_canonical_history(&fixture.canonical);
+    assert_retained_history_invariants(&rows, &proxy, &fixture);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #102

## Outcome

Bounds canonical `history-v1.jsonl` by the configured retention horizon while preserving the owning boot, the strict pre-cutoff full-sample baseline, and exact retained physical order. Compaction is serialized behind the canonical writer and publishes with a synced same-directory temporary, atomic rename, replacement append handle, and directory sync.

The change also adds bounded release-load measurement, fast and ignored restart/idle proofs, and updates the governing plan, knowledge, runbooks, and public canonical path.

## Constraint

Intersecting recovery gaps defer replacement; legacy `history.jsonl`, proxy response bytes, metric names and values, request pacing, and the rate-limiter hot path remain untouched.

## Ponytail rung

4 — native filesystem temporary-file, rename, file-sync, and directory-sync primitives; existing history writer and test harnesses are reused.

## Proof

- `python3 scripts/loadtest.py --selftest` — 23 passed
- `cargo test history::store::tests --lib` — 32 passed
- fast restart E2E — 1 passed in 2.12s
- ignored release restart/idle E2E — 1 passed in 4.34s
- `cargo test history` — 83 history tests plus 12 related E2E passed, 1 ignored
- `cargo test` — 179 unit, 110 E2E, and 7 OpenAPI passed; 1 explicit release test ignored
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- independent full-range review — approved after repairing one README path contradiction

## Measured fixture evidence

The deterministic two-horizon fixture settled at 6,469 bytes, established 195-byte checkpoint and 391-byte restart allowances, and finished exactly at its 8,227-byte bound. These figures validate the fixed fixture, not arbitrary workload cardinality.