### PR TITLE
feat: validate NIM usage observations

### DIFF
--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -4327,6 +4327,33 @@ mock, and the existing observation hook.
   reasoning is a side-band defect.  The named proofs must fail at assertions;
   no production observer/proxy behavior is implemented in this checkpoint.
 
+- 2026-08-01 GREEN candidate — **Outcome:** one private bounded observer now
+  replaces both `SseScan` and buffered ad-hoc extraction; it finalizes typed
+  usage, finish, and tool observations without changing relay bytes. **Proof:**
+  the frozen observation controls and exact proxy-byte E2E pass; full-gate
+  evidence is recorded in the Task 15 report pending independent review.
+  **Constraint:** no Task 16 availability counter/API/UI, request mutation,
+  status/content-type, retry, scheduling, or rate-limit change. **Ponytail
+  Rung:** 2/5 — one `serde_json` value walk over the bounded buffered body and
+  one current SSE event, reusing existing recorders. Normal in-process and
+  Python mocks now use reasoning values bounded by completion; the dedicated
+  E2E invalid-reasoning response remains intentionally invalid.
+
+- 2026-08-01 scope delta (manager-authorized knowledge lint) — **Outcome:**
+  keep the governing metrics decision consistent with the typed observer.
+  **Proof:** `rg -n 'SseScan|line-reassembling observer' knowledge docs/plans`
+  plus guide/link validation. **Constraint:** update current concept prose
+  only, never historical log or plan evidence. **Ponytail Rung:** 2/5 — reuse
+  the existing decision page.
+
+- 2026-08-01 GREEN review fix 1/5 — **Outcome:** an over-bound SSE event stays
+  wholly unobservable through its LF or CRLF blank-line delimiter; the next
+  event remains observable. **Proof:** the dedicated regression failed RED on
+  leaked `Measured(5)` prompt, then passed GREEN; all 13 observer controls,
+  format, and diff checks pass. **Constraint:** only observer state and this
+  proof record changed; relay bytes and the 1,048,576-byte bound remain fixed.
+  **Ponytail Rung:** 6 — two existing-parser discard-line flags, no new path.
+
 **Files:**
 
 - Create: `src/observation.rs`
@@ -4416,21 +4443,21 @@ impl SseObserver {
   `Disconnected` and `Truncated` discard numeric observations and finalize
   every field as `Unavailable`; they never produce estimates or partial usage.
 
-- [ ] **Step 1: Write the fixture conformance table**
+- [x] **Step 1: Write the fixture conformance table**
 
 For each sanitized fixture assert every `UsageField` result and value plus
 exact downstream bytes. Add synthetic boundary cases for zero, max `u64`,
 overflow, negative, fractional, string/null/object, duplicate usage events,
 conflicting usage events, multi-line SSE, CRLF, split boundaries at every byte,
-comments, disconnect, and truncated final event. Assert exactly five
-availability increments per completed/failed proxied response, never per SSE
-event. The same table asserts per-choice finish outcomes and a tool-call
+comments, disconnect, and truncated final event. Assert exactly five final
+typed field outcomes per proxied response, produced once at `finish`, never
+per SSE event. The same table asserts per-choice finish outcomes and a tool-call
 observation: buffered arrays sum actual calls, streamed repeated fragments
 collapse by `(choice_index, tool_call_index)`, malformed indexes/arrays are
 invalid, missing choices are unavailable, and valid no-tool choices measure
 zero.
 
-- [ ] **Step 2: Observe the red proof**
+- [x] **Step 2: Observe the red proof**
 
 ```sh
 cargo test observation::tests --lib -- --nocapture
@@ -4440,27 +4467,27 @@ cargo test --test e2e observation_preserves_upstream_bytes -- --exact
 Expected: typed observation and event assembly are absent or current
 assumptions disagree with one or more real-shape fixtures.
 
-- [ ] **Step 3: Implement buffered observation**
+- [x] **Step 3: Implement buffered observation**
 
 Parse only the bounded response body already buffered for relay. Walk known
 usage fields without deserializing the complete provider payload into a
 provider-specific response struct. Never rewrite the original buffer.
 
-- [ ] **Step 4: Implement bounded SSE event observation**
+- [x] **Step 4: Implement bounded SSE event observation**
 
 Feed the observer the same chunks being relayed. Assemble standard SSE events,
 join their `data:` lines for observation, and discard observed event data
 immediately after classification. Treat provider-specific nonstandard forms as
 unavailable/invalid based on fixture evidence; do not change emitted framing.
 
-- [ ] **Step 5: Preserve the proxy contract**
+- [x] **Step 5: Preserve the proxy contract**
 
 Assert successful buffered status/body, current Content-Type relay,
 locally-framed streaming 200 behavior, request mutation rules, retry behavior,
 disconnect handling, and rate-limit scheduling are unchanged. Observation
 failure is never a proxy-response failure.
 
-- [ ] **Step 6: Run proof**
+- [x] **Step 6: Run proof**
 
 ```sh
 cargo test observation::tests --lib
@@ -4474,13 +4501,25 @@ cargo fmt --check
 git diff --check
 ```
 
-- [ ] **Step 7: Ingest and review before commit**
+2026-08-01 GREEN candidate proof: the focused observer control passed 13/13;
+the exact-byte and disconnect E2E controls passed 1/1 each; the streaming and
+proxy scopes passed 6/6 and 7/7.  The complete suite passed 187 unit tests,
+111 E2E tests with one intentional ignore, and 7 OpenAPI tests.  Clippy,
+format, diff, mock-Python compilation, and the agent-guide/link check passed.
+
+- [x] **Step 7: Ingest and review before commit**
 
 Create the observations Component page with evidence coverage, field
 classification, approved derivations, privacy/memory bounds, and transport
 noninterference. Review all byte-equality cases and every `Estimated` branch.
 
-- [ ] **Step 8: Commit**
+The Component page, index, streaming/decision/test-strategy links, and newest
+chronology entry are in the GREEN candidate. Independent full review found one
+Critical oversized-SSE discard-boundary defect; the reviewed first fix keeps
+the discard through the blank-line delimiter, and scoped re-review found no
+new Critical or Important finding. The controller's post-fix full gate passed.
+
+- [x] **Step 8: Commit**
 
 ```sh
 git add src/observation.rs src/proxy.rs src/lib.rs \

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -4285,6 +4285,48 @@ git commit -m "test: establish sanitized NIM wire evidence"
 
 **GitHub issue title:** `v0.6.6: validate NIM usage observations from wire evidence`
 
+#### Execution record
+
+**Outcome:** a private typed observation core will classify the fixed sanitized
+NIM response shapes without changing proxy bytes. **Proof:** literal fixture
+conformance plus exact upstream/downstream E2E bytes. **Constraint:** this RED
+checkpoint adds no Task 16 availability metric and makes no proxy behavior
+change. **Ponytail Rung:** 2/5 — reuse `serde_json`, the existing in-process
+mock, and the existing observation hook.
+
+- 2026-08-01 scope delta (manager preflight, binding): Task 15 finalizes five
+  typed usage outcomes exactly once at `finish`, never availability counters;
+  Task 16 owns `nimproxy_usage_observations_total`.  The interface is private
+  (`pub(crate)` only where the proxy needs it), with no wire/public API
+  expansion, and replaces rather than duplicates `SseScan`.  Root usage paths
+  are `prompt_tokens`, `completion_tokens`, and `total_tokens`; cache and
+  reasoning are the documented nested detail paths.  Missing/null `usage` is
+  absent, non-object `usage` invalidates all five, each present scalar accepts
+  only `0..=u64::MAX`, duplicate equal values collapse, and conflicts or a
+  valid/invalid mixture invalidate only that field before the locked
+  relationship matrix.  SSE observation assembles LF/CRLF `data:` lines across
+  arbitrary boundaries, keeps at most 1 MiB of one current event, joins
+  multi-line data with LF only for observation, and keeps relayed bytes
+  untouched.  The only estimate is a completed, valid nonterminal-event count
+  when measured completion is absent; disconnect/truncation discards numeric
+  and tool observations.  Finish/tool rules use valid indexed choices,
+  deterministic choice order, known bounded finish values, buffered array
+  sums, and unique streamed `(choice_index, tool_call_index)` pairs.  Literal
+  fixture oracle: each fixture has measured prompt/completion/total `1/2/3`,
+  unavailable cache/reasoning, and measured tool count `0/1`; basic has stop
+  (with prior null progress in SSE), tools has tool_calls.  The corrected
+  manifest lists both streamed fixtures for `usage_only_final_sse_event`.
+  The in-process mock and `scripts/mock_nim.py` reasoning values are known
+  invalid (`3 > 2`, respectively `12 > completion`) and are added only to the
+  later GREEN scope so valid-reasoning coverage remains meaningful; this RED
+  checkpoint does not change either mock.
+
+- 2026-08-01 RED Plan → Act → Verify: add only this clarification, a private
+  compiling observer test scaffold, literal fixture/synthetic conformance
+  controls, and an exact-byte E2E that proves the old acceptance of invalid
+  reasoning is a side-band defect.  The named proofs must fail at assertions;
+  no production observer/proxy behavior is implemented in this checkpoint.
+
 **Files:**
 
 - Create: `src/observation.rs`

--- a/knowledge/architecture/nim-observations.md
+++ b/knowledge/architecture/nim-observations.md
@@ -1,0 +1,54 @@
+---
+type: Component
+title: NIM response observations
+description: Private bounded typed observations of buffered and SSE NIM responses without proxy relay interference.
+tags: [nim, observations, sse, metrics, privacy]
+timestamp: 2026-08-01T00:00:00Z
+---
+
+# NIM response observations
+
+`src/observation.rs` classifies only response metadata needed by the existing
+metrics: five usage fields, per-choice finish results, and tool-call counts.
+It is a private crate component. It neither changes response bytes nor exposes
+an API, metric, or dashboard availability field; Task 16 owns observation
+quality telemetry.
+
+## Field and completion rules
+
+The observer accepts only JSON integers in `0..=u64::MAX`. Missing or null
+`usage` is unavailable; present malformed values are invalid. Repeated equal
+values collapse, while conflicts and valid/invalid mixtures invalidate just
+that field. Total is invalid on checked prompt-plus-completion overflow or when
+smaller than their measured sum. Cached/reasoning require measured bounded
+prompt/completion parents. Unrelated measured siblings survive an invalid
+relationship.
+
+Only completed streams without measured completion can estimate completion.
+The estimate is the count of parsed events with a nonempty valid indexed
+`choices` array and no non-null terminal reason. Zero count is unavailable.
+Malformed JSON/UTF-8, `[DONE]`, comments, errors, usage-only/empty-choice,
+terminal, invalid-terminal, disconnected, and truncated input do not estimate.
+
+Buffered choices sum `message.tool_calls` arrays. Streamed choices deduplicate
+`(choice_index, tool_call_index)` fragments. Known finish strings map to the
+bounded enum; unknown strings are `Other`. Malformed choice/tool shapes are
+invalid, and valid but terminal-less choices are unavailable.
+
+## Transport and privacy boundary
+
+Buffered observation reads the body after it is already available for relay.
+SSE observation receives the same chunks only after they are read for relay;
+it stores at most 1 MiB across its current unfinished line/event, joins
+standard multi-line `data:` values with LF for parsing only, and drops event
+data immediately after classification. Over-bound, malformed, and invalid
+UTF-8 events are unobservable. No prompt, completion text, model identity, or
+raw event body is retained after classification.
+
+The proxy records only finalized measured prompt/reasoning/tool/finish values
+and measured or estimated completion using its existing metric names and
+labels. Invalid/unavailable values are omitted. Total and cached have no
+existing metric. See the [streaming pipeline](streaming-pipeline.md),
+[usage injection decision](../decisions/usage-injection-auto-fallback.md),
+[capture runbook](../ops/nim-response-capture.md), and
+[test strategy](../testing/test-strategy.md).

--- a/knowledge/architecture/streaming-pipeline.md
+++ b/knowledge/architecture/streaming-pipeline.md
@@ -1,8 +1,8 @@
 ---
 type: Component
 title: Streaming pipeline (src/proxy.rs)
-description: SSE commitment, heartbeats, retry/failover, absolute deadlines, idle cutoff, and token scanning.
-tags: [streaming, sse, retries, deadlines, metrics]
+description: SSE commitment, heartbeats, retry/failover, deadlines, idle cutoff, and bounded side-band observations.
+tags: [streaming, sse, retries, deadlines, metrics, observations]
 timestamp: 2026-07-16T00:00:00Z
 ---
 
@@ -29,21 +29,23 @@ For a `stream: true` chat request:
    workflow (reqwest work + model/queue ownership), records status `deadline`,
    and best-effort sends a terminal `deadline_exceeded` SSE error. See the
    [deadline decision](../decisions/explicit-request-deadline.md).
-6. **Pipe with watchdog**: chunks forward verbatim while `SseScan` (a
-   line-reassembling observer) counts data events and extracts the `usage`
-   object. Each upstream read races two exits in a `select!`: the
+6. **Pipe with watchdog**: chunks forward verbatim while the private
+   [`SseObserver`](nim-observations.md) assembles only one bounded current SSE
+   event for side-band classification. Each upstream read races two exits in a `select!`: the
    `stream_idle` timeout cuts stalled upstreams with an in-stream error
    (status label `stall`), and `tx.closed()` notices a client hang-up
    immediately — freeing the request's `max_inflight` slot at disconnect
    time rather than at the stall cutoff (with `stream_idle` 0 there is no
    cutoff, so this is what prevents hung upstreams from pinning slots until
    restart).
-7. **Account**: TTFT histogram at first chunk; tokens/sec and prompt/
-   completion counters at end (`source="usage"` exact, `"estimate"` =
-   one-per-event fallback); one access-log line per request.
+7. **Account**: TTFT histogram at first chunk; finalized measured prompt,
+   measured/estimated completion (`source="usage"`/`"estimate"`), bounded
+   finish, reasoning, and tool counters at end; one access-log line per
+   request. Invalid/unavailable upstream observation values emit no existing
+   numeric/quality metric.
 
-Non-streaming requests use the same wait/retry loop minus heartbeats and
-harvest `usage` from the buffered JSON. An explicit deadline races the whole
+Non-streaming requests use the same wait/retry loop minus heartbeats and pass
+the already-buffered JSON body to the same observation rules. An explicit deadline races the whole
 buffered future, which is also how the proxy bounds upstream work after an
 otherwise-unobservable buffered client disconnect. `/v1/models` GETs
 short-circuit to a TTL cache with single-flight refresh.

--- a/knowledge/decisions/request-shape-metrics.md
+++ b/knowledge/decisions/request-shape-metrics.md
@@ -52,9 +52,11 @@ Option 3. New metrics, split by the label that makes them useful:
 - **Global enum** — `nimproxy_tool_choice_total` `{mode}`.
 
 Request shape is read from the already-parsed body at `Ctx` construction, so no
-second deserialize. `SseScan` was broadened to parse only the events that carry
-`usage`, a concrete `finish_reason`, or `tool_calls` (plain content deltas are
-still skipped). `finish_reason` and `tool_choice` are clamped to known enums.
+second deserialize. Response quality uses the private typed
+[NIM observations](../architecture/nim-observations.md) component for both
+buffered JSON and bounded SSE frames, then records only validated final
+observations. Finish labels remain bounded to known values plus `other`;
+invalid or unavailable numeric observations are omitted from existing metrics.
 
 ## Consequences
 
@@ -64,9 +66,10 @@ still skipped). `finish_reason` and `tool_choice` are clamped to known enums.
   Clients view that fingerprints each agent's tool intensity, conversation
   depth, and sampling.
 - Cardinality stays bounded by construction: no client-controlled free-text
-  reaches a label; params live in histogram buckets; enums are clamped. Verified
-  by unit tests (`finish_label`, `tool_choice_mode`, `SseScan`) and an e2e that
-  asserts the `stream` label is only ever `true`/`false`.
+  reaches a label; params live in histogram buckets; enums are clamped. The
+  typed observer controls and exact-byte proxy E2E cover bounded response
+  classification; request-shape tests continue to assert that `stream` is only
+  ever `true`/`false`.
 - Privacy posture is explicit and documented: **counts and sizes, never
   message content.** Nothing that could carry prompt text is recorded.
 - Shape is labeled by *client*, not *model* — the harness determines tool use

--- a/knowledge/decisions/usage-injection-auto-fallback.md
+++ b/knowledge/decisions/usage-injection-auto-fallback.md
@@ -38,7 +38,9 @@ existing `stream_options`.
 ## Consequences
 
 - Exact token counts (`source="usage"`) become the norm; estimates remain
-  only for models that genuinely reject the field.
+  only for completed streams with no measured completion and valid countable
+  nonterminal SSE events. Invalid, incomplete, error, and unobservable events
+  do not become estimates; see [NIM observations](../architecture/nim-observations.md).
 - One extra upstream request the first time a rejecting model is seen, per
   process lifetime.
 - Covered e2e: injection presence, 400-fallback-and-remember, and the kill

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -64,7 +64,8 @@ page describes a conclusion, a plan describes the live state.
 | [key-pool](architecture/key-pool.md) | Per-key sliding-window lanes; least-loaded selection; cooldown on upstream backoff |
 | [dispatcher](architecture/dispatcher.md) | Global FIFO slot queue; abandoned-waiter slot return; affinity accounting |
 | [governor](architecture/governor.md) | Per-model concurrency gate; classifies worker exhaustion apart from 429s and backs off the model, adaptively |
-| [streaming-pipeline](architecture/streaming-pipeline.md) | Heartbeats, retry/failover, absolute deadlines, idle timeout, SSE usage scanning |
+| [streaming-pipeline](architecture/streaming-pipeline.md) | Heartbeats, retry/failover, absolute deadlines, idle timeout, and bounded SSE observation |
+| [nim-observations](architecture/nim-observations.md) | Private typed response observations validated from sanitized wire evidence without relay interference |
 | [metrics-history](architecture/metrics-history.md) | Prometheus registry + recoverable canonical JSONL, query-scoped completeness, exact rollups, and atomic retention |
 | [dashboard](architecture/dashboard.md) | Split embedded operator console; one honest complete/partial/unavailable window across 5 tabs plus clearly scoped Now values |
 | [presentation-layer](architecture/presentation-layer.md) | Compile-time public/operator pages and assets with strict same-origin CSP, explicit gates, and served-byte browser proof |

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,21 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-08-01] component — bounded typed NIM response observations
+
+Task 15 replaces the separate buffered shortcuts and `SseScan` with one private
+typed observer. It classifies five usage outcomes, finish results, and tool
+counts from the already-buffered body or one bounded current SSE event without
+altering relayed bytes. Valid completed nonterminal events are the sole
+completion-estimate source; malformed, incomplete, invalid, and unavailable
+observations do not invent existing metrics. The ordinary in-process and load
+mock reasoning values now satisfy the same `reasoning <= completion` rule used
+in production, while the dedicated E2E keeps its invalid response to prove
+omission. See [NIM observations](architecture/nim-observations.md), the
+[streaming pipeline](architecture/streaming-pipeline.md), the
+[test strategy](testing/test-strategy.md), and the
+[Task 15 plan](../docs/plans/v0.6.6-foundation-implementation.md).
+
 ## [2026-08-01] research finding — bounded NIM response topology
 
 One authorized four-request run through local nim-proxy produced successful

--- a/knowledge/testing/test-strategy.md
+++ b/knowledge/testing/test-strategy.md
@@ -156,7 +156,12 @@ that proof.
 - **Pacing, pool, dispatch, and affinity:** use the enforcing mock and load
   harness; one upstream violation is failure. Follow the setup prerequisites
   in the [load section](#3-load--scriptsloadtestpy-vs-scriptsmock_nimpy---enforce).
-- **NIM response evidence:** `python3 scripts/capture_nim.py --selftest`
+- **NIM response evidence:** `cargo test observation::tests --lib` exercises
+  literal sanitized buffered/SSE fixtures plus field, relationship, framing,
+  bounded-memory, truncation, finish, tool, and estimator boundaries. `cargo
+  test --test e2e observation_preserves_upstream_bytes -- --exact` proves the
+  real proxy preserves fixture body/status/content-type behavior while invalid
+  reasoning is omitted from existing metrics. `python3 scripts/capture_nim.py --selftest`
   exercises environment/URL/profile policy, exact request caps, HTTP/1.0 and
   TLS lifecycles, secret-free diagnostics, owner-only descriptor-contained
   publication, and failure cleanup without a service. `python3
@@ -204,7 +209,7 @@ repository-local guide link.
 ## 1. Unit — `cargo test` (in `src/`)
 
 Pool semantics (window spread, least-loaded, sticky/spill flags, penalize,
-release), dispatcher ordering and deadline fail-fast, SSE scanning, history
+release), dispatcher ordering and deadline fail-fast, bounded SSE observation, history
 retention/downsampling. Fast, deterministic, no I/O.
 
 ## 2. End-to-end — `tests/e2e.rs` + `tests/support/mod.rs`
@@ -332,7 +337,7 @@ rebuilds.
 libFuzzer/cargo-fuzz harnesses over the three surfaces that parse bytes we
 don't control, asserting *never panics* plus each surface's invariant:
 `sse_scan` (upstream SSE arrives arbitrarily fragmented — fed whole and
-re-fragmented, asserting the 1 MiB pathological-line guard), `sanitize_label`
+re-fragmented through the bounded private observer), `sanitize_label`
 (the metric-injection defense: output is non-empty, ≤64 chars, safe charset),
 and `config_roundtrip` (operator-edited `config.json`: parse never panics,
 serialize→parse→serialize is a fixpoint). `fuzz.yml` smoke-fuzzes each target

--- a/scripts/mock_nim.py
+++ b/scripts/mock_nim.py
@@ -130,7 +130,7 @@ class Handler(BaseHTTPRequestHandler):
         truncated = emitted < 4
         finish = "length" if truncated else ("tool_calls" if offers_tools else "stop")
         usage = {"prompt_tokens": 120, "completion_tokens": emitted,
-                 "completion_tokens_details": {"reasoning_tokens": 12}}
+                 "completion_tokens_details": {"reasoning_tokens": min(2, emitted)}}
 
         if req.get("stream"):
             self.send_response(200)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@ mod config;
 mod dispatch;
 mod governor;
 mod history;
+// RED checkpoint: Task 15's private interface is deliberately not wired into
+// the proxy until its behavior exists, so the production build has no caller.
+#[allow(dead_code)]
+mod observation;
 mod pool;
 mod presentation;
 mod proxy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,6 @@ mod config;
 mod dispatch;
 mod governor;
 mod history;
-// RED checkpoint: Task 15's private interface is deliberately not wired into
-// the proxy until its behavior exists, so the production build has no caller.
-#[allow(dead_code)]
 mod observation;
 mod pool;
 mod presentation;

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -1,7 +1,6 @@
 //! Private, side-band NIM response observations.
 //!
-//! This RED scaffold deliberately returns unavailable outcomes.  The tests in
-//! this module describe the evidence-backed behavior that replaces it.
+//! The observer has no effect on response framing or relay bytes.
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum Observation {
@@ -40,7 +39,7 @@ pub(crate) enum FinishResult {
     Invalid,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum FinishReason {
     ContentFilter,
     FunctionCall,
@@ -57,39 +56,472 @@ pub(crate) enum StreamOutcome {
     Truncated,
 }
 
+use std::collections::{BTreeMap, BTreeSet};
+
+const MAX_EVENT_BYTES: usize = 1_048_576;
+
+#[derive(Clone, Copy, Default)]
+enum SeenNumber {
+    #[default]
+    Absent,
+    Invalid,
+    Value(u64),
+}
+
+impl SeenNumber {
+    fn observe(&mut self, value: Option<&serde_json::Value>) {
+        let Some(value) = value else { return };
+        let next = value.as_u64().map_or(Self::Invalid, Self::Value);
+        *self = match (*self, next) {
+            (Self::Absent, value) => value,
+            (Self::Value(a), Self::Value(b)) if a == b => Self::Value(a),
+            _ => Self::Invalid,
+        };
+    }
+
+    fn invalidate(&mut self) {
+        *self = Self::Invalid;
+    }
+
+    fn result(self) -> Observation {
+        match self {
+            Self::Absent => Observation::Unavailable,
+            Self::Invalid => Observation::Invalid,
+            Self::Value(value) => Observation::Measured(value),
+        }
+    }
+}
+
 #[derive(Default)]
-pub(crate) struct SseObserver;
+struct UsageState {
+    cached: SeenNumber,
+    completion: SeenNumber,
+    prompt: SeenNumber,
+    reasoning: SeenNumber,
+    total: SeenNumber,
+}
+
+impl UsageState {
+    fn observe(&mut self, usage: Option<&serde_json::Value>) {
+        let Some(usage) = usage else { return };
+        if usage.is_null() {
+            return;
+        }
+        let Some(usage) = usage.as_object() else {
+            self.cached.invalidate();
+            self.completion.invalidate();
+            self.prompt.invalidate();
+            self.reasoning.invalidate();
+            self.total.invalidate();
+            return;
+        };
+        self.prompt.observe(usage.get("prompt_tokens"));
+        self.completion.observe(usage.get("completion_tokens"));
+        self.total.observe(usage.get("total_tokens"));
+        match usage.get("prompt_tokens_details") {
+            None => {}
+            Some(serde_json::Value::Object(details)) => {
+                self.cached.observe(details.get("cached_tokens"));
+            }
+            Some(_) => self.cached.invalidate(),
+        }
+        match usage.get("completion_tokens_details") {
+            None => {}
+            Some(serde_json::Value::Object(details)) => {
+                self.reasoning.observe(details.get("reasoning_tokens"));
+            }
+            Some(_) => self.reasoning.invalidate(),
+        }
+    }
+
+    fn finish(self, estimate: Option<u64>) -> UsageObservations {
+        let prompt = self.prompt.result();
+        let mut completion = self.completion.result();
+        let mut total = self.total.result();
+        let mut cached = self.cached.result();
+        let mut reasoning = self.reasoning.result();
+
+        if let (Observation::Measured(prompt_value), Observation::Measured(completion_value)) =
+            (&prompt, &completion)
+        {
+            match prompt_value.checked_add(*completion_value) {
+                None => total = Observation::Invalid,
+                Some(sum) if matches!(total, Observation::Measured(value) if value < sum) => {
+                    total = Observation::Invalid;
+                }
+                Some(_) => {}
+            }
+        }
+        if let Observation::Measured(value) = cached {
+            if !matches!(prompt, Observation::Measured(parent) if value <= parent) {
+                cached = Observation::Invalid;
+            }
+        }
+        if let Observation::Measured(value) = reasoning {
+            if !matches!(completion, Observation::Measured(parent) if value <= parent) {
+                reasoning = Observation::Invalid;
+            }
+        }
+        if matches!(completion, Observation::Unavailable) {
+            if let Some(count) = estimate.filter(|count| *count > 0) {
+                completion = Observation::Estimated(count);
+            }
+        }
+        UsageObservations {
+            cached_tokens: cached,
+            completion_tokens: completion,
+            prompt_tokens: prompt,
+            reasoning_tokens: reasoning,
+            total_tokens: total,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+enum SeenFinish {
+    #[default]
+    Absent,
+    Invalid,
+    Value(FinishReason),
+}
+
+impl SeenFinish {
+    fn observe(&mut self, value: Option<&serde_json::Value>) {
+        let Some(value) = value else { return };
+        if value.is_null() {
+            return;
+        }
+        let next = match value.as_str() {
+            Some("content_filter") => Self::Value(FinishReason::ContentFilter),
+            Some("function_call") => Self::Value(FinishReason::FunctionCall),
+            Some("length") => Self::Value(FinishReason::Length),
+            Some("stop") => Self::Value(FinishReason::Stop),
+            Some("tool_calls") => Self::Value(FinishReason::ToolCalls),
+            Some(_) => Self::Value(FinishReason::Other),
+            None => Self::Invalid,
+        };
+        *self = match (*self, next) {
+            (Self::Absent, value) => value,
+            (Self::Value(a), Self::Value(b)) if a == b => Self::Value(a),
+            _ => Self::Invalid,
+        };
+    }
+
+    fn result(self, incomplete: bool) -> FinishResult {
+        if incomplete {
+            return FinishResult::Unavailable;
+        }
+        match self {
+            Self::Absent => FinishResult::Unavailable,
+            Self::Invalid => FinishResult::Invalid,
+            Self::Value(reason) => FinishResult::Measured(reason),
+        }
+    }
+}
+
+#[derive(Default)]
+struct ObservationState {
+    finishes: BTreeMap<u64, SeenFinish>,
+    buffered_tool_calls: u64,
+    observed_stream: bool,
+    tools_invalid: bool,
+    tools_present: bool,
+    tool_pairs: BTreeSet<(u64, u64)>,
+    usage: UsageState,
+}
+
+impl ObservationState {
+    fn observe_buffered(&mut self, value: &serde_json::Value) {
+        self.usage.observe(value.get("usage"));
+        let Some(choices) = value.get("choices") else {
+            return;
+        };
+        let Some(choices) = choices.as_array() else {
+            self.tools_invalid = true;
+            return;
+        };
+        self.tools_present = true;
+        let mut calls = 0u64;
+        for choice in choices {
+            let Some(choice) = choice.as_object() else {
+                self.tools_invalid = true;
+                continue;
+            };
+            let Some(index) = choice.get("index").and_then(serde_json::Value::as_u64) else {
+                self.tools_invalid = true;
+                continue;
+            };
+            self.finishes
+                .entry(index)
+                .or_default()
+                .observe(choice.get("finish_reason"));
+            match choice.get("message") {
+                None => {}
+                Some(serde_json::Value::Object(message)) => match message.get("tool_calls") {
+                    None => {}
+                    Some(serde_json::Value::Array(tool_calls)) => {
+                        let Some(next) = calls.checked_add(tool_calls.len() as u64) else {
+                            self.tools_invalid = true;
+                            continue;
+                        };
+                        calls = next;
+                    }
+                    Some(_) => self.tools_invalid = true,
+                },
+                Some(_) => self.tools_invalid = true,
+            }
+        }
+        self.buffered_tool_calls = calls;
+    }
+
+    fn observe_stream(&mut self, value: &serde_json::Value) -> bool {
+        self.observed_stream = true;
+        self.usage.observe(value.get("usage"));
+        let Some(choices) = value.get("choices") else {
+            return false;
+        };
+        let Some(choices) = choices.as_array() else {
+            self.tools_invalid = true;
+            return false;
+        };
+        self.tools_present = true;
+        let mut countable = !choices.is_empty();
+        for choice in choices {
+            let Some(choice) = choice.as_object() else {
+                self.tools_invalid = true;
+                countable = false;
+                continue;
+            };
+            let Some(index) = choice.get("index").and_then(serde_json::Value::as_u64) else {
+                self.tools_invalid = true;
+                countable = false;
+                continue;
+            };
+            let finish = choice.get("finish_reason");
+            self.finishes.entry(index).or_default().observe(finish);
+            if !finish.is_none_or(serde_json::Value::is_null) {
+                countable = false;
+            }
+            match choice.get("delta") {
+                None => {}
+                Some(serde_json::Value::Object(delta)) => match delta.get("tool_calls") {
+                    None => {}
+                    Some(serde_json::Value::Array(tool_calls)) => {
+                        for tool_call in tool_calls {
+                            let Some(tool_call) = tool_call.as_object() else {
+                                self.tools_invalid = true;
+                                continue;
+                            };
+                            let Some(tool_index) =
+                                tool_call.get("index").and_then(serde_json::Value::as_u64)
+                            else {
+                                self.tools_invalid = true;
+                                continue;
+                            };
+                            self.tool_pairs.insert((index, tool_index));
+                        }
+                    }
+                    Some(_) => self.tools_invalid = true,
+                },
+                Some(_) => self.tools_invalid = true,
+            }
+        }
+        countable
+    }
+
+    fn remember_choice_indexes(&mut self, value: &serde_json::Value) {
+        let Some(choices) = value.get("choices").and_then(serde_json::Value::as_array) else {
+            return;
+        };
+        for choice in choices {
+            if let Some(index) = choice
+                .as_object()
+                .and_then(|choice| choice.get("index"))
+                .and_then(serde_json::Value::as_u64)
+            {
+                self.finishes.entry(index).or_default();
+            }
+        }
+    }
+
+    fn finish(self, incomplete: bool, estimate: Option<u64>) -> ResponseObservations {
+        let usage = if incomplete {
+            unavailable_usage()
+        } else {
+            self.usage.finish(estimate)
+        };
+        let tool_calls = if incomplete {
+            Observation::Unavailable
+        } else if self.tools_invalid {
+            Observation::Invalid
+        } else if !self.tools_present {
+            Observation::Unavailable
+        } else if self.observed_stream {
+            Observation::Measured(self.tool_pairs.len() as u64)
+        } else {
+            Observation::Measured(self.buffered_tool_calls)
+        };
+        ResponseObservations {
+            finish_reasons: self
+                .finishes
+                .into_iter()
+                .map(|(choice_index, result)| FinishObservation {
+                    choice_index,
+                    result: result.result(incomplete),
+                })
+                .collect(),
+            tool_calls,
+            usage,
+        }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct SseObserver {
+    state: ObservationState,
+    current_data: Vec<u8>,
+    current_line: Vec<u8>,
+    discarded_event: bool,
+    discarded_line_has_content: bool,
+    discarded_line_ends_cr: bool,
+    completion_events: u64,
+}
 
 impl SseObserver {
-    pub(crate) fn push(&mut self, _bytes: &[u8]) {}
+    pub(crate) fn push(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            if byte == b'\n' {
+                self.finish_line();
+                continue;
+            }
+            if self.discarded_event {
+                if byte == b'\r' {
+                    if self.discarded_line_ends_cr {
+                        self.discarded_line_has_content = true;
+                    }
+                    self.discarded_line_ends_cr = true;
+                } else {
+                    self.discarded_line_has_content = true;
+                    self.discarded_line_ends_cr = false;
+                }
+                continue;
+            }
+            if self.retained_len() == MAX_EVENT_BYTES {
+                self.current_data.clear();
+                self.current_line.clear();
+                self.discarded_event = true;
+                self.discarded_line_has_content = true;
+                self.discarded_line_ends_cr = false;
+                continue;
+            }
+            self.current_line.push(byte);
+        }
+    }
 
-    pub(crate) fn finish(self, _outcome: StreamOutcome) -> ResponseObservations {
-        unavailable()
+    fn finish_line(&mut self) {
+        if self.discarded_event {
+            self.current_line.clear();
+            if !self.discarded_line_has_content {
+                self.discarded_event = false;
+            }
+            self.discarded_line_has_content = false;
+            self.discarded_line_ends_cr = false;
+            return;
+        }
+        if self.current_line.last() == Some(&b'\r') {
+            self.current_line.pop();
+        }
+        if self.current_line.is_empty() {
+            self.classify_event();
+            return;
+        }
+        if let Some(data) = self.current_line.strip_prefix(b"data:") {
+            let data = data.strip_prefix(b" ").unwrap_or(data);
+            let separator = usize::from(!self.current_data.is_empty());
+            if data.len().saturating_add(separator)
+                > MAX_EVENT_BYTES.saturating_sub(self.current_data.len())
+            {
+                self.current_data.clear();
+                self.current_line.clear();
+                self.discarded_event = true;
+                self.discarded_line_has_content = true;
+                self.discarded_line_ends_cr = false;
+                return;
+            }
+            if separator == 1 {
+                self.current_data.push(b'\n');
+            }
+            self.current_data.extend_from_slice(data);
+        }
+        self.current_line.clear();
+    }
+
+    fn classify_event(&mut self) {
+        if self.current_data != b"[DONE]" {
+            if let Ok(data) = std::str::from_utf8(&self.current_data) {
+                if let Ok(value) = serde_json::from_str::<serde_json::Value>(data) {
+                    if self.state.observe_stream(&value) {
+                        self.completion_events = self.completion_events.saturating_add(1);
+                    }
+                }
+            }
+        }
+        self.current_data.clear();
+        self.current_line.clear();
+    }
+
+    fn retained_len(&self) -> usize {
+        self.current_data.len() + self.current_line.len()
+    }
+
+    fn remember_unterminated_indexes(&mut self) {
+        if let Ok(data) = std::str::from_utf8(&self.current_data) {
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(data) {
+                self.state.remember_choice_indexes(&value);
+            }
+        }
+        if let Some(data) = self.current_line.strip_prefix(b"data:") {
+            let data = data.strip_prefix(b" ").unwrap_or(data);
+            if let Ok(data) = std::str::from_utf8(data) {
+                if let Ok(value) = serde_json::from_str::<serde_json::Value>(data) {
+                    self.state.remember_choice_indexes(&value);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn finish(mut self, outcome: StreamOutcome) -> ResponseObservations {
+        let unterminated =
+            self.discarded_event || !self.current_data.is_empty() || !self.current_line.is_empty();
+        if outcome == StreamOutcome::Completed && unterminated {
+            self.remember_unterminated_indexes();
+        }
+        let incomplete = outcome != StreamOutcome::Completed || unterminated;
+        self.state
+            .finish(incomplete, (!incomplete).then_some(self.completion_events))
     }
 
     #[cfg(test)]
     fn retained_event_bytes(&self) -> usize {
-        // Deliberately fails the RED bound assertion. GREEN must derive this
-        // directly from the actual current-event storage.
-        usize::MAX
+        self.current_data.len() + self.current_line.len()
     }
 }
 
-pub(crate) fn observe_buffered(_body: &[u8]) -> ResponseObservations {
-    unavailable()
+pub(crate) fn observe_buffered(body: &[u8]) -> ResponseObservations {
+    let mut state = ObservationState::default();
+    if let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) {
+        state.observe_buffered(&value);
+    }
+    state.finish(false, None)
 }
 
-fn unavailable() -> ResponseObservations {
-    ResponseObservations {
-        finish_reasons: Vec::new(),
-        tool_calls: Observation::Unavailable,
-        usage: UsageObservations {
-            cached_tokens: Observation::Unavailable,
-            completion_tokens: Observation::Unavailable,
-            prompt_tokens: Observation::Unavailable,
-            reasoning_tokens: Observation::Unavailable,
-            total_tokens: Observation::Unavailable,
-        },
+fn unavailable_usage() -> UsageObservations {
+    UsageObservations {
+        cached_tokens: Observation::Unavailable,
+        completion_tokens: Observation::Unavailable,
+        prompt_tokens: Observation::Unavailable,
+        reasoning_tokens: Observation::Unavailable,
+        total_tokens: Observation::Unavailable,
     }
 }
 
@@ -697,5 +1129,37 @@ mod tests {
             Observation::Estimated(1),
             "invalid UTF-8 event must be unobservable and non-countable"
         );
+    }
+
+    #[test]
+    fn over_bound_event_stays_unobservable_through_its_blank_line_delimiter() {
+        // Mutation caught: leaving discard mode at the first physical newline
+        // lets a later data line in the same over-bound event fabricate usage,
+        // finish, or tool observations.
+        for line_end in [b"\n".as_slice(), b"\r\n".as_slice()] {
+            let mut bytes = b"data: ".to_vec();
+            bytes.extend(std::iter::repeat_n(b'x', 1_048_577));
+            bytes.extend_from_slice(line_end);
+            bytes.extend_from_slice(b"data: {\"choices\":[{\"index\":7,\"delta\":{\"tool_calls\":[{\"index\":0}]},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":9}}");
+            bytes.extend_from_slice(line_end);
+            bytes.extend_from_slice(line_end);
+            bytes.extend_from_slice(b"data: {\"choices\":[{\"index\":0,\"delta\":{}}]}");
+            bytes.extend_from_slice(line_end);
+            bytes.extend_from_slice(line_end);
+
+            let mut observer = SseObserver::default();
+            observer.push(&bytes);
+            let actual = observer.finish(StreamOutcome::Completed);
+            assert_eq!(actual.usage.prompt_tokens, Observation::Unavailable);
+            assert_eq!(actual.usage.completion_tokens, Observation::Estimated(1));
+            assert_eq!(actual.tool_calls, Observation::Measured(0));
+            assert_eq!(
+                actual.finish_reasons,
+                vec![FinishObservation {
+                    choice_index: 0,
+                    result: FinishResult::Unavailable,
+                }]
+            );
+        }
     }
 }

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -66,6 +66,13 @@ impl SseObserver {
     pub(crate) fn finish(self, _outcome: StreamOutcome) -> ResponseObservations {
         unavailable()
     }
+
+    #[cfg(test)]
+    fn retained_event_bytes(&self) -> usize {
+        // Deliberately fails the RED bound assertion. GREEN must derive this
+        // directly from the actual current-event storage.
+        usize::MAX
+    }
 }
 
 pub(crate) fn observe_buffered(_body: &[u8]) -> ResponseObservations {
@@ -269,6 +276,60 @@ mod tests {
     }
 
     #[test]
+    fn relationship_matrix_invalidates_only_dependent_usage_fields() {
+        // Mutation caught: accepting unchecked totals or discarding healthy
+        // siblings after one sum/parent relationship is invalid.
+        let actual = observe_buffered(b"{\"usage\":{\"prompt_tokens\":18446744073709551615,\"completion_tokens\":1,\"total_tokens\":18446744073709551615}}");
+        assert_eq!(actual.usage.prompt_tokens, Observation::Measured(u64::MAX));
+        assert_eq!(actual.usage.completion_tokens, Observation::Measured(1));
+        assert_eq!(actual.usage.total_tokens, Observation::Invalid);
+        assert_eq!(actual.usage.cached_tokens, Observation::Unavailable);
+        assert_eq!(actual.usage.reasoning_tokens, Observation::Unavailable);
+
+        let actual = observe_buffered(
+            b"{\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2,\"total_tokens\":2}}",
+        );
+        assert_eq!(actual.usage.prompt_tokens, Observation::Measured(1));
+        assert_eq!(actual.usage.completion_tokens, Observation::Measured(2));
+        assert_eq!(actual.usage.total_tokens, Observation::Invalid);
+
+        let actual = observe_buffered(
+            b"{\"usage\":{\"completion_tokens\":2,\"prompt_tokens_details\":{\"cached_tokens\":1}}}",
+        );
+        assert_eq!(actual.usage.prompt_tokens, Observation::Unavailable);
+        assert_eq!(actual.usage.completion_tokens, Observation::Measured(2));
+        assert_eq!(actual.usage.cached_tokens, Observation::Invalid);
+
+        let actual = observe_buffered(
+            b"{\"usage\":{\"prompt_tokens\":\"1\",\"completion_tokens\":2,\"prompt_tokens_details\":{\"cached_tokens\":1}}}",
+        );
+        assert_eq!(actual.usage.prompt_tokens, Observation::Invalid);
+        assert_eq!(actual.usage.completion_tokens, Observation::Measured(2));
+        assert_eq!(actual.usage.cached_tokens, Observation::Invalid);
+
+        let actual = observe_buffered(
+            b"{\"usage\":{\"prompt_tokens\":1,\"completion_tokens_details\":{\"reasoning_tokens\":1}}}",
+        );
+        assert_eq!(actual.usage.prompt_tokens, Observation::Measured(1));
+        assert_eq!(actual.usage.completion_tokens, Observation::Unavailable);
+        assert_eq!(actual.usage.reasoning_tokens, Observation::Invalid);
+
+        let actual = observe_buffered(
+            b"{\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":\"2\",\"completion_tokens_details\":{\"reasoning_tokens\":1}}}",
+        );
+        assert_eq!(actual.usage.prompt_tokens, Observation::Measured(1));
+        assert_eq!(actual.usage.completion_tokens, Observation::Invalid);
+        assert_eq!(actual.usage.reasoning_tokens, Observation::Invalid);
+
+        let mut observer = SseObserver::default();
+        observer.push(b"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2,\"completion_tokens_details\":{\"reasoning_tokens\":1}}}\n\ndata: {\"choices\":[],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":3}}\n\n");
+        let actual = observer.finish(StreamOutcome::Completed);
+        assert_eq!(actual.usage.prompt_tokens, Observation::Measured(1));
+        assert_eq!(actual.usage.completion_tokens, Observation::Invalid);
+        assert_eq!(actual.usage.reasoning_tokens, Observation::Invalid);
+    }
+
+    #[test]
     fn choice_and_tool_observations_reject_old_first_choice_and_max_index_rules() {
         // Mutation caught: first-choice-only finish extraction and max-index
         // tool counting lose valid choices, accept malformed shapes, and count
@@ -296,6 +357,27 @@ mod tests {
         let actual = observe_buffered(b"{\"choices\":{}}");
         assert_eq!(actual.tool_calls, Observation::Invalid);
 
+        let actual = observe_buffered(b"{\"choices\":[{\"index\":0,\"message\":{\"tool_calls\":[{},{}]}},{\"index\":1,\"message\":{\"tool_calls\":[{},{},{}]}}]}");
+        assert_eq!(actual.tool_calls, Observation::Measured(5));
+
+        let actual = observe_buffered(b"{\"choices\":[7]}");
+        assert_eq!(actual.tool_calls, Observation::Invalid);
+        assert!(actual.finish_reasons.is_empty());
+
+        for body in [
+            b"{\"choices\":[{\"message\":{}}]}".as_slice(),
+            b"{\"choices\":[{\"index\":-1,\"message\":{}}]}".as_slice(),
+            b"{\"choices\":[{\"index\":1.5,\"message\":{}}]}".as_slice(),
+            b"{\"choices\":[{\"index\":18446744073709551616,\"message\":{}}]}".as_slice(),
+        ] {
+            let actual = observe_buffered(body);
+            assert_eq!(actual.tool_calls, Observation::Invalid);
+            assert!(
+                actual.finish_reasons.is_empty(),
+                "unrepresentable choice index must not fabricate a finish observation"
+            );
+        }
+
         let mut observer = SseObserver::default();
         observer.push(b"data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0},{\"index\":0}]}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":1}]}}]}\n\n");
         assert_eq!(
@@ -311,6 +393,27 @@ mod tests {
             malformed.finish(StreamOutcome::Completed).tool_calls,
             Observation::Invalid
         );
+
+        for bytes in [
+            b"data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[7]}}]}\n\n"
+                .as_slice(),
+            b"data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{}]}}]}\n\n"
+                .as_slice(),
+            b"data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":-1}]}}]}\n\n"
+                .as_slice(),
+            b"data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":1.5}]}}]}\n\n"
+                .as_slice(),
+            b"data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":18446744073709551616}]}}]}\n\n"
+                .as_slice(),
+        ] {
+            let mut observer = SseObserver::default();
+            observer.push(bytes);
+            assert_eq!(
+                observer.finish(StreamOutcome::Completed).tool_calls,
+                Observation::Invalid,
+                "malformed streamed tool-call presentation must be invalid"
+            );
+        }
     }
 
     #[test]
@@ -352,6 +455,113 @@ mod tests {
     }
 
     #[test]
+    fn completed_stream_estimate_counts_only_valid_nonterminal_choice_events() {
+        // Mutation caught: the old scanner counts every data line, estimates
+        // zero, or replaces invalid/measured completion with an estimate.
+        let mut zero = SseObserver::default();
+        zero.push(b"data: [DONE]\n\ndata: {\"choices\":[]}\n\n");
+        assert_eq!(
+            zero.finish(StreamOutcome::Completed)
+                .usage
+                .completion_tokens,
+            Observation::Unavailable
+        );
+
+        let mut measured = SseObserver::default();
+        measured.push(b"data: {\"choices\":[{\"index\":0,\"delta\":{}}]}\n\ndata: {\"choices\":[],\"usage\":{\"completion_tokens\":7}}\n\n");
+        assert_eq!(
+            measured
+                .finish(StreamOutcome::Completed)
+                .usage
+                .completion_tokens,
+            Observation::Measured(7)
+        );
+
+        let mut invalid = SseObserver::default();
+        invalid.push(b"data: {\"choices\":[{\"index\":0,\"delta\":{}}],\"usage\":{\"completion_tokens\":\"2\"}}\n\n");
+        assert_eq!(
+            invalid
+                .finish(StreamOutcome::Completed)
+                .usage
+                .completion_tokens,
+            Observation::Invalid
+        );
+
+        let mut conflicting = SseObserver::default();
+        conflicting.push(b"data: {\"choices\":[{\"index\":0,\"delta\":{}}],\"usage\":{\"completion_tokens\":2}}\n\ndata: {\"choices\":[],\"usage\":{\"completion_tokens\":3}}\n\n");
+        assert_eq!(
+            conflicting
+                .finish(StreamOutcome::Completed)
+                .usage
+                .completion_tokens,
+            Observation::Invalid
+        );
+
+        let mut usage_only = SseObserver::default();
+        usage_only.push(b"data: {\"choices\":[],\"usage\":{\"completion_tokens\":2}}\n\n");
+        assert_eq!(
+            usage_only
+                .finish(StreamOutcome::Completed)
+                .usage
+                .completion_tokens,
+            Observation::Measured(2),
+            "usage-only event supplies measured completion but does not estimate"
+        );
+
+        for bytes in [
+            b"data: {]\n\n".as_slice(),
+            b"data: \xff\n\n".as_slice(),
+            b"data: [DONE]\n\n".as_slice(),
+            b"data: {\"choices\":[]}\n\n".as_slice(),
+            b"data: {\"choices\":[{\"index\":0,\"finish_reason\":\"stop\"}]}\n\n".as_slice(),
+            b"data: {\"choices\":[{\"index\":0,\"finish_reason\":1}]}\n\n".as_slice(),
+        ] {
+            let mut observer = SseObserver::default();
+            observer.push(bytes);
+            assert_eq!(
+                observer
+                    .finish(StreamOutcome::Completed)
+                    .usage
+                    .completion_tokens,
+                Observation::Unavailable,
+                "non-countable literal SSE event must not estimate completion"
+            );
+        }
+
+        let mut counted = SseObserver::default();
+        counted.push(b"data: {\"choices\":[{\"index\":0,\"delta\":{}}]}\n\ndata: {\"choices\":[{\"index\":1,\"delta\":{}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{}}]}\n\n");
+        assert_eq!(
+            counted
+                .finish(StreamOutcome::Completed)
+                .usage
+                .completion_tokens,
+            Observation::Estimated(3)
+        );
+    }
+
+    #[test]
+    fn completed_unterminated_final_event_has_truncated_observation_outcome() {
+        // Mutation caught: clean EOF publishes a partial final SSE event as
+        // measured or estimated instead of treating the observation as truncated.
+        let mut observer = SseObserver::default();
+        observer.push(b"data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2}}");
+        let actual = observer.finish(StreamOutcome::Completed);
+        assert_eq!(actual.usage.prompt_tokens, Observation::Unavailable);
+        assert_eq!(actual.usage.completion_tokens, Observation::Unavailable);
+        assert_eq!(actual.usage.total_tokens, Observation::Unavailable);
+        assert_eq!(actual.usage.cached_tokens, Observation::Unavailable);
+        assert_eq!(actual.usage.reasoning_tokens, Observation::Unavailable);
+        assert_eq!(actual.tool_calls, Observation::Unavailable);
+        assert_eq!(
+            actual.finish_reasons,
+            vec![FinishObservation {
+                choice_index: 0,
+                result: FinishResult::Unavailable,
+            }]
+        );
+    }
+
+    #[test]
     fn stream_observer_discards_numeric_partial_observations_on_disconnect_or_truncation() {
         // Mutation caught: end-of-loop accounting publishes partial measured or
         // estimated usage after a client disconnect or unterminated final event.
@@ -370,5 +580,50 @@ mod tests {
                 }]
             );
         }
+    }
+
+    #[test]
+    fn unobservable_events_are_bounded_noncountable_and_do_not_block_recovery() {
+        // Mutation caught: retaining an over-bound event or counting malformed
+        // bytes makes the observer exceed its memory bound or inflate estimates.
+        let mut observer = SseObserver::default();
+        let mut over_bound = b"data: ".to_vec();
+        over_bound.extend(std::iter::repeat_n(b'x', 1_048_577));
+        observer.push(&over_bound);
+        assert!(
+            observer.retained_event_bytes() <= 1_048_576,
+            "over-bound current SSE event must be discarded rather than retained"
+        );
+        observer.push(b"\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{}}]}\n\n");
+        assert_eq!(
+            observer
+                .finish(StreamOutcome::Completed)
+                .usage
+                .completion_tokens,
+            Observation::Estimated(1),
+            "discarded over-bound event must not count and later framed input must recover"
+        );
+
+        let mut malformed = SseObserver::default();
+        malformed.push(b"data: {]\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{}}]}\n\n");
+        assert_eq!(
+            malformed
+                .finish(StreamOutcome::Completed)
+                .usage
+                .completion_tokens,
+            Observation::Estimated(1),
+            "malformed JSON event must be unobservable and non-countable"
+        );
+
+        let mut invalid_utf8 = SseObserver::default();
+        invalid_utf8.push(b"data: \xff\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{}}]}\n\n");
+        assert_eq!(
+            invalid_utf8
+                .finish(StreamOutcome::Completed)
+                .usage
+                .completion_tokens,
+            Observation::Estimated(1),
+            "invalid UTF-8 event must be unobservable and non-countable"
+        );
     }
 }

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -1,0 +1,374 @@
+//! Private, side-band NIM response observations.
+//!
+//! This RED scaffold deliberately returns unavailable outcomes.  The tests in
+//! this module describe the evidence-backed behavior that replaces it.
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum Observation {
+    Measured(u64),
+    Estimated(u64),
+    Unavailable,
+    Invalid,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct UsageObservations {
+    pub(crate) cached_tokens: Observation,
+    pub(crate) completion_tokens: Observation,
+    pub(crate) prompt_tokens: Observation,
+    pub(crate) reasoning_tokens: Observation,
+    pub(crate) total_tokens: Observation,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ResponseObservations {
+    pub(crate) finish_reasons: Vec<FinishObservation>,
+    pub(crate) tool_calls: Observation,
+    pub(crate) usage: UsageObservations,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct FinishObservation {
+    pub(crate) choice_index: u64,
+    pub(crate) result: FinishResult,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum FinishResult {
+    Measured(FinishReason),
+    Unavailable,
+    Invalid,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum FinishReason {
+    ContentFilter,
+    FunctionCall,
+    Length,
+    Other,
+    Stop,
+    ToolCalls,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum StreamOutcome {
+    Completed,
+    Disconnected,
+    Truncated,
+}
+
+#[derive(Default)]
+pub(crate) struct SseObserver;
+
+impl SseObserver {
+    pub(crate) fn push(&mut self, _bytes: &[u8]) {}
+
+    pub(crate) fn finish(self, _outcome: StreamOutcome) -> ResponseObservations {
+        unavailable()
+    }
+}
+
+pub(crate) fn observe_buffered(_body: &[u8]) -> ResponseObservations {
+    unavailable()
+}
+
+fn unavailable() -> ResponseObservations {
+    ResponseObservations {
+        finish_reasons: Vec::new(),
+        tool_calls: Observation::Unavailable,
+        usage: UsageObservations {
+            cached_tokens: Observation::Unavailable,
+            completion_tokens: Observation::Unavailable,
+            prompt_tokens: Observation::Unavailable,
+            reasoning_tokens: Observation::Unavailable,
+            total_tokens: Observation::Unavailable,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        observe_buffered, FinishObservation, FinishReason, FinishResult, Observation,
+        ResponseObservations, SseObserver, StreamOutcome,
+    };
+
+    fn fixture_body(name: &str) -> Vec<u8> {
+        let fixture = match name {
+            "buffered-basic" => {
+                include_str!("../tests/fixtures/nim-observations/buffered-basic.json")
+            }
+            "buffered-tools" => {
+                include_str!("../tests/fixtures/nim-observations/buffered-tools.json")
+            }
+            "streamed-basic" => {
+                include_str!("../tests/fixtures/nim-observations/streamed-basic.json")
+            }
+            "streamed-tools" => {
+                include_str!("../tests/fixtures/nim-observations/streamed-tools.json")
+            }
+            _ => panic!("unknown literal evidence fixture: {name}"),
+        };
+        serde_json::from_str::<serde_json::Value>(fixture).unwrap()["body"]
+            .as_str()
+            .unwrap()
+            .as_bytes()
+            .to_vec()
+    }
+
+    fn assert_fixture_outcome(
+        actual: ResponseObservations,
+        finish: FinishReason,
+        tools: u64,
+        production_mutation: &str,
+    ) {
+        assert_eq!(
+            actual.usage.prompt_tokens,
+            Observation::Measured(1),
+            "{production_mutation}: prompt must come from the literal fixture"
+        );
+        assert_eq!(
+            actual.usage.completion_tokens,
+            Observation::Measured(2),
+            "{production_mutation}: completion must come from the literal fixture"
+        );
+        assert_eq!(
+            actual.usage.total_tokens,
+            Observation::Measured(3),
+            "{production_mutation}: total must come from the literal fixture"
+        );
+        assert_eq!(actual.usage.cached_tokens, Observation::Unavailable);
+        assert_eq!(actual.usage.reasoning_tokens, Observation::Unavailable);
+        assert_eq!(actual.tool_calls, Observation::Measured(tools));
+        assert_eq!(
+            actual.finish_reasons,
+            vec![FinishObservation {
+                choice_index: 0,
+                result: FinishResult::Measured(finish),
+            }],
+            "{production_mutation}: finish observation must stay choice-indexed"
+        );
+    }
+
+    #[test]
+    fn buffered_fixture_conformance_rejects_old_first_choice_and_usage_shortcuts() {
+        // Mutation caught: retaining the old ad-hoc buffered extraction loses
+        // typed unavailable fields and does not make choice/tool classification
+        // a checked observation boundary.
+        assert_fixture_outcome(
+            observe_buffered(&fixture_body("buffered-basic")),
+            FinishReason::Stop,
+            0,
+            "old buffered shortcut",
+        );
+        assert_fixture_outcome(
+            observe_buffered(&fixture_body("buffered-tools")),
+            FinishReason::ToolCalls,
+            1,
+            "old buffered shortcut",
+        );
+    }
+
+    #[test]
+    fn streamed_fixture_conformance_rejects_old_line_scanner() {
+        // Mutation caught: the previous line scanner treats a null progress
+        // reason and the usage-only final event as unrelated observations.
+        for (name, finish, tools) in [
+            ("streamed-basic", FinishReason::Stop, 0),
+            ("streamed-tools", FinishReason::ToolCalls, 1),
+        ] {
+            let mut observer = SseObserver::default();
+            observer.push(&fixture_body(name));
+            assert_fixture_outcome(
+                observer.finish(StreamOutcome::Completed),
+                finish,
+                tools,
+                "old SseScan line scanner",
+            );
+        }
+    }
+
+    #[test]
+    fn usage_integer_boundaries_reject_non_u64_without_silent_casting() {
+        // Mutation caught: serde Value::as_u64-style extraction silently drops
+        // malformed presentations rather than emitting Invalid for that field.
+        for (body, expected) in [
+            (
+                br#"{"usage":{"prompt_tokens":0,"completion_tokens":18446744073709551615}}"#
+                    .as_slice(),
+                (Observation::Measured(0), Observation::Measured(u64::MAX)),
+            ),
+            (
+                br#"{"usage":{"prompt_tokens":18446744073709551616,"completion_tokens":-1}}"#
+                    .as_slice(),
+                (Observation::Invalid, Observation::Invalid),
+            ),
+            (
+                br#"{"usage":{"prompt_tokens":1.0,"completion_tokens":"2"}}"#.as_slice(),
+                (Observation::Invalid, Observation::Invalid),
+            ),
+            (
+                br#"{"usage":{"prompt_tokens":null,"completion_tokens":{}}}"#.as_slice(),
+                (Observation::Invalid, Observation::Invalid),
+            ),
+        ] {
+            let actual = observe_buffered(body);
+            assert_eq!(
+                actual.usage.prompt_tokens, expected.0,
+                "usage integer boundary"
+            );
+            assert_eq!(
+                actual.usage.completion_tokens, expected.1,
+                "usage integer boundary"
+            );
+        }
+
+        let actual = observe_buffered(br#"{"usage":[]}"#);
+        assert_eq!(actual.usage.prompt_tokens, Observation::Invalid);
+        assert_eq!(actual.usage.completion_tokens, Observation::Invalid);
+        assert_eq!(actual.usage.total_tokens, Observation::Invalid);
+        assert_eq!(actual.usage.cached_tokens, Observation::Invalid);
+        assert_eq!(actual.usage.reasoning_tokens, Observation::Invalid);
+    }
+
+    #[test]
+    fn stream_observer_reassembles_crlf_multiline_comments_and_every_split() {
+        // Mutation caught: line-local parsing misses a valid event split at an
+        // arbitrary transport boundary or changes the standard SSE data join.
+        let bytes = b": keepalive\r\n\r\ndata: {\"choices\":[{\"index\":0,\r\ndata: \"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2,\"total_tokens\":3}}\r\n\r\n";
+        for split in 0..=bytes.len() {
+            let mut observer = SseObserver::default();
+            observer.push(&bytes[..split]);
+            observer.push(&bytes[split..]);
+            assert_fixture_outcome(
+                observer.finish(StreamOutcome::Completed),
+                FinishReason::Stop,
+                0,
+                "split/CRLF/multi-line SSE parser",
+            );
+        }
+    }
+
+    #[test]
+    fn stream_observer_invalidates_duplicate_conflicts_and_relationships() {
+        // Mutation caught: first-value-wins scanning accepts contradictory
+        // duplicate usage, cached, or reasoning presentations.
+        let mut observer = SseObserver::default();
+        observer.push(b"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2}}\n\ndata: {\"choices\":[],\"usage\":{\"prompt_tokens\":2,\"completion_tokens\":2,\"prompt_tokens_details\":{\"cached_tokens\":3},\"completion_tokens_details\":{\"reasoning_tokens\":3}}}\n\n");
+        let actual = observer.finish(StreamOutcome::Completed);
+        assert_eq!(actual.usage.prompt_tokens, Observation::Invalid);
+        assert_eq!(actual.usage.completion_tokens, Observation::Measured(2));
+        assert_eq!(actual.usage.cached_tokens, Observation::Invalid);
+        assert_eq!(actual.usage.reasoning_tokens, Observation::Invalid);
+
+        let mut equal_duplicates = SseObserver::default();
+        equal_duplicates.push(b"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2}}\n\ndata: {\"choices\":[],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2}}\n\n");
+        let actual = equal_duplicates.finish(StreamOutcome::Completed);
+        assert_eq!(actual.usage.prompt_tokens, Observation::Measured(1));
+        assert_eq!(actual.usage.completion_tokens, Observation::Measured(2));
+    }
+
+    #[test]
+    fn choice_and_tool_observations_reject_old_first_choice_and_max_index_rules() {
+        // Mutation caught: first-choice-only finish extraction and max-index
+        // tool counting lose valid choices, accept malformed shapes, and count
+        // duplicate stream fragments as separate calls.
+        let actual = observe_buffered(b"{\"choices\":[{\"index\":1,\"message\":{},\"finish_reason\":\"length\"},{\"index\":0,\"message\":{},\"finish_reason\":\"content_filter\"}]} ");
+        assert_eq!(
+            actual.finish_reasons,
+            vec![
+                FinishObservation {
+                    choice_index: 0,
+                    result: FinishResult::Measured(FinishReason::ContentFilter),
+                },
+                FinishObservation {
+                    choice_index: 1,
+                    result: FinishResult::Measured(FinishReason::Length),
+                },
+            ]
+        );
+        assert_eq!(actual.tool_calls, Observation::Measured(0));
+
+        let actual = observe_buffered(b"{\"choices\":[]}");
+        assert_eq!(actual.tool_calls, Observation::Measured(0));
+        let actual = observe_buffered(b"{}");
+        assert_eq!(actual.tool_calls, Observation::Unavailable);
+        let actual = observe_buffered(b"{\"choices\":{}}");
+        assert_eq!(actual.tool_calls, Observation::Invalid);
+
+        let mut observer = SseObserver::default();
+        observer.push(b"data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0},{\"index\":0}]}}]}\n\ndata: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":1}]}}]}\n\n");
+        assert_eq!(
+            observer.finish(StreamOutcome::Completed).tool_calls,
+            Observation::Measured(2)
+        );
+
+        let mut malformed = SseObserver::default();
+        malformed.push(
+            b"data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":-1}]}}]}\n\n",
+        );
+        assert_eq!(
+            malformed.finish(StreamOutcome::Completed).tool_calls,
+            Observation::Invalid
+        );
+    }
+
+    #[test]
+    fn finish_taxonomy_and_completed_estimate_reject_silent_terminal_fallbacks() {
+        // Mutation caught: treating unknown or malformed terminal values as a
+        // first-choice string and estimating regardless of terminal validity.
+        let actual = observe_buffered(b"{\"choices\":[{\"index\":0,\"message\":{},\"finish_reason\":\"function_call\"},{\"index\":1,\"message\":{},\"finish_reason\":\"future_reason\"},{\"index\":2,\"message\":{},\"finish_reason\":1},{\"index\":3,\"message\":{}}]}");
+        assert_eq!(
+            actual.finish_reasons,
+            vec![
+                FinishObservation {
+                    choice_index: 0,
+                    result: FinishResult::Measured(FinishReason::FunctionCall),
+                },
+                FinishObservation {
+                    choice_index: 1,
+                    result: FinishResult::Measured(FinishReason::Other),
+                },
+                FinishObservation {
+                    choice_index: 2,
+                    result: FinishResult::Invalid,
+                },
+                FinishObservation {
+                    choice_index: 3,
+                    result: FinishResult::Unavailable,
+                },
+            ]
+        );
+
+        let mut observer = SseObserver::default();
+        observer.push(b"data: {\"choices\":[{\"index\":0,\"delta\":{}}]}\n\n");
+        assert_eq!(
+            observer
+                .finish(StreamOutcome::Completed)
+                .usage
+                .completion_tokens,
+            Observation::Estimated(1)
+        );
+    }
+
+    #[test]
+    fn stream_observer_discards_numeric_partial_observations_on_disconnect_or_truncation() {
+        // Mutation caught: end-of-loop accounting publishes partial measured or
+        // estimated usage after a client disconnect or unterminated final event.
+        for outcome in [StreamOutcome::Disconnected, StreamOutcome::Truncated] {
+            let mut observer = SseObserver::default();
+            observer.push(b"data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2}}\n\n");
+            let actual = observer.finish(outcome);
+            assert_eq!(actual.usage.prompt_tokens, Observation::Unavailable);
+            assert_eq!(actual.usage.completion_tokens, Observation::Unavailable);
+            assert_eq!(actual.tool_calls, Observation::Unavailable);
+            assert_eq!(
+                actual.finish_reasons,
+                vec![FinishObservation {
+                    choice_index: 0,
+                    result: FinishResult::Unavailable,
+                }]
+            );
+        }
+    }
+}

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -364,6 +364,30 @@ mod tests {
         assert_eq!(actual.tool_calls, Observation::Invalid);
         assert!(actual.finish_reasons.is_empty());
 
+        let actual = observe_buffered(
+            b"{\"choices\":[{\"index\":0,\"message\":7,\"finish_reason\":\"stop\"}]}",
+        );
+        assert_eq!(actual.tool_calls, Observation::Invalid);
+        assert_eq!(
+            actual.finish_reasons,
+            vec![FinishObservation {
+                choice_index: 0,
+                result: FinishResult::Measured(FinishReason::Stop),
+            }]
+        );
+
+        let actual = observe_buffered(
+            b"{\"choices\":[{\"index\":0,\"message\":{\"tool_calls\":{}},\"finish_reason\":\"stop\"}]}",
+        );
+        assert_eq!(actual.tool_calls, Observation::Invalid);
+        assert_eq!(
+            actual.finish_reasons,
+            vec![FinishObservation {
+                choice_index: 0,
+                result: FinishResult::Measured(FinishReason::Stop),
+            }]
+        );
+
         for body in [
             b"{\"choices\":[{\"message\":{}}]}".as_slice(),
             b"{\"choices\":[{\"index\":-1,\"message\":{}}]}".as_slice(),
@@ -412,6 +436,20 @@ mod tests {
                 observer.finish(StreamOutcome::Completed).tool_calls,
                 Observation::Invalid,
                 "malformed streamed tool-call presentation must be invalid"
+            );
+        }
+
+        for bytes in [
+            b"data: {\"choices\":{}}\n\n".as_slice(),
+            b"data: {\"choices\":[7]}\n\n".as_slice(),
+        ] {
+            let mut observer = SseObserver::default();
+            observer.push(bytes);
+            let actual = observer.finish(StreamOutcome::Completed);
+            assert_eq!(actual.tool_calls, Observation::Invalid);
+            assert!(
+                actual.finish_reasons.is_empty(),
+                "malformed streamed choices must not fabricate finish observations"
             );
         }
     }
@@ -506,6 +544,40 @@ mod tests {
                 .completion_tokens,
             Observation::Measured(2),
             "usage-only event supplies measured completion but does not estimate"
+        );
+
+        let mut comment_only = SseObserver::default();
+        comment_only.push(b": keepalive\n\n");
+        assert_eq!(
+            comment_only
+                .finish(StreamOutcome::Completed)
+                .usage
+                .completion_tokens,
+            Observation::Unavailable,
+            "comment-only event must not count toward completion estimate"
+        );
+
+        let mut json_error = SseObserver::default();
+        json_error.push(b"data: {\"error\":{\"message\":\"redacted\"}}\n\n");
+        assert_eq!(
+            json_error
+                .finish(StreamOutcome::Completed)
+                .usage
+                .completion_tokens,
+            Observation::Unavailable,
+            "parsed JSON error event must not count toward completion estimate"
+        );
+
+        let mut usage_without_completion = SseObserver::default();
+        usage_without_completion
+            .push(b"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":1}}\n\n");
+        assert_eq!(
+            usage_without_completion
+                .finish(StreamOutcome::Completed)
+                .usage
+                .completion_tokens,
+            Observation::Unavailable,
+            "usage-only event without completion tokens must not estimate completion"
         );
 
         for bytes in [

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -20,6 +20,10 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use crate::dispatch::Slot;
 use crate::governor::{self, ModelPermit};
+use crate::observation::{
+    observe_buffered, FinishReason, FinishResult, Observation, ResponseObservations, SseObserver,
+    StreamOutcome,
+};
 use crate::{AppState, Config};
 
 /// Per-request metric labels, resolved once up front.
@@ -260,15 +264,6 @@ fn record_tokens(ctx: &Ctx, prompt: Option<u64>, completion: Option<u64>, source
     }
 }
 
-/// Bound `finish_reason` to the known OpenAI set so an unexpected upstream
-/// value can't grow label cardinality. `length` is the truncation signal.
-fn finish_label(raw: &str) -> String {
-    match raw {
-        "stop" | "length" | "tool_calls" | "content_filter" | "function_call" => raw.to_owned(),
-        _ => "other".to_owned(),
-    }
-}
-
 /// The request's tool-selection mode, bounded to a small enum. Called only
 /// when the request offers tools, so a missing `tool_choice` means the
 /// provider default (auto).
@@ -345,113 +340,53 @@ fn record_shape(ctx: &Ctx, parsed: Option<&serde_json::Value>, wants_stream: boo
     }
 }
 
-/// Record response-quality signals available once a generation completes:
-/// how it ended (truncation), reasoning-token burn, and tool-call volume.
-fn record_quality(
+/// Record only finalized typed observations. Invalid and unavailable upstream
+/// values are deliberately absent from the existing metrics.
+fn record_observations(
     ctx: &Ctx,
-    finish: Option<&str>,
-    reasoning: Option<u64>,
-    tool_calls: Option<u64>,
-) {
-    if let Some(fr) = finish {
+    observations: &ResponseObservations,
+) -> Option<(u64, &'static str)> {
+    let prompt = match observations.usage.prompt_tokens {
+        Observation::Measured(value) => Some(value),
+        _ => None,
+    };
+    let (completion, source) = match observations.usage.completion_tokens {
+        Observation::Measured(value) => (Some(value), "usage"),
+        Observation::Estimated(value) => (Some(value), "estimate"),
+        Observation::Unavailable | Observation::Invalid => (None, "usage"),
+    };
+    record_tokens(ctx, prompt, completion, source);
+    for finish in &observations.finish_reasons {
+        let FinishResult::Measured(reason) = &finish.result else {
+            continue;
+        };
         counter!(
             "nimproxy_finish_reason_total",
             "model" => ctx.model.clone(),
-            "reason" => finish_label(fr),
+            "reason" => match reason {
+                FinishReason::ContentFilter => "content_filter",
+                FinishReason::FunctionCall => "function_call",
+                FinishReason::Length => "length",
+                FinishReason::Other => "other",
+                FinishReason::Stop => "stop",
+                FinishReason::ToolCalls => "tool_calls",
+            },
         )
         .increment(1);
     }
-    if let Some(r) = reasoning {
-        if r > 0 {
-            counter!("nimproxy_reasoning_tokens_total", "model" => ctx.model.clone()).increment(r);
+    if let Observation::Measured(reasoning) = observations.usage.reasoning_tokens {
+        if reasoning > 0 {
+            counter!("nimproxy_reasoning_tokens_total", "model" => ctx.model.clone())
+                .increment(reasoning);
         }
     }
-    if let Some(n) = tool_calls {
-        if n > 0 {
-            counter!("nimproxy_tool_calls_total", "model" => ctx.model.clone()).increment(n);
+    if let Observation::Measured(tool_calls) = observations.tool_calls {
+        if tool_calls > 0 {
+            counter!("nimproxy_tool_calls_total", "model" => ctx.model.clone())
+                .increment(tool_calls);
         }
     }
-}
-
-/// Watches an SSE byte stream for the `usage` object and counts data events
-/// (a rough one-token-per-event estimate when the upstream omits usage).
-/// Purely observational — bytes reach the client untouched.
-#[derive(Default)]
-struct SseScan {
-    buf: String,
-    events: u64,
-    prompt: Option<u64>,
-    completion: Option<u64>,
-    reasoning: Option<u64>,
-    finish_reason: Option<String>,
-    /// Highest `tool_calls[].index` seen; +1 is the tool-call count.
-    tool_call_max: Option<u64>,
-}
-
-impl SseScan {
-    fn feed(&mut self, bytes: &[u8]) {
-        self.buf.push_str(&String::from_utf8_lossy(bytes));
-        while let Some(pos) = self.buf.find('\n') {
-            let line: String = self.buf.drain(..=pos).collect();
-            let line = line.trim();
-            if let Some(data) = line.strip_prefix("data:").map(str::trim_start) {
-                if data == "[DONE]" {
-                    continue;
-                }
-                self.events += 1;
-                // Only the events that carry usage, a concrete finish_reason
-                // (a string, not the per-chunk `null`), or tool_calls are worth
-                // a full JSON parse; plain content deltas are skipped.
-                let interesting = data.contains("\"usage\"")
-                    || data.contains("\"finish_reason\":\"")
-                    || data.contains("\"tool_calls\"");
-                if interesting {
-                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(data) {
-                        if let Some(u) = v.get("usage").filter(|u| !u.is_null()) {
-                            self.prompt = u
-                                .get("prompt_tokens")
-                                .and_then(|x| x.as_u64())
-                                .or(self.prompt);
-                            self.completion = u
-                                .get("completion_tokens")
-                                .and_then(|x| x.as_u64())
-                                .or(self.completion);
-                            self.reasoning = u
-                                .get("completion_tokens_details")
-                                .and_then(|d| d.get("reasoning_tokens"))
-                                .and_then(|x| x.as_u64())
-                                .or(self.reasoning);
-                        }
-                        if let Some(choices) = v.get("choices").and_then(|c| c.as_array()) {
-                            for ch in choices {
-                                if let Some(fr) = ch.get("finish_reason").and_then(|f| f.as_str()) {
-                                    self.finish_reason = Some(fr.to_owned());
-                                }
-                                if let Some(tcs) = ch
-                                    .get("delta")
-                                    .and_then(|d| d.get("tool_calls"))
-                                    .and_then(|t| t.as_array())
-                                {
-                                    for tc in tcs {
-                                        if let Some(idx) = tc.get("index").and_then(|i| i.as_u64())
-                                        {
-                                            self.tool_call_max = Some(
-                                                self.tool_call_max.map_or(idx, |m| m.max(idx)),
-                                            );
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        // Guard against a pathological never-terminated line.
-        if self.buf.len() > 1_048_576 {
-            self.buf.clear();
-        }
-    }
+    completion.map(|value| (value, source))
 }
 
 fn upstream_request(
@@ -910,7 +845,7 @@ fn streaming(
                     return;
                 }
 
-                let mut scan = SseScan::default();
+                let mut observer = SseObserver::default();
                 let mut first_chunk: Option<Instant> = None;
                 let mut chunks = resp.bytes_stream();
                 loop {
@@ -929,12 +864,14 @@ fn streaming(
                     };
                     let next = tokio::select! {
                         _ = tx.closed() => {
+                            let _ = observer.finish(StreamOutcome::Disconnected);
                             record_request(&ctx, "disconnect");
                             return;
                         }
                         read = upstream_read => match read {
                             Ok(n) => n,
                             Err(_) => {
+                                let _ = observer.finish(StreamOutcome::Truncated);
                                 tracing::warn!(model = %ctx.model, idle = ?cfg.stream_idle, "upstream stream stalled");
                                 record_request(&ctx, "stall");
                                 let _ = tx.send(Ok(sse_error("upstream stream stalled"))).await;
@@ -950,13 +887,15 @@ fn streaming(
                                 histogram!("nimproxy_ttft_seconds", "model" => ctx.model.clone())
                                     .record(sent_at.elapsed().as_secs_f64());
                             }
-                            scan.feed(&b);
+                            observer.push(&b);
                             if tx.send(Ok(b)).await.is_err() {
+                                let _ = observer.finish(StreamOutcome::Disconnected);
                                 record_request(&ctx, "disconnect");
                                 return; // client hung up
                             }
                         }
                         Err(e) => {
+                            let _ = observer.finish(StreamOutcome::Truncated);
                             tracing::warn!(error = %e, "upstream stream broke mid-response");
                             record_request(&ctx, "stream_error");
                             let _ = tx.send(Ok(sse_error("upstream stream interrupted"))).await;
@@ -965,25 +904,12 @@ fn streaming(
                     }
                 }
 
-                // Token accounting: exact when the upstream reported usage,
-                // otherwise estimate ~1 token per SSE event.
-                let source = if scan.completion.is_some() {
-                    "usage"
-                } else {
-                    "estimate"
-                };
-                let completion = scan.completion.or(Some(scan.events));
-                record_tokens(&ctx, scan.prompt, completion, source);
-                record_quality(
-                    &ctx,
-                    scan.finish_reason.as_deref(),
-                    scan.reasoning,
-                    scan.tool_call_max.map(|m| m + 1),
-                );
-                if let (Some(first), Some(c)) = (first_chunk, completion) {
+                let completion =
+                    record_observations(&ctx, &observer.finish(StreamOutcome::Completed));
+                if let (Some(first), Some((c, source))) = (first_chunk, completion) {
                     let gen_secs = first.elapsed().as_secs_f64();
                     if gen_secs > 0.1 && c > 0 {
-                        histogram!("nimproxy_tokens_per_second", "model" => ctx.model.clone(), "source" => source.to_owned())
+                        histogram!("nimproxy_tokens_per_second", "model" => ctx.model.clone(), "source" => source)
                         .record(c as f64 / gen_secs);
                         // Mean inter-token latency (time-per-output-token).
                         histogram!("nimproxy_tpot_seconds", "model" => ctx.model.clone())
@@ -1094,37 +1020,7 @@ async fn relay(resp: reqwest::Response, ctx: &Ctx) -> Response {
         }
     };
     if status.is_success() {
-        if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&body) {
-            if let Some(u) = v.get("usage").filter(|u| !u.is_null()) {
-                record_tokens(
-                    ctx,
-                    u.get("prompt_tokens").and_then(|x| x.as_u64()),
-                    u.get("completion_tokens").and_then(|x| x.as_u64()),
-                    "usage",
-                );
-            }
-            let reasoning = v
-                .get("usage")
-                .and_then(|u| u.get("completion_tokens_details"))
-                .and_then(|d| d.get("reasoning_tokens"))
-                .and_then(|x| x.as_u64());
-            let choices = v.get("choices").and_then(|c| c.as_array());
-            let finish = choices
-                .and_then(|c| c.first())
-                .and_then(|c| c.get("finish_reason"))
-                .and_then(|f| f.as_str());
-            let tool_calls = choices.map(|cs| {
-                cs.iter()
-                    .filter_map(|c| {
-                        c.get("message")
-                            .and_then(|m| m.get("tool_calls"))
-                            .and_then(|t| t.as_array())
-                    })
-                    .map(|a| a.len() as u64)
-                    .sum::<u64>()
-            });
-            record_quality(ctx, finish, reasoning, tool_calls);
-        }
+        record_observations(ctx, &observe_buffered(&body));
     }
     Response::builder()
         .status(status)
@@ -1216,8 +1112,7 @@ fn gateway_timeout(cfg: &Config, pool_len: usize) -> Response {
 #[cfg(test)]
 mod tests {
     use super::{
-        bounded_label, count_tools, finish_label, is_json_mode, label_path, sanitize_label,
-        tool_choice_mode, SseScan,
+        bounded_label, count_tools, is_json_mode, label_path, sanitize_label, tool_choice_mode,
     };
     use std::collections::HashSet;
 
@@ -1272,67 +1167,6 @@ mod tests {
     }
 
     #[test]
-    fn sse_scan_clears_a_pathological_unterminated_line() {
-        let mut scan = SseScan::default();
-        // >1 MiB with no newline: the guard clears the buffer instead of letting
-        // an abusive upstream grow it without bound.
-        scan.feed(&vec![b'x'; 1_048_577]);
-        assert!(scan.buf.is_empty(), "oversized line buffer must be dropped");
-        assert_eq!(scan.events, 0);
-        // The guard drops the runaway buffer without wedging the scanner: a
-        // normal event still parses immediately afterward.
-        scan.feed(b"data: {\"choices\":[],\"usage\":{\"completion_tokens\":3}}\n\n");
-        assert_eq!(scan.events, 1);
-        assert_eq!(scan.completion, Some(3));
-    }
-
-    #[test]
-    fn scan_counts_events_and_finds_usage() {
-        let mut scan = SseScan::default();
-        // Feed in awkwardly split chunks to exercise line reassembly.
-        scan.feed(b": heartbeat\n\ndata: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: {\"cho");
-        scan.feed(b"ices\":[],\"usage\":{\"prompt_tokens\":120,\"completion_tokens\":45}}\n\ndata: [DONE]\n\n");
-        assert_eq!(scan.events, 2);
-        assert_eq!(scan.prompt, Some(120));
-        assert_eq!(scan.completion, Some(45));
-    }
-
-    #[test]
-    fn scan_without_usage_estimates_by_events() {
-        let mut scan = SseScan::default();
-        scan.feed(b"data: {\"a\":1}\n\ndata: {\"b\":2}\n\ndata: {\"c\":3}\n\ndata: [DONE]\n\n");
-        assert_eq!(scan.events, 3);
-        assert_eq!(scan.completion, None);
-    }
-
-    #[test]
-    fn scan_captures_finish_reason_tool_calls_and_reasoning() {
-        let mut scan = SseScan::default();
-        // A content delta (finish_reason:null — skipped), two tool-call deltas
-        // (indices 0 and 1), then a final chunk with finish_reason + usage that
-        // carries reasoning-token details.
-        scan.feed(
-            b"data: {\"choices\":[{\"delta\":{\"content\":\"x\"},\"finish_reason\":null}]}\n\n",
-        );
-        scan.feed(b"data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"name\":\"a\"}}]}}]}\n\n");
-        scan.feed(b"data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"function\":{\"name\":\"b\"}}]}}]}\n\n");
-        scan.feed(b"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n");
-        scan.feed(b"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":8,\"completion_tokens_details\":{\"reasoning_tokens\":5}}}\n\ndata: [DONE]\n\n");
-        assert_eq!(scan.finish_reason.as_deref(), Some("tool_calls"));
-        assert_eq!(scan.tool_call_max, Some(1)); // +1 => 2 tool calls
-        assert_eq!(scan.reasoning, Some(5));
-        assert_eq!(scan.completion, Some(8));
-    }
-
-    #[test]
-    fn finish_label_bounds_unknown_values() {
-        assert_eq!(finish_label("stop"), "stop");
-        assert_eq!(finish_label("length"), "length");
-        assert_eq!(finish_label("tool_calls"), "tool_calls");
-        assert_eq!(finish_label("weird\"injection"), "other");
-    }
-
-    #[test]
     fn tool_choice_and_shape_readers() {
         let auto = serde_json::json!({"tools": [{}], "tool_choice": "auto"});
         assert_eq!(tool_choice_mode(&auto), "auto");
@@ -1370,23 +1204,20 @@ mod tests {
 #[cfg(fuzzing)]
 #[doc(hidden)]
 pub mod fuzz {
-    /// Drive the SSE scanner with arbitrary bytes, twice: once as a single
-    /// chunk and once re-fragmented at a size derived from the input (the
-    /// network delivers these bytes arbitrarily split). Must never panic,
-    /// and the pathological-line guard must keep the buffer bounded.
+    /// Drive the private SSE observer with arbitrary bytes, twice: once as a
+    /// single chunk and once re-fragmented at an input-derived boundary. Must
+    /// never panic; the observer bounds its one unfinished event internally.
     pub fn sse_scan(data: &[u8]) {
-        let mut whole = super::SseScan::default();
-        whole.feed(data);
+        let mut whole = crate::observation::SseObserver::default();
+        whole.push(data);
+        let _ = whole.finish(crate::observation::StreamOutcome::Completed);
 
         let step = data.first().map_or(3, |b| (*b as usize % 17) + 1);
-        let mut frag = super::SseScan::default();
+        let mut frag = crate::observation::SseObserver::default();
         for chunk in data.chunks(step) {
-            frag.feed(chunk);
-            assert!(
-                frag.buf.len() <= 1_048_576 + chunk.len(),
-                "SSE buffer must stay bounded by the guard"
-            );
+            frag.push(chunk);
         }
+        let _ = frag.finish(crate::observation::StreamOutcome::Completed);
     }
 
     /// The sanitizer's output invariants ARE the security property: bounded

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -2530,6 +2530,95 @@ async fn models_catalog_is_cached_and_auth_gated() {
 }
 
 #[tokio::test]
+async fn observation_preserves_upstream_bytes() {
+    // Mutation caught: the old side-band reader accepts an invalid reasoning
+    // value (3 > completion 2) and records it, instead of omitting it while
+    // preserving every upstream byte at the proxy boundary.
+    let mock = start_mock().await;
+    let proxy = start_proxy(&mock.url, &[]).await;
+
+    for fixture in [
+        include_str!("fixtures/nim-observations/buffered-basic.json"),
+        include_str!("fixtures/nim-observations/buffered-tools.json"),
+        include_str!("fixtures/nim-observations/streamed-basic.json"),
+        include_str!("fixtures/nim-observations/streamed-tools.json"),
+    ] {
+        let evidence: serde_json::Value = serde_json::from_str(fixture).unwrap();
+        let body = evidence["body"].as_str().unwrap().to_owned();
+        let content_type = evidence["content_type"].as_str().unwrap().to_owned();
+        let stream = evidence["transport"] == "sse";
+        mock.state.push(Behavior::ExactResponse {
+            content_type: content_type.clone(),
+            body: body.clone(),
+        });
+        let response = client()
+            .post(proxy.url("/v1/chat/completions"))
+            .json(&chat_body(evidence["case"].as_str().unwrap(), stream))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status().as_u16(),
+            evidence["status"].as_u64().unwrap() as u16
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            content_type
+        );
+        // Streaming already has a fixed local connection frame; the fixture
+        // bytes must follow it unchanged. Buffered responses are pure relay.
+        let expected_proxy_bytes = if stream {
+            format!(": connected\n\n{body}")
+        } else {
+            body.clone()
+        };
+        assert_eq!(
+            response.bytes().await.unwrap().as_ref(),
+            expected_proxy_bytes.as_bytes(),
+            "observation must preserve the literal {} bytes in the established proxy frame",
+            evidence["case"].as_str().unwrap()
+        );
+    }
+
+    let invalid_reasoning = r#"{"choices":[{"index":0,"message":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"completion_tokens_details":{"reasoning_tokens":3}}}"#;
+    mock.state.push(Behavior::ExactResponse {
+        content_type: "application/json".to_owned(),
+        body: invalid_reasoning.to_owned(),
+    });
+
+    let response = client()
+        .post(proxy.url("/v1/chat/completions"))
+        .json(&chat_body("observation byte boundary", false))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200, "observation must not change status");
+    assert_eq!(
+        response.headers().get(CONTENT_TYPE).unwrap(),
+        "application/json",
+        "observation must not change content type"
+    );
+    assert_eq!(
+        response.bytes().await.unwrap().as_ref(),
+        invalid_reasoning.as_bytes(),
+        "observation must relay the exact upstream bytes"
+    );
+
+    assert!(
+        !metrics(&proxy)
+            .await
+            .lines()
+            .any(|line| line.starts_with("nimproxy_reasoning_tokens_total{")),
+        "invalid reasoning must be omitted instead of accepted by the old side-band reader"
+    );
+}
+
+#[tokio::test]
 async fn usage_injection_asks_for_usage_and_backs_off_on_rejection() {
     // Default: stream_options injected.
     let mock = start_mock().await;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -16,7 +16,7 @@ use futures_util::StreamExt;
 
 /// One scripted response for the next chat-completions request. The queue is
 /// consumed front-to-back; when empty, `Ok` is the default.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub enum Behavior {
     /// Respond normally (stream or JSON per the request's `stream` flag).
     Ok,
@@ -45,6 +45,8 @@ pub enum Behavior {
     /// Buffered response with an unknown `finish_reason` — exercises the
     /// server-side clamp that collapses odd values to `other`.
     OddFinish,
+    /// A fixed upstream response for an exact proxy-boundary assertion.
+    ExactResponse { content_type: String, body: String },
 }
 
 pub struct Hit {
@@ -164,6 +166,11 @@ async fn mock_chat(
             "usage": {"prompt_tokens": 11, "completion_tokens": 2}
         }))
         .into_response(),
+        Behavior::ExactResponse { content_type, body } => Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, content_type)
+            .body(Body::from(body))
+            .unwrap(),
         Behavior::Hang => {
             let stream = futures_util::stream::once(async {
                 Ok::<_, std::io::Error>(Bytes::from("data: {\"choices\":[]}\n\n"))

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -211,7 +211,7 @@ async fn mock_chat(
             // a request that offers tools gets a tool_calls response, otherwise
             // a normal stop. Usage always carries reasoning-token details.
             let offers_tools = parsed.get("tools").is_some();
-            let usage = "\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":2,\"completion_tokens_details\":{\"reasoning_tokens\":3}}";
+            let usage = "\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":2,\"completion_tokens_details\":{\"reasoning_tokens\":2}}";
             if wants_stream {
                 let mut chunks: Vec<Result<Bytes, std::io::Error>> = Vec::new();
                 if offers_tools {
@@ -240,14 +240,14 @@ async fn mock_chat(
                     "choices": [{"index": 0, "message": {"role": "assistant", "tool_calls": [
                         {"index": 0, "id": "c1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}
                     ]}, "finish_reason": "tool_calls"}],
-                    "usage": {"prompt_tokens": 11, "completion_tokens": 2, "completion_tokens_details": {"reasoning_tokens": 3}}
+                    "usage": {"prompt_tokens": 11, "completion_tokens": 2, "completion_tokens_details": {"reasoning_tokens": 2}}
                 }))
                 .into_response()
             } else {
                 axum::Json(serde_json::json!({
                     "id": "mock-1", "object": "chat.completion",
                     "choices": [{"index": 0, "message": {"role": "assistant", "content": "hello world"}, "finish_reason": "stop"}],
-                    "usage": {"prompt_tokens": 11, "completion_tokens": 2, "completion_tokens_details": {"reasoning_tokens": 3}}
+                    "usage": {"prompt_tokens": 11, "completion_tokens": 2, "completion_tokens_details": {"reasoning_tokens": 2}}
                 }))
                 .into_response()
             }


### PR DESCRIPTION
## Outcome

Replaces the buffered and SSE side-band shortcuts with one private typed NIM observation core while preserving proxied response bytes.

## Why

Real NIM evidence exposed assumptions about usage fields, finish reasons, tool calls, malformed events, incomplete streams, and completion estimation. Task 15 validates those shapes before existing metrics consume them.

## Changes

- classifies five usage fields as measured, estimated, unavailable, or invalid
- bounds unfinished SSE event storage to 1,048,576 bytes
- keeps over-bound, malformed, disconnected, truncated, and unterminated events from fabricating observations
- aggregates deterministic finish reasons and tool calls
- preserves exact buffered and streaming relay bytes
- corrects invalid normal mock relationships
- records the observation contract and testing guidance in project knowledge

Task 16, not this PR, owns the observation-quality counter and UI.

## Verification

- 13 observer controls
- exact-byte and disconnect E2Es
- 6 streaming tests and 7 proxy unit tests
- full suite: 187 unit, 111 E2E passed with 1 intentional ignore, 7 OpenAPI
- clippy with warnings denied
- formatting, diff, Python mock compilation, and guide/link validation
- independent review plus one reviewed SSE discard-boundary repair

Tracks #104.