### PR TITLE
v0.6.6: expose usage observation quality

### DIFF
--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -4586,6 +4586,34 @@ Rust-owned fixtures, the catalog, `metricRow` assertions, and the render matrix.
   interaction, locale, syntax, format, and diff controls are clean. RED Gate
   OPEN for this checkpoint commit; no GREEN step is complete.
 
+- 2026-08-01 GREEN candidate Plan → Act → Verify: replace the RED mapping seam
+  with the private five-pair canonical mapper; register and record the bounded
+  counter at every existing final observer boundary; derive the existing
+  Overview health row directly from recognized finite nonnegative sample rows
+  and the valid tail. Add only the five catalog messages and the planned
+  durable component/test documentation. Verify the complete named Task 16
+  proof set against committed RED fixtures, with no API, wire, scheduling, or
+  request mutation change. **Ponytail Rung:** 2/5 — Task 15 observations,
+  existing recorder/metricRow/catalog/render matrix only.
+
+- 2026-08-01 GREEN candidate proof: `cargo test observation::tests --lib`
+  passed 17/17; the exact real-proxy quality E2E passed 1/1; Rust fixture
+  generation and verification passed 1/1 each with no fixture diff. The
+  69-row browser matrix and pseudolocale browser run passed; i18n passed 443
+  ids with 102/102 self-test controls, pseudolocale generated 443 messages,
+  and locale-v1 passed 19/19 self-test controls plus the production set. Full
+  Rust proof passed 191 unit, 112 E2E with one intentional ignore, and 7
+  OpenAPI tests; clippy, syntax, agent-guide, format, and diff checks passed.
+  The candidate is uncommitted and awaits independent review.
+
+- 2026-08-01 GREEN review/controller proof: independent review APPROVED with
+  no Critical, Important, or Minor finding. Controller fresh proof passed 17/17
+  observations, the 1/1 quality E2E, fixture generation/verification without
+  drift, 69 browser states/5 tabs/17 hovers plus pseudolocale, 443-id i18n and
+  en-XA, 19/19 locale controls, 191 unit, 112 E2E with one intentional ignore,
+  and 7 OpenAPI tests; clippy warnings-denied, syntax, agent-guide, format, and
+  diff controls are clean. The reviewed GREEN checkpoint is ready to commit.
+
 **Files:**
 
 - Modify: `src/proxy.rs`
@@ -4637,21 +4665,21 @@ node scripts/render_check.js --all-states
 
 Expected: the counter and honest UI states are absent.
 
-- [ ] **Step 3: Instrument at the classification boundary**
+- [x] **Step 3: Instrument at the classification boundary**
 
 Increment once per classified field/result at the point Task 15 produces an
 observation. Do not parse Prometheus text to drive Rust decisions. When the
 dashboard consumes its existing metrics payload, tolerate absent new series
 as unavailable for mixed-version fixture coverage.
 
-- [ ] **Step 4: Render quality and completeness separately**
+- [x] **Step 4: Render quality and completeness separately**
 
 Observation quality describes the upstream response; history completeness
 describes the persisted time window. Keep both states visible and independently
 testable. Standard English labels explain what is known without provider-
 specific claims.
 
-- [ ] **Step 5: Run proof**
+- [x] **Step 5: Run proof**
 
 ```sh
 cargo test observation::tests --lib
@@ -4666,13 +4694,13 @@ cargo fmt --check
 git diff --check
 ```
 
-- [ ] **Step 6: Ingest and review before commit**
+- [x] **Step 6: Ingest and review before commit**
 
 Document metric semantics, cardinality, dashboard interpretation, and the
 separation from history completeness. Review the exposition bytes, fixture
 authority, and all zero-vs-absent cases.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```sh
 git add src/proxy.rs src/api.rs src/lib.rs src/web/dashboard.js \

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -4535,6 +4535,57 @@ git commit -m "feat: validate NIM usage observations"
 
 **GitHub issue title:** `v0.6.6: expose usage observation quality`
 
+#### Execution record
+
+**Outcome:** a compile-stable RED checkpoint exposes the missing bounded usage
+observation counter, final accounting for aborted streams, and honest dashboard
+quality states without changing proxy or dashboard production behavior.
+**Proof:** the three named RED controls compile/start and fail at their literal
+counter, selector, or text assertions. **Constraint:** RED changes stay in the
+test/fixture/catalog/render surfaces; no counter registration, proxy recording,
+dashboard derivation, API field, or history behavior is implemented.
+**Ponytail Rung:** 2 — reuse Task 15 observations, the real-proxy E2E support,
+Rust-owned fixtures, the catalog, `metricRow` assertions, and the render matrix.
+
+- 2026-08-01 scope delta (Task 16 RED, manager preflight binding): add only
+  compile-stable regression controls and generated fixture data for the locked
+  `nimproxy_usage_observations_total{field="...",result="..."}` counter,
+  interrupted-stream finalization, present/missing observation-quality states,
+  and their independence from `window.complete`.  Every expected label, count,
+  selector, and English text is literal in its regression; no expectation is
+  derived from production helpers.  The smallest compile-only test seam may be
+  deliberately wrong only when required to reach its intended assertion.
+
+- 2026-08-01 RED Plan → Act → Verify: first record the production mutations
+  caught by each regression in test comments and the task report; then add the
+  minimal observer/E2E/render controls plus Rust-generated UI fixture states.
+  Run the exact named RED commands until each fails at missing counter or
+  quality behavior rather than setup, fixture, catalog, syntax, or cleanup.
+  Run fixture generation then non-mutating verification, catalog/pseudolocale,
+  syntax, format, and diff checks; commit only this RED checkpoint.
+
+- 2026-08-01 RED review fix 1/5 Plan → Act → Verify: strengthen the RED
+  controls to exact observation exposition lines, HELP/TYPE, closed label
+  schema, and completed/aborted/excluded finalization boundaries; add
+  Rust-generated dashboard states for zero/absent/tied/live-tail quality and
+  exact `metricRow` order/tone. Verify the same three named RED commands still
+  reach only absent instrumentation or missing health-row assertions, then
+  regenerate/verify fixtures and rerun catalog, pseudolocale, syntax, format,
+  and diff controls. No production mapping, counter, proxy path, API field, or
+  dashboard rendering is added.
+
+- 2026-08-01 RED review fix 2/5 Plan → Act → Verify: bind the HELP wording to
+  the frozen counter contract and select all TYPE declarations by family prefix
+  before asserting the one exact counter declaration. Verify only the focused
+  E2E RED check plus formatting and diff controls; no fixture, catalog, or
+  production behavior changes.
+
+- 2026-08-01 RED review/controller proof: independent review is clean after
+  fix 2/5. Controller reran the four literal-empty mapping controls, the exact
+  HELP-absence E2E, and the missing quality-row browser check; fixture,
+  interaction, locale, syntax, format, and diff controls are clean. RED Gate
+  OPEN for this checkpoint commit; no GREEN step is complete.
+
 **Files:**
 
 - Modify: `src/proxy.rs`
@@ -4570,13 +4621,13 @@ nimproxy_usage_observations_total{field="...",result="..."}
   incomplete-history states. Missing/invalid values are gaps or explicit
   states, never zeros. Machine ids and metric values remain untouched.
 
-- [ ] **Step 1: Add metric and UI failures**
+- [x] **Step 1: Add metric and UI failures**
 
 Assert exact Prometheus exposition names, label order/values, counter changes
 for every observation class, cardinality bound, and absence of request data.
 Add browser states where each class dominates and where history is incomplete.
 
-- [ ] **Step 2: Observe the red proof**
+- [x] **Step 2: Observe the red proof**
 
 ```sh
 cargo test observation::tests::observation_metric_ --lib -- --nocapture

--- a/knowledge/architecture/dashboard.md
+++ b/knowledge/architecture/dashboard.md
@@ -180,6 +180,21 @@ available history but with no usable points says **History unavailable for
 selected time range**. No global history remains **No data yet**. These states
 are catalog-owned; absent observations never become zeros.
 
+Overview's **Observation quality** health row reads the existing generic
+`nimproxy_usage_observations_total` rows from the selected range's final
+cumulative sample, including only a revision-matching live tail already
+accepted by `rangeSamples()`. It recognizes only the five fixed field labels
+and four fixed result labels, ignores non-finite or negative values, and keeps
+recognized-row presence separate from totals so the synthetic zero baseline
+cannot invent telemetry. No recognized row is **Unavailable**; recognized rows
+whose aggregate is zero are **No observations**. Otherwise the greatest result
+total wins, with conservative ties `invalid`, `unavailable`, `estimated`, then
+`measured`. Invalid is critical, unavailable/estimated warn, measured is
+normal, and no-observations uses the zero tone. This response-quality signal is
+independent from `window.complete`: **Partial history** and **Measured** may
+appear together. Its counter semantics live in
+[NIM observations](nim-observations.md).
+
 **Notable derivations, worth recording so they aren't rediscovered:**
 
 - **Delta chips** (the `+8.2%`-style pill on every KPI card) compare the

--- a/knowledge/architecture/metrics-history.md
+++ b/knowledge/architecture/metrics-history.md
@@ -148,7 +148,12 @@ capacity average: the unavailable prefix is not treated as observed time.
 generation lock. It returns current typed metrics plus a tail whose totals are
 the counter delta after the persisted baseline. The tail carries
 `base_history_revision`; the browser accepts it only alongside the matching
-range revision, so a newly persisted sample cannot be double-counted.
+range revision, so a newly persisted sample cannot be double-counted. The
+bounded `nimproxy_usage_observations_total` counter is ordinary generic
+counter state: history preserves its exact field/result rows without a special
+API field, while the dashboard's response-quality derivation ignores
+non-finite/negative rows and only reads a revision-matching live tail. See
+[NIM observations](nim-observations.md) and [Dashboard](dashboard.md).
 
 ## Retention and durability
 

--- a/knowledge/architecture/nim-observations.md
+++ b/knowledge/architecture/nim-observations.md
@@ -47,8 +47,22 @@ raw event body is retained after classification.
 
 The proxy records only finalized measured prompt/reasoning/tool/finish values
 and measured or estimated completion using its existing metric names and
-labels. Invalid/unavailable values are omitted. Total and cached have no
-existing metric. See the [streaming pipeline](streaming-pipeline.md),
-[usage injection decision](../decisions/usage-injection-auto-fallback.md),
+labels. Invalid/unavailable values are omitted there. Total and cached have no
+existing token metric.
+
+Every finalized response also emits exactly five
+`nimproxy_usage_observations_total` counter outcomes, one for each fixed field
+(`prompt_tokens`, `completion_tokens`, `total_tokens`, `cached_tokens`, and
+`reasoning_tokens`) with one closed result label (`measured`, `estimated`,
+`unavailable`, or `invalid`). The canonical observation-owned mapping is the
+only classification-to-counter boundary, so it neither reparses response bytes
+nor repeats an SSE event. Its maximum cardinality is 20 series and it carries
+no request, model, client, provider, or upstream-content label. Successful
+buffered and completed streams use their final typed values; disconnect,
+truncation, idle cutoff, and unterminated completed SSE all finalize five
+unavailable outcomes before the proxy preserves their existing request/error
+behavior. Rejected/retried responses and failed buffered body reads have no
+final observed body and emit none. See the [streaming pipeline](streaming-pipeline.md),
+[metrics history](metrics-history.md), [usage injection decision](../decisions/usage-injection-auto-fallback.md),
 [capture runbook](../ops/nim-response-capture.md), and
 [test strategy](../testing/test-strategy.md).

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,21 @@ description: Append-only record of ingests, decisions, and maintenance passes.
 
 # Log
 
+## [2026-08-01] component — bounded finalized usage-observation quality
+
+Task 16 adds the private, fixed-cardinality
+`nimproxy_usage_observations_total{field,result}` counter at the Task 15
+finalization boundary. Each successful observed response or finalized stream
+exit contributes exactly five closed outcomes; retries, rejected responses,
+and failed body reads contribute none. The Overview derives one catalog-backed
+quality row from recognized finite nonnegative selected-range/tail rows without
+inventing presence from a synthetic zero baseline: absent is Unavailable,
+observed zero is No observations, and positive ties favor invalid,
+unavailable, estimated, then measured. History completeness remains separate.
+See [NIM observations](architecture/nim-observations.md),
+[Dashboard](architecture/dashboard.md), [metrics history](architecture/metrics-history.md),
+and [test strategy](testing/test-strategy.md).
+
 ## [2026-08-01] component — bounded typed NIM response observations
 
 Task 15 replaces the separate buffered shortcuts and `SseScan` with one private

--- a/knowledge/testing/test-strategy.md
+++ b/knowledge/testing/test-strategy.md
@@ -161,7 +161,12 @@ that proof.
   bounded-memory, truncation, finish, tool, and estimator boundaries. `cargo
   test --test e2e observation_preserves_upstream_bytes -- --exact` proves the
   real proxy preserves fixture body/status/content-type behavior while invalid
-  reasoning is omitted from existing metrics. `python3 scripts/capture_nim.py --selftest`
+  reasoning is omitted from existing metrics. `cargo test --test e2e
+  dashboard_observation_quality_is_honest -- --exact` additionally locks the
+  exact bounded usage-observation exposition, successful and abort finalizers,
+  and excluded retry/non-success paths; `node scripts/render_check.js
+  --all-states` locks the catalog-backed absent/zero/dominance/tie/live-tail
+  quality row independently from history completeness. `python3 scripts/capture_nim.py --selftest`
   exercises environment/URL/profile policy, exact request caps, HTTP/1.0 and
   TLS lifecycles, secret-free diagnostics, owner-only descriptor-contained
   publication, and failure cleanup without a service. `python3

--- a/scripts/render_check.js
+++ b/scripts/render_check.js
@@ -43,6 +43,10 @@ const PRESENTATION_CSP = "default-src 'none'; img-src 'self' data:; style-src 's
  * reports each missing row by stable id.
  */
 const INTERACTION_ROWS = [
+  /* Mutation caught by the observation-quality state rows below: rendering
+     absent/invalid observations as zero, omitting a closed result state, or
+     coupling that state to history-window completeness. The expected health
+     row text is literal catalog English, not a dashboard helper result. */
   {
     id: 'startup-dashboard-healthy',
     category: 'startup',
@@ -803,6 +807,83 @@ const INTERACTION_ROWS = [
     visual: [{ case: 'dashboard-partial-incomplete', locales: ['en-US', 'en-XA'], roles: ['superuser'], surfaces: ['dashboard-tabs'] }],
   },
   {
+    id: 'state-observation-measured',
+    category: 'state',
+    state: 'observation-measured',
+    action: 'fulfill the dashboard range from the measured-observation Rust fixture',
+    visible: 'the health row says Measured without a numeric quality zero',
+  },
+  {
+    id: 'state-observation-estimated',
+    category: 'state',
+    state: 'observation-estimated',
+    action: 'fulfill the dashboard range from the estimated-observation Rust fixture',
+    visible: 'the health row says Estimated without a numeric quality zero',
+  },
+  {
+    id: 'state-observation-unavailable',
+    category: 'state',
+    state: 'observation-unavailable',
+    action: 'fulfill the dashboard range from the unavailable-observation Rust fixture',
+    visible: 'the health row says Unavailable rather than zero',
+  },
+  {
+    id: 'state-observation-invalid',
+    category: 'state',
+    state: 'observation-invalid',
+    action: 'fulfill the dashboard range from the invalid-observation Rust fixture',
+    visible: 'the health row says Invalid rather than zero',
+  },
+  {
+    id: 'state-observation-incomplete-history',
+    category: 'state',
+    state: 'observation-measured-history-incomplete',
+    action: 'fulfill the dashboard range from measured observations with incomplete history',
+    visible: 'Measured observation quality and Partial history remain independently visible',
+  },
+  {
+    id: 'state-observation-zero',
+    category: 'state',
+    state: 'observation-zero',
+    action: 'fulfill the dashboard range from the zero-observation Rust fixture',
+    visible: 'recognized zero observations say No observations rather than an unavailable quality',
+  },
+  {
+    id: 'state-observation-absent',
+    category: 'state',
+    state: 'observation-absent',
+    action: 'fulfill the dashboard range with no recognized observation rows',
+    visible: 'absent observation rows say Unavailable rather than zero',
+  },
+  {
+    id: 'state-observation-tie-invalid',
+    category: 'state',
+    state: 'observation-tie-invalid',
+    action: 'fulfill tied observation results including invalid from the Rust fixture',
+    visible: 'Invalid wins a positive result tie',
+  },
+  {
+    id: 'state-observation-tie-unavailable',
+    category: 'state',
+    state: 'observation-tie-unavailable',
+    action: 'fulfill tied observation results including unavailable from the Rust fixture',
+    visible: 'Unavailable wins a positive result tie without invalid',
+  },
+  {
+    id: 'state-observation-tie-estimated',
+    category: 'state',
+    state: 'observation-tie-estimated',
+    action: 'fulfill tied estimated and measured observations from the Rust fixture',
+    visible: 'Estimated wins a positive result tie without invalid or unavailable',
+  },
+  {
+    id: 'state-observation-live-tail',
+    category: 'state',
+    state: 'observation-live-tail',
+    action: 'append a valid observation row and an ignored negative row through the live dashboard tail',
+    visible: 'the valid live-tail result renders while the negative row does not become Invalid',
+  },
+  {
     id: 'state-history-unavailable',
     category: 'state',
     state: 'history-unavailable',
@@ -1488,6 +1569,64 @@ const DOM_CONTRACTS = {
       })()`,
       true),
   ],
+  'state-observation-measured': [
+    domContract('measured-observation-quality',
+      `(() => { const rows = Array.from(document.querySelectorAll('#o-health .kv')); const row = rows.filter(row => row.textContent.trim() === 'Observation qualityMeasured'); const queued = rows.findIndex(row => row.textContent.trim() === 'Queued1'); return queued >= 0 && row.length === 1 && rows[queued + 1] === row[0] && row[0].className === 'kv'; })()`,
+      true),
+  ],
+  'state-observation-estimated': [
+    domContract('estimated-observation-quality',
+      `(() => { const rows = Array.from(document.querySelectorAll('#o-health .kv')); const row = rows.filter(row => row.textContent.trim() === 'Observation qualityEstimated'); const queued = rows.findIndex(row => row.textContent.trim() === 'Queued1'); return queued >= 0 && row.length === 1 && rows[queued + 1] === row[0] && row[0].className === 'kv warn'; })()`,
+      true),
+  ],
+  'state-observation-unavailable': [
+    domContract('unavailable-observation-quality-is-not-zero',
+      `(() => { const rows = Array.from(document.querySelectorAll('#o-health .kv')); const row = rows.filter(row => row.textContent.trim() === 'Observation qualityUnavailable'); const queued = rows.findIndex(row => row.textContent.trim() === 'Queued1'); return queued >= 0 && row.length === 1 && rows[queued + 1] === row[0] && row[0].className === 'kv warn'; })()`,
+      true),
+  ],
+  'state-observation-invalid': [
+    domContract('invalid-observation-quality-is-not-zero',
+      `(() => { const rows = Array.from(document.querySelectorAll('#o-health .kv')); const row = rows.filter(row => row.textContent.trim() === 'Observation qualityInvalid'); const queued = rows.findIndex(row => row.textContent.trim() === 'Queued1'); return queued >= 0 && row.length === 1 && rows[queued + 1] === row[0] && row[0].className === 'kv crit'; })()`,
+      true),
+  ],
+  'state-observation-incomplete-history': [
+    domContract('measured-quality-survives-incomplete-history',
+      `(() => { const rows = Array.from(document.querySelectorAll('#o-health .kv')); const row = rows.filter(row => row.textContent.trim() === 'Observation qualityMeasured'); const queued = rows.findIndex(row => row.textContent.trim() === 'Queued1'); return queued >= 0 && row.length === 1 && rows[queued + 1] === row[0] && row[0].className === 'kv'; })()`,
+      true),
+    domContract('incomplete-history-remains-separate',
+      `document.querySelector('#rangeinfo')?.textContent.includes('Partial history ·') ?? false`,
+      true),
+  ],
+  'state-observation-zero': [
+    domContract('zero-observation-quality-is-no-observations',
+      `(() => { const rows = Array.from(document.querySelectorAll('#o-health .kv')); const row = rows.filter(row => row.textContent.trim() === 'Observation qualityNo observations'); const queued = rows.findIndex(row => row.textContent.trim() === 'Queued1'); return queued >= 0 && row.length === 1 && rows[queued + 1] === row[0] && row[0].className === 'kv zero'; })()`,
+      true),
+  ],
+  'state-observation-absent': [
+    domContract('absent-observation-quality-is-unavailable',
+      `(() => { const rows = Array.from(document.querySelectorAll('#o-health .kv')); const row = rows.filter(row => row.textContent.trim() === 'Observation qualityUnavailable'); const queued = rows.findIndex(row => row.textContent.trim() === 'Queued1'); return queued >= 0 && row.length === 1 && rows[queued + 1] === row[0] && row[0].className === 'kv warn'; })()`,
+      true),
+  ],
+  'state-observation-tie-invalid': [
+    domContract('invalid-wins-observation-quality-tie',
+      `(() => { const rows = Array.from(document.querySelectorAll('#o-health .kv')); const row = rows.filter(row => row.textContent.trim() === 'Observation qualityInvalid'); const queued = rows.findIndex(row => row.textContent.trim() === 'Queued1'); return queued >= 0 && row.length === 1 && rows[queued + 1] === row[0] && row[0].className === 'kv crit'; })()`,
+      true),
+  ],
+  'state-observation-tie-unavailable': [
+    domContract('unavailable-wins-observation-quality-tie',
+      `(() => { const rows = Array.from(document.querySelectorAll('#o-health .kv')); const row = rows.filter(row => row.textContent.trim() === 'Observation qualityUnavailable'); const queued = rows.findIndex(row => row.textContent.trim() === 'Queued1'); return queued >= 0 && row.length === 1 && rows[queued + 1] === row[0] && row[0].className === 'kv warn'; })()`,
+      true),
+  ],
+  'state-observation-tie-estimated': [
+    domContract('estimated-wins-observation-quality-tie',
+      `(() => { const rows = Array.from(document.querySelectorAll('#o-health .kv')); const row = rows.filter(row => row.textContent.trim() === 'Observation qualityEstimated'); const queued = rows.findIndex(row => row.textContent.trim() === 'Queued1'); return queued >= 0 && row.length === 1 && rows[queued + 1] === row[0] && row[0].className === 'kv warn'; })()`,
+      true),
+  ],
+  'state-observation-live-tail': [
+    domContract('live-tail-observation-quality-ignores-negative-row',
+      `(() => { const rows = Array.from(document.querySelectorAll('#o-health .kv')); const row = rows.filter(row => row.textContent.trim() === 'Observation qualityEstimated'); const queued = rows.findIndex(row => row.textContent.trim() === 'Queued1'); return queued >= 0 && row.length === 1 && rows[queued + 1] === row[0] && row[0].className === 'kv warn'; })()`,
+      true),
+  ],
   'state-history-unavailable': [
     domContract('unavailable-range-message', `document.querySelector('#rangeinfo')?.textContent.trim() ?? null`, 'History unavailable for selected time range'),
   ],
@@ -1639,6 +1778,61 @@ const EXPLICIT_REQUEST_SEQUENCES = {
       from: '1697411600',
       points: '288',
       to: '1700003600',
+    }),
+  ],
+  'state-observation-measured': [
+    getRequest('/api/dashboard', {
+      from: '1697411600', points: '288', to: '1700003600',
+    }),
+  ],
+  'state-observation-estimated': [
+    getRequest('/api/dashboard', {
+      from: '1697411600', points: '288', to: '1700003600',
+    }),
+  ],
+  'state-observation-unavailable': [
+    getRequest('/api/dashboard', {
+      from: '1697411600', points: '288', to: '1700003600',
+    }),
+  ],
+  'state-observation-invalid': [
+    getRequest('/api/dashboard', {
+      from: '1697411600', points: '288', to: '1700003600',
+    }),
+  ],
+  'state-observation-incomplete-history': [
+    getRequest('/api/dashboard', {
+      from: '1697411600', points: '288', to: '1700003600',
+    }),
+  ],
+  'state-observation-zero': [
+    getRequest('/api/dashboard', {
+      from: '1697411600', points: '288', to: '1700003600',
+    }),
+  ],
+  'state-observation-absent': [
+    getRequest('/api/dashboard', {
+      from: '1697411600', points: '288', to: '1700003600',
+    }),
+  ],
+  'state-observation-tie-invalid': [
+    getRequest('/api/dashboard', {
+      from: '1697411600', points: '288', to: '1700003600',
+    }),
+  ],
+  'state-observation-tie-unavailable': [
+    getRequest('/api/dashboard', {
+      from: '1697411600', points: '288', to: '1700003600',
+    }),
+  ],
+  'state-observation-tie-estimated': [
+    getRequest('/api/dashboard', {
+      from: '1697411600', points: '288', to: '1700003600',
+    }),
+  ],
+  'state-observation-live-tail': [
+    getRequest('/api/dashboard', {
+      from: '1697411600', points: '288', to: '1700003600',
     }),
   ],
   'state-history-unavailable': [
@@ -1969,6 +2163,52 @@ const FIXTURE_SCENARIOS = {
   'state-partial-incomplete': dashboardRecipe({
     now: 'scenarios.json#dashboard-now-partial',
     range: 'dashboard-partial.json',
+    boundary: 'startup-dashboard-range',
+  }),
+  'state-observation-measured': dashboardRecipe({
+    range: 'dashboard-observation-measured.json',
+    boundary: 'startup-dashboard-range',
+  }),
+  'state-observation-estimated': dashboardRecipe({
+    range: 'dashboard-observation-estimated.json',
+    boundary: 'startup-dashboard-range',
+  }),
+  'state-observation-unavailable': dashboardRecipe({
+    range: 'dashboard-observation-unavailable.json',
+    boundary: 'startup-dashboard-range',
+  }),
+  'state-observation-invalid': dashboardRecipe({
+    range: 'dashboard-observation-invalid.json',
+    boundary: 'startup-dashboard-range',
+  }),
+  'state-observation-incomplete-history': dashboardRecipe({
+    now: 'scenarios.json#dashboard-now-partial',
+    range: 'dashboard-observation-incomplete.json',
+    boundary: 'startup-dashboard-range',
+  }),
+  'state-observation-zero': dashboardRecipe({
+    range: 'dashboard-observation-zero.json',
+    boundary: 'startup-dashboard-range',
+  }),
+  'state-observation-absent': dashboardRecipe({
+    range: 'dashboard-observation-absent.json',
+    boundary: 'startup-dashboard-range',
+  }),
+  'state-observation-tie-invalid': dashboardRecipe({
+    range: 'dashboard-observation-tie-invalid.json',
+    boundary: 'startup-dashboard-range',
+  }),
+  'state-observation-tie-unavailable': dashboardRecipe({
+    range: 'dashboard-observation-tie-unavailable.json',
+    boundary: 'startup-dashboard-range',
+  }),
+  'state-observation-tie-estimated': dashboardRecipe({
+    range: 'dashboard-observation-tie-estimated.json',
+    boundary: 'startup-dashboard-range',
+  }),
+  'state-observation-live-tail': dashboardRecipe({
+    now: 'dashboard-now-observation-tail.json',
+    range: 'dashboard-observation-absent.json',
     boundary: 'startup-dashboard-range',
   }),
   'state-history-unavailable': dashboardRecipe({

--- a/src/api.rs
+++ b/src/api.rs
@@ -816,6 +816,23 @@ mod tests {
                 10_240.0,
             ),
         ];
+        values.extend(
+            [
+                "prompt_tokens",
+                "completion_tokens",
+                "total_tokens",
+                "cached_tokens",
+                "reasoning_tokens",
+            ]
+            .into_iter()
+            .map(|field| {
+                labeled_metric(
+                    "nimproxy_usage_observations_total",
+                    &[("field", field), ("result", "measured")],
+                    10.0,
+                )
+            }),
+        );
         for metric in &mut values {
             metric.value = fixture_delta(metric.value, segment, metric.metric.ends_with("_sum"));
         }
@@ -845,6 +862,29 @@ mod tests {
             histogram_samples("nimproxy_queue_wait_seconds", segment),
         ));
         values
+    }
+
+    fn observation_quality_fixture_metrics(results: &[(&str, f64)]) -> Vec<MetricValue> {
+        results
+            .iter()
+            .flat_map(|(result, value)| {
+                [
+                    "prompt_tokens",
+                    "completion_tokens",
+                    "total_tokens",
+                    "cached_tokens",
+                    "reasoning_tokens",
+                ]
+                .into_iter()
+                .map(move |field| {
+                    labeled_metric(
+                        "nimproxy_usage_observations_total",
+                        &[("field", field), ("result", result)],
+                        *value,
+                    )
+                })
+            })
+            .collect()
     }
 
     fn assert_representative_metrics_are_production_faithful(range: &DashboardResponse) {
@@ -972,13 +1012,32 @@ mod tests {
 
     fn dashboard_ui_fixture(kind: &str) -> DashboardResponse {
         let empty = kind == "empty";
-        let partial = kind == "partial";
+        let partial = kind == "partial" || kind == "observation-incomplete";
         let unavailable = kind == "unavailable";
         let outside_before = kind == "outside-before";
         let outside_after = kind == "outside-after";
         let extreme = kind == "extreme";
         let long = kind == "long";
-        let values = if empty || unavailable || outside_before || outside_after {
+        let observation_results: Option<&[(&str, f64)]> = match kind {
+            "observation-estimated" => Some(&[("estimated", 9.0)]),
+            "observation-unavailable" => Some(&[("unavailable", 9.0)]),
+            "observation-invalid" => Some(&[("invalid", 9.0)]),
+            "observation-incomplete" | "observation-measured" => Some(&[("measured", 9.0)]),
+            "observation-zero" => Some(&[("measured", 0.0)]),
+            "observation-tie-invalid" => Some(&[
+                ("invalid", 9.0),
+                ("unavailable", 9.0),
+                ("estimated", 9.0),
+                ("measured", 9.0),
+            ]),
+            "observation-tie-unavailable" => {
+                Some(&[("unavailable", 9.0), ("estimated", 9.0), ("measured", 9.0)])
+            }
+            "observation-tie-estimated" => Some(&[("estimated", 9.0), ("measured", 9.0)]),
+            _ => None,
+        };
+        let observation_absent = kind == "observation-absent";
+        let mut values = if empty || unavailable || outside_before || outside_after {
             Vec::new()
         } else if long {
             let client = format!("client-fixture-{}", "c".repeat(49));
@@ -1007,6 +1066,12 @@ mod tests {
                 representative_dashboard_metrics(FixtureSegment::All)
             }
         };
+        if observation_absent || observation_results.is_some() {
+            values.retain(|metric| metric.metric != "nimproxy_usage_observations_total");
+            if let Some(results) = observation_results {
+                values.extend(observation_quality_fixture_metrics(results));
+            }
+        }
         let available_from = if partial {
             1_699_913_600
         } else {
@@ -1044,7 +1109,7 @@ mod tests {
         };
         let points = if empty || unavailable || outside_before || outside_after {
             Vec::new()
-        } else if extreme || long {
+        } else if extreme || long || observation_absent || observation_results.is_some() {
             vec![point(effective_from, effective_to, values.clone())]
         } else {
             let midpoint = effective_from + (effective_to - effective_from) / 2;
@@ -1480,6 +1545,28 @@ mod tests {
         response
     }
 
+    fn dashboard_now_observation_tail_ui_fixture() -> DashboardNowResponse {
+        let mut response = dashboard_now_ui_fixture(false);
+        response
+            .metrics
+            .retain(|metric| metric.metric != "nimproxy_usage_observations_total");
+        response.tail.from = Some(1_700_003_600);
+        response.tail.to = 1_700_007_200;
+        response.tail.totals = vec![
+            labeled_metric(
+                "nimproxy_usage_observations_total",
+                &[("field", "completion_tokens"), ("result", "estimated")],
+                7.0,
+            ),
+            labeled_metric(
+                "nimproxy_usage_observations_total",
+                &[("field", "prompt_tokens"), ("result", "invalid")],
+                -1.0,
+            ),
+        ];
+        response
+    }
+
     fn assert_dashboard_pair(label: &str, range: &DashboardResponse, now: &DashboardNowResponse) {
         assert_eq!(
             range.history_revision, now.history_revision,
@@ -1530,6 +1617,7 @@ mod tests {
         let changed_now = dashboard_now_ui_fixture(true);
         let empty_now = dashboard_now_empty_ui_fixture();
         let partial_now = dashboard_now_partial_ui_fixture();
+        let observation_tail_now = dashboard_now_observation_tail_ui_fixture();
         let healthy_range = dashboard_ui_fixture("healthy");
         assert_representative_metrics_are_production_faithful(&healthy_range);
         let metric_inventory: std::collections::BTreeSet<_> = healthy_range
@@ -1582,6 +1670,7 @@ mod tests {
             "nimproxy_upstream_seconds_bucket",
             "nimproxy_upstream_seconds_count",
             "nimproxy_upstream_seconds_sum",
+            "nimproxy_usage_observations_total",
             "nimproxy_worker_exhausted_total",
         ]);
         assert_eq!(
@@ -1615,6 +1704,61 @@ mod tests {
             ("extreme", dashboard_ui_fixture("extreme"), &initial_now),
             ("long", dashboard_ui_fixture("long"), &initial_now),
             (
+                "observation-measured",
+                dashboard_ui_fixture("observation-measured"),
+                &initial_now,
+            ),
+            (
+                "observation-estimated",
+                dashboard_ui_fixture("observation-estimated"),
+                &initial_now,
+            ),
+            (
+                "observation-unavailable",
+                dashboard_ui_fixture("observation-unavailable"),
+                &initial_now,
+            ),
+            (
+                "observation-invalid",
+                dashboard_ui_fixture("observation-invalid"),
+                &initial_now,
+            ),
+            (
+                "observation-incomplete",
+                dashboard_ui_fixture("observation-incomplete"),
+                &partial_now,
+            ),
+            (
+                "observation-zero",
+                dashboard_ui_fixture("observation-zero"),
+                &initial_now,
+            ),
+            (
+                "observation-absent",
+                dashboard_ui_fixture("observation-absent"),
+                &initial_now,
+            ),
+            (
+                "observation-tie-invalid",
+                dashboard_ui_fixture("observation-tie-invalid"),
+                &initial_now,
+            ),
+            (
+                "observation-tie-unavailable",
+                dashboard_ui_fixture("observation-tie-unavailable"),
+                &initial_now,
+            ),
+            (
+                "observation-tie-estimated",
+                dashboard_ui_fixture("observation-tie-estimated"),
+                &initial_now,
+            ),
+            (
+                "observation-live-tail",
+                dashboard_ui_fixture("observation-absent"),
+                &observation_tail_now,
+            ),
+            (
                 "one-hour",
                 dashboard_window_ui_fixture(1_700_000_000, 1_700_003_600),
                 &initial_now,
@@ -1627,6 +1771,22 @@ mod tests {
         ] {
             assert_dashboard_pair(label, &range, now);
         }
+        assert_eq!(
+            observation_tail_now.tail.totals,
+            vec![
+                labeled_metric(
+                    "nimproxy_usage_observations_total",
+                    &[("field", "completion_tokens"), ("result", "estimated")],
+                    7.0,
+                ),
+                labeled_metric(
+                    "nimproxy_usage_observations_total",
+                    &[("field", "prompt_tokens"), ("result", "invalid")],
+                    -1.0,
+                ),
+            ],
+            "ui-fixture: live tail contains one valid quality row and one ignored negative row"
+        );
         let partial_range = dashboard_ui_fixture("partial");
         let unavailable_range = dashboard_ui_fixture("unavailable");
         let unavailable_from = unavailable_range
@@ -1946,6 +2106,10 @@ mod tests {
                 serde_json::to_value(dashboard_now_ui_fixture(false)).unwrap(),
             ),
             (
+                "dashboard-now-observation-tail.json",
+                serde_json::to_value(dashboard_now_observation_tail_ui_fixture()).unwrap(),
+            ),
+            (
                 "dashboard-partial.json",
                 serde_json::to_value(dashboard_ui_fixture("partial")).unwrap(),
             ),
@@ -1960,6 +2124,46 @@ mod tests {
             (
                 "dashboard-unavailable.json",
                 serde_json::to_value(dashboard_ui_fixture("unavailable")).unwrap(),
+            ),
+            (
+                "dashboard-observation-estimated.json",
+                serde_json::to_value(dashboard_ui_fixture("observation-estimated")).unwrap(),
+            ),
+            (
+                "dashboard-observation-incomplete.json",
+                serde_json::to_value(dashboard_ui_fixture("observation-incomplete")).unwrap(),
+            ),
+            (
+                "dashboard-observation-invalid.json",
+                serde_json::to_value(dashboard_ui_fixture("observation-invalid")).unwrap(),
+            ),
+            (
+                "dashboard-observation-measured.json",
+                serde_json::to_value(dashboard_ui_fixture("observation-measured")).unwrap(),
+            ),
+            (
+                "dashboard-observation-unavailable.json",
+                serde_json::to_value(dashboard_ui_fixture("observation-unavailable")).unwrap(),
+            ),
+            (
+                "dashboard-observation-zero.json",
+                serde_json::to_value(dashboard_ui_fixture("observation-zero")).unwrap(),
+            ),
+            (
+                "dashboard-observation-absent.json",
+                serde_json::to_value(dashboard_ui_fixture("observation-absent")).unwrap(),
+            ),
+            (
+                "dashboard-observation-tie-invalid.json",
+                serde_json::to_value(dashboard_ui_fixture("observation-tie-invalid")).unwrap(),
+            ),
+            (
+                "dashboard-observation-tie-unavailable.json",
+                serde_json::to_value(dashboard_ui_fixture("observation-tie-unavailable")).unwrap(),
+            ),
+            (
+                "dashboard-observation-tie-estimated.json",
+                serde_json::to_value(dashboard_ui_fixture("observation-tie-estimated")).unwrap(),
             ),
             (
                 "locale-bootstrap.json",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,6 +536,10 @@ pub async fn run() {
             .unwrap();
     }
     let prometheus = builder.install_recorder().expect("prometheus recorder");
+    metrics::describe_counter!(
+        "nimproxy_usage_observations_total",
+        "Final classified upstream usage observations by field and result."
+    );
 
     let pool: PoolHandle = Arc::new(RwLock::new(Arc::new(Pool::new(pool_specs))));
 

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -26,6 +26,21 @@ pub(crate) struct ResponseObservations {
     pub(crate) usage: UsageObservations,
 }
 
+#[cfg(test)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct UsageObservationMetric {
+    pub(crate) field: &'static str,
+    pub(crate) result: &'static str,
+}
+
+/// Task 16 RED seam. The deliberately empty result lets the regression state
+/// the locked, bounded mapping before the counter is implemented at the proxy
+/// classification boundary.
+#[cfg(test)]
+pub(crate) fn usage_observation_metrics(_usage: &UsageObservations) -> Vec<UsageObservationMetric> {
+    Vec::new()
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct FinishObservation {
     pub(crate) choice_index: u64,
@@ -528,9 +543,165 @@ fn unavailable_usage() -> UsageObservations {
 #[cfg(test)]
 mod tests {
     use super::{
-        observe_buffered, FinishObservation, FinishReason, FinishResult, Observation,
-        ResponseObservations, SseObserver, StreamOutcome,
+        observe_buffered, usage_observation_metrics, FinishObservation, FinishReason, FinishResult,
+        Observation, ResponseObservations, SseObserver, StreamOutcome, UsageObservationMetric,
+        UsageObservations,
     };
+
+    #[test]
+    fn observation_metric_records_each_final_usage_result_with_closed_labels() {
+        // Mutation caught: omitting the Task 16 counter, or emitting a raw
+        // response/request value instead of one final bounded field/result pair.
+        let usage = UsageObservations {
+            prompt_tokens: Observation::Measured(0),
+            completion_tokens: Observation::Estimated(3),
+            total_tokens: Observation::Invalid,
+            cached_tokens: Observation::Unavailable,
+            reasoning_tokens: Observation::Measured(2),
+        };
+
+        assert_eq!(
+            usage_observation_metrics(&usage),
+            vec![
+                UsageObservationMetric {
+                    field: "prompt_tokens",
+                    result: "measured"
+                },
+                UsageObservationMetric {
+                    field: "completion_tokens",
+                    result: "estimated"
+                },
+                UsageObservationMetric {
+                    field: "total_tokens",
+                    result: "invalid"
+                },
+                UsageObservationMetric {
+                    field: "cached_tokens",
+                    result: "unavailable"
+                },
+                UsageObservationMetric {
+                    field: "reasoning_tokens",
+                    result: "measured"
+                },
+            ],
+            "nimproxy_usage_observations_total must have only literal field/result labels"
+        );
+    }
+
+    #[test]
+    fn observation_metric_finalizes_disconnected_stream_as_unavailable() {
+        // Mutation caught: discarding the finalized observer result on a
+        // client disconnect instead of counting all five unavailable fields.
+        let mut observer = SseObserver::default();
+        observer.push(b"data: {\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":2}}\n\n");
+        let usage = observer.finish(StreamOutcome::Disconnected).usage;
+
+        assert_eq!(
+            usage_observation_metrics(&usage),
+            vec![
+                UsageObservationMetric {
+                    field: "prompt_tokens",
+                    result: "unavailable"
+                },
+                UsageObservationMetric {
+                    field: "completion_tokens",
+                    result: "unavailable"
+                },
+                UsageObservationMetric {
+                    field: "total_tokens",
+                    result: "unavailable"
+                },
+                UsageObservationMetric {
+                    field: "cached_tokens",
+                    result: "unavailable"
+                },
+                UsageObservationMetric {
+                    field: "reasoning_tokens",
+                    result: "unavailable"
+                },
+            ],
+            "a disconnected stream has five final unavailable observations"
+        );
+    }
+
+    #[test]
+    fn observation_metric_records_successful_buffered_usage_as_measured() {
+        // Mutation caught: bypassing final counter accounting for a successful
+        // buffered response, including the zero-valued measured observation.
+        let usage = observe_buffered(
+            br#"{"usage":{"prompt_tokens":0,"completion_tokens":2,"total_tokens":2,"prompt_tokens_details":{"cached_tokens":0},"completion_tokens_details":{"reasoning_tokens":1}}}"#,
+        )
+        .usage;
+
+        assert_eq!(
+            usage_observation_metrics(&usage),
+            vec![
+                UsageObservationMetric {
+                    field: "prompt_tokens",
+                    result: "measured"
+                },
+                UsageObservationMetric {
+                    field: "completion_tokens",
+                    result: "measured"
+                },
+                UsageObservationMetric {
+                    field: "total_tokens",
+                    result: "measured"
+                },
+                UsageObservationMetric {
+                    field: "cached_tokens",
+                    result: "measured"
+                },
+                UsageObservationMetric {
+                    field: "reasoning_tokens",
+                    result: "measured"
+                },
+            ],
+            "a successful buffered response finalizes all five usage fields"
+        );
+    }
+
+    #[test]
+    fn observation_metric_finalizes_truncated_or_unterminated_stream_as_unavailable() {
+        // Mutation caught: treating an upstream truncation or nominal EOF with
+        // an unterminated SSE event as a completed measured observation.
+        for outcome in [StreamOutcome::Truncated, StreamOutcome::Completed] {
+            let mut observer = SseObserver::default();
+            let event = if outcome == StreamOutcome::Truncated {
+                b"data: {\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":2}}\n\n".as_slice()
+            } else {
+                b"data: {\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":2}}".as_slice()
+            };
+            observer.push(event);
+
+            assert_eq!(
+                usage_observation_metrics(&observer.finish(outcome).usage),
+                vec![
+                    UsageObservationMetric {
+                        field: "prompt_tokens",
+                        result: "unavailable"
+                    },
+                    UsageObservationMetric {
+                        field: "completion_tokens",
+                        result: "unavailable"
+                    },
+                    UsageObservationMetric {
+                        field: "total_tokens",
+                        result: "unavailable"
+                    },
+                    UsageObservationMetric {
+                        field: "cached_tokens",
+                        result: "unavailable"
+                    },
+                    UsageObservationMetric {
+                        field: "reasoning_tokens",
+                        result: "unavailable"
+                    },
+                ],
+                "{outcome:?} has five final unavailable observations"
+            );
+        }
+    }
 
     fn fixture_body(name: &str) -> Vec<u8> {
         let fixture = match name {

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -26,19 +26,44 @@ pub(crate) struct ResponseObservations {
     pub(crate) usage: UsageObservations,
 }
 
-#[cfg(test)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct UsageObservationMetric {
     pub(crate) field: &'static str,
     pub(crate) result: &'static str,
 }
 
-/// Task 16 RED seam. The deliberately empty result lets the regression state
-/// the locked, bounded mapping before the counter is implemented at the proxy
-/// classification boundary.
-#[cfg(test)]
-pub(crate) fn usage_observation_metrics(_usage: &UsageObservations) -> Vec<UsageObservationMetric> {
-    Vec::new()
+/// Map the finalized fixed usage fields to the only bounded observation metric
+/// labels. This is the sole classification-to-metric boundary: callers must
+/// not inspect response values or recreate these field/result pairs.
+pub(crate) fn usage_observation_metrics(usage: &UsageObservations) -> Vec<UsageObservationMetric> {
+    let result = |observation: &Observation| match observation {
+        Observation::Measured(_) => "measured",
+        Observation::Estimated(_) => "estimated",
+        Observation::Unavailable => "unavailable",
+        Observation::Invalid => "invalid",
+    };
+    vec![
+        UsageObservationMetric {
+            field: "prompt_tokens",
+            result: result(&usage.prompt_tokens),
+        },
+        UsageObservationMetric {
+            field: "completion_tokens",
+            result: result(&usage.completion_tokens),
+        },
+        UsageObservationMetric {
+            field: "total_tokens",
+            result: result(&usage.total_tokens),
+        },
+        UsageObservationMetric {
+            field: "cached_tokens",
+            result: result(&usage.cached_tokens),
+        },
+        UsageObservationMetric {
+            field: "reasoning_tokens",
+            result: result(&usage.reasoning_tokens),
+        },
+    ]
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -21,8 +21,8 @@ use tokio_stream::wrappers::ReceiverStream;
 use crate::dispatch::Slot;
 use crate::governor::{self, ModelPermit};
 use crate::observation::{
-    observe_buffered, FinishReason, FinishResult, Observation, ResponseObservations, SseObserver,
-    StreamOutcome,
+    observe_buffered, usage_observation_metrics, FinishReason, FinishResult, Observation,
+    ResponseObservations, SseObserver, StreamOutcome,
 };
 use crate::{AppState, Config};
 
@@ -346,6 +346,14 @@ fn record_observations(
     ctx: &Ctx,
     observations: &ResponseObservations,
 ) -> Option<(u64, &'static str)> {
+    for metric in usage_observation_metrics(&observations.usage) {
+        counter!(
+            "nimproxy_usage_observations_total",
+            "field" => metric.field,
+            "result" => metric.result,
+        )
+        .increment(1);
+    }
     let prompt = match observations.usage.prompt_tokens {
         Observation::Measured(value) => Some(value),
         _ => None,
@@ -864,14 +872,14 @@ fn streaming(
                     };
                     let next = tokio::select! {
                         _ = tx.closed() => {
-                            let _ = observer.finish(StreamOutcome::Disconnected);
+                            record_observations(&ctx, &observer.finish(StreamOutcome::Disconnected));
                             record_request(&ctx, "disconnect");
                             return;
                         }
                         read = upstream_read => match read {
                             Ok(n) => n,
                             Err(_) => {
-                                let _ = observer.finish(StreamOutcome::Truncated);
+                                record_observations(&ctx, &observer.finish(StreamOutcome::Truncated));
                                 tracing::warn!(model = %ctx.model, idle = ?cfg.stream_idle, "upstream stream stalled");
                                 record_request(&ctx, "stall");
                                 let _ = tx.send(Ok(sse_error("upstream stream stalled"))).await;
@@ -889,13 +897,16 @@ fn streaming(
                             }
                             observer.push(&b);
                             if tx.send(Ok(b)).await.is_err() {
-                                let _ = observer.finish(StreamOutcome::Disconnected);
+                                record_observations(
+                                    &ctx,
+                                    &observer.finish(StreamOutcome::Disconnected),
+                                );
                                 record_request(&ctx, "disconnect");
                                 return; // client hung up
                             }
                         }
                         Err(e) => {
-                            let _ = observer.finish(StreamOutcome::Truncated);
+                            record_observations(&ctx, &observer.finish(StreamOutcome::Truncated));
                             tracing::warn!(error = %e, "upstream stream broke mid-response");
                             record_request(&ctx, "stream_error");
                             let _ = tx.send(Ok(sse_error("upstream stream interrupted"))).await;

--- a/src/web/dashboard.js
+++ b/src/web/dashboard.js
@@ -95,6 +95,41 @@ function render() {
   const qwS = wsum('nimproxy_queue_wait_seconds_sum'), qwN = wsum('nimproxy_queue_wait_seconds_count');
   const upS = wsum('nimproxy_upstream_seconds_sum'), upN = wsum('nimproxy_upstream_seconds_count');
   const statusG = wgroups('nimproxy_requests_total', 'status');
+  const observationFields = new Set([
+    'prompt_tokens', 'completion_tokens', 'total_tokens', 'cached_tokens', 'reasoning_tokens',
+  ]);
+  const observationResults = ['invalid', 'unavailable', 'estimated', 'measured'];
+  const observationCounts = Object.fromEntries(observationResults.map(result => [result, 0]));
+  let observationPresent = false;
+  for (const row of last.rows) {
+    if (row.name !== 'nimproxy_usage_observations_total'
+        || !observationFields.has(row.labels.field)
+        || !observationResults.includes(row.labels.result)
+        || !Number.isFinite(+row.value) || +row.value < 0) continue;
+    observationPresent = true;
+    observationCounts[row.labels.result] += +row.value;
+  }
+  const observationMax = Math.max(...Object.values(observationCounts));
+  const observationResult = !observationPresent ? 'unavailable'
+    : observationMax === 0 ? 'zero'
+    : observationResults.find(result => observationCounts[result] === observationMax);
+  const observationQuality = {
+    invalid: {
+      value: catalogMessage('dashboard.overview.observation_quality.invalid'), tone: 'crit',
+    },
+    unavailable: {
+      value: catalogMessage('dashboard.overview.observation_quality.unavailable'), tone: 'warn',
+    },
+    estimated: {
+      value: catalogMessage('dashboard.overview.observation_quality.estimated'), tone: 'warn',
+    },
+    measured: {
+      value: catalogMessage('dashboard.overview.observation_quality.measured'), tone: undefined,
+    },
+    zero: {
+      value: catalogMessage('dashboard.overview.observation_quality.zero'), tone: 'zero',
+    },
+  }[observationResult];
 
   const c = {
     last, rows, windowLabel,
@@ -104,7 +139,7 @@ function render() {
     tpotMS, tpotMC, finTotal, finLen, reasoningByModel, tpotAvg, truncPct, reasonPct, pct,
     reqPts, capacityPoints, curRpm, avgRpm, peakRpm, capacity, rpmNow, capRatio, capColor, wreq, wok, okRatio, okColor,
     cReq, cP, cC, clients, streamT, streamF, toolReqs, totStreamT, totStreamF, totGen, totToolReq,
-    shed, unauth, logins, cooldown429, cooldownOther, qwS, qwN, upS, upN, statusG,
+    shed, unauth, logins, cooldown429, cooldownOther, qwS, qwN, upS, upN, statusG, observationQuality,
   };
   (RENDERERS[activeTab] || renderOverview)(c);
 }
@@ -117,7 +152,7 @@ const clientChip = cl =>
 function renderOverview(c) {
   const { windowLabel, capRatio, capColor, okRatio, okColor, wreq, wok, allP, allC,
     reqPts, rows, shed, unauth, logins, cooldown429, rpmNow, capacity, curRpm,
-    models, ctok, clients, cC, errRate } = c;
+    models, ctok, clients, cC, errRate, observationQuality } = c;
   const ctokPts = rateSeries(s => sum(s.rows, 'nimproxy_completion_tokens_total'));
   const okPts = samples.slice(1).map((s, i) => {
     const dr = sum(s.rows, 'nimproxy_requests_total') - sum(samples[i].rows, 'nimproxy_requests_total');
@@ -145,6 +180,7 @@ function renderOverview(c) {
   $('o-health').innerHTML =
     metricRow(catalogMessage('dashboard.common.row.active_now'), fmt(sum(rows, 'nimproxy_active_requests'))) +
     metricRow(catalogMessage('dashboard.common.row.queued'), fmt(sum(rows, 'nimproxy_queue_depth'))) +
+    metricRow(catalogMessage('dashboard.overview.row.observation_quality'), observationQuality.value, observationQuality.tone) +
     metricRow(catalogMessage('dashboard.common.row.rate_limit_cooldowns'), fmt(cooldown429), cooldown429 > 0 ? 'warn' : 'zero') +
     metricRow(catalogMessage('dashboard.common.row.dropped'), fmt(shed), shed > 0 ? 'crit' : 'zero') +
     metricRow(catalogMessage('dashboard.common.row.unauthorized'), fmt(unauth), unauth > 0 ? 'crit' : 'zero') +

--- a/src/web/locales/en-US.json
+++ b/src/web/locales/en-US.json
@@ -766,6 +766,26 @@
       "en": "{tokens} in",
       "hash": "b48a8ba7"
     },
+    "dashboard.overview.observation_quality.estimated": {
+      "en": "Estimated",
+      "hash": "b774599a"
+    },
+    "dashboard.overview.observation_quality.invalid": {
+      "en": "Invalid",
+      "hash": "96c34a07"
+    },
+    "dashboard.overview.observation_quality.measured": {
+      "en": "Measured",
+      "hash": "9298c8f4"
+    },
+    "dashboard.overview.observation_quality.unavailable": {
+      "en": "Unavailable",
+      "hash": "ca184496"
+    },
+    "dashboard.overview.observation_quality.zero": {
+      "en": "No observations",
+      "hash": "fed7c51b"
+    },
     "dashboard.overview.perf.higher_is_better": {
       "en": "higher is better",
       "desc": "Note beside a throughput distribution: larger numbers are better. Lowercase, sits under the card heading.",
@@ -836,6 +856,10 @@
     "dashboard.overview.ring.errors.zero": {
       "en": "errors {pct} · {cooldowns} cooldowns",
       "hash": "17ac4dc4"
+    },
+    "dashboard.overview.row.observation_quality": {
+      "en": "Observation quality",
+      "hash": "b56e5b8f"
     },
     "dashboard.overview.top_clients.heading": {
       "en": "Top clients",

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -32,6 +32,58 @@ fn no_redirect_client() -> reqwest::Client {
         .unwrap()
 }
 
+fn usage_observation_counter_lines(exposition: &str) -> BTreeSet<String> {
+    let rows: Vec<_> = exposition
+        .lines()
+        .filter(|line| line.starts_with("nimproxy_usage_observations_total{"))
+        .collect();
+    let unique_rows: BTreeSet<_> = rows.iter().copied().collect();
+    assert_eq!(
+        unique_rows.len(),
+        rows.len(),
+        "usage observation exposition must not duplicate a series: {rows:?}"
+    );
+    for row in &rows {
+        let (labels, value) = row
+            .strip_prefix("nimproxy_usage_observations_total{")
+            .and_then(|row| row.split_once("} "))
+            .expect("usage observation counter has labels and an integer value");
+        let labels: Vec<_> = labels.split(',').collect();
+        assert_eq!(
+            labels.len(),
+            2,
+            "usage observation label count is closed: {row}"
+        );
+        let field = labels[0]
+            .strip_prefix("field=\"")
+            .and_then(|field| field.strip_suffix('"'))
+            .expect("field is the first, quoted label");
+        let result = labels[1]
+            .strip_prefix("result=\"")
+            .and_then(|result| result.strip_suffix('"'))
+            .expect("result is the second, quoted label");
+        assert!(
+            matches!(
+                field,
+                "prompt_tokens"
+                    | "completion_tokens"
+                    | "total_tokens"
+                    | "cached_tokens"
+                    | "reasoning_tokens"
+            ),
+            "usage observation field is closed: {row}"
+        );
+        assert!(
+            matches!(result, "measured" | "estimated" | "unavailable" | "invalid"),
+            "usage observation result is closed: {row}"
+        );
+        value
+            .parse::<u64>()
+            .expect("usage observation counter value is an unsigned integer");
+    }
+    unique_rows.into_iter().map(str::to_owned).collect()
+}
+
 async fn assert_exact_api_error(
     response: reqwest::Response,
     status: reqwest::StatusCode,
@@ -2743,6 +2795,278 @@ async fn metrics_report_traffic_tokens_and_affinity() {
         "exact usage counted: {metrics}"
     );
     assert!(metrics.contains("nimproxy_affinity_total"));
+}
+
+#[tokio::test]
+async fn dashboard_observation_quality_is_honest() {
+    // Mutation caught: the proxy omits `nimproxy_usage_observations_total`,
+    // does not record the terminal disconnected-stream result, or exposes a
+    // request/model/client/error label instead of the closed field/result pair.
+    let mock = start_mock().await;
+    let proxy = start_proxy_with(
+        &mock.url,
+        StoreOpts {
+            stream_idle_secs: 1,
+            strict_passthrough: true,
+            ..Default::default()
+        },
+        &[],
+    )
+    .await;
+    let cookie = login(&proxy).await;
+
+    // A successful buffered response makes all five usage fields measured,
+    // including a measured zero. This is a distinct finalization path from
+    // the ordinary streamed response below.
+    mock.state.push(Behavior::ExactResponse {
+        content_type: "application/json".into(),
+        body: r#"{"choices":[],"usage":{"prompt_tokens":0,"completion_tokens":2,"total_tokens":2,"prompt_tokens_details":{"cached_tokens":0},"completion_tokens_details":{"reasoning_tokens":1}}}"#.into(),
+    });
+    client()
+        .post(proxy.url("/v1/chat/completions"))
+        .json(&chat_body("buffered-measured", false))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+
+    // Measured: prompt, completion, and reasoning arrive in the ordinary
+    // completed stream. Total and cached are absent.
+    read_sse(
+        client()
+            .post(proxy.url("/v1/chat/completions"))
+            .json(&chat_body("measured", true))
+            .send()
+            .await
+            .unwrap(),
+    )
+    .await;
+
+    // Unavailable: a valid buffered response carries no usage object.
+    mock.state.push(Behavior::ExactResponse {
+        content_type: "application/json".into(),
+        body: r#"{"choices":[]}"#.into(),
+    });
+    client()
+        .post(proxy.url("/v1/chat/completions"))
+        .json(&chat_body("unavailable", false))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+
+    // Estimated: one successful nonterminal SSE event has no measured usage.
+    mock.state.push(Behavior::ExactResponse {
+        content_type: "text/event-stream".into(),
+        body:
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"x\"}}]}\n\ndata: [DONE]\n\n"
+                .into(),
+    });
+    read_sse(
+        client()
+            .post(proxy.url("/v1/chat/completions"))
+            .json(&chat_body("estimated", true))
+            .send()
+            .await
+            .unwrap(),
+    )
+    .await;
+
+    // Invalid: a present non-object usage value invalidates exactly the five
+    // bounded usage fields without turning any of them into zero.
+    mock.state.push(Behavior::ExactResponse {
+        content_type: "application/json".into(),
+        body: r#"{"choices":[],"usage":[]}"#.into(),
+    });
+    client()
+        .post(proxy.url("/v1/chat/completions"))
+        .json(&chat_body("invalid", false))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+
+    // Final accounting must also happen when the downstream disconnects after
+    // its first streamed chunk, not only on the completed-stream path.
+    mock.state.push(Behavior::Hang);
+    let mut disconnected = client()
+        .post(proxy.url("/v1/chat/completions"))
+        .json(&chat_body("disconnect", true))
+        .send()
+        .await
+        .unwrap();
+    assert!(disconnected.chunk().await.unwrap().is_some());
+    drop(disconnected);
+    let disconnect_deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let request_rows = metrics(&proxy).await;
+        if request_rows.lines().any(|line| {
+            line == r#"nimproxy_requests_total{client="local",model="mock/model-a",path="/v1/chat/completions",status="disconnect"} 1"#
+        }) {
+            break;
+        }
+        assert!(
+            Instant::now() < disconnect_deadline,
+            "disconnect never finalized in request metrics: {request_rows}"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    // The idle timeout finalizes a successfully opened but stalled upstream
+    // stream as unavailable rather than leaving its observations unrecorded.
+    mock.state.push(Behavior::Hang);
+    let stalled = client()
+        .post(proxy.url("/v1/chat/completions"))
+        .json(&chat_body("idle-stall", true))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        read_sse(stalled).await.contains("stalled"),
+        "idle-stalled upstream stream must return a terminal proxy error"
+    );
+
+    // A nominal completed response with an unterminated final SSE event is
+    // still a truncated observation, not measured or estimated usage.
+    mock.state.push(Behavior::ExactResponse {
+        content_type: "text/event-stream".into(),
+        body: "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2}}"
+            .into(),
+    });
+    read_sse(
+        client()
+            .post(proxy.url("/v1/chat/completions"))
+            .json(&chat_body("unterminated", true))
+            .send()
+            .await
+            .unwrap(),
+    )
+    .await;
+
+    let exposition = metrics(&proxy).await;
+    assert_eq!(
+        exposition
+            .lines()
+            .filter(|line| line.starts_with("# HELP nimproxy_usage_observations_total"))
+            .collect::<Vec<_>>(),
+        vec!["# HELP nimproxy_usage_observations_total Final classified upstream usage observations by field and result."],
+        "usage observation HELP contract is exact"
+    );
+    assert_eq!(
+        exposition
+            .lines()
+            .filter(|line| line.starts_with("# TYPE nimproxy_usage_observations_total"))
+            .collect::<Vec<_>>(),
+        vec!["# TYPE nimproxy_usage_observations_total counter"],
+        "usage observation TYPE contract is exact"
+    );
+    assert_eq!(
+        usage_observation_counter_lines(&exposition),
+        BTreeSet::from([
+            r#"nimproxy_usage_observations_total{field="prompt_tokens",result="measured"} 2"#.to_owned(),
+            r#"nimproxy_usage_observations_total{field="prompt_tokens",result="unavailable"} 5"#.to_owned(),
+            r#"nimproxy_usage_observations_total{field="prompt_tokens",result="invalid"} 1"#.to_owned(),
+            r#"nimproxy_usage_observations_total{field="completion_tokens",result="measured"} 2"#.to_owned(),
+            r#"nimproxy_usage_observations_total{field="completion_tokens",result="estimated"} 1"#.to_owned(),
+            r#"nimproxy_usage_observations_total{field="completion_tokens",result="unavailable"} 4"#.to_owned(),
+            r#"nimproxy_usage_observations_total{field="completion_tokens",result="invalid"} 1"#.to_owned(),
+            r#"nimproxy_usage_observations_total{field="total_tokens",result="measured"} 1"#.to_owned(),
+            r#"nimproxy_usage_observations_total{field="total_tokens",result="unavailable"} 6"#.to_owned(),
+            r#"nimproxy_usage_observations_total{field="total_tokens",result="invalid"} 1"#.to_owned(),
+            r#"nimproxy_usage_observations_total{field="cached_tokens",result="measured"} 1"#.to_owned(),
+            r#"nimproxy_usage_observations_total{field="cached_tokens",result="unavailable"} 6"#.to_owned(),
+            r#"nimproxy_usage_observations_total{field="cached_tokens",result="invalid"} 1"#.to_owned(),
+            r#"nimproxy_usage_observations_total{field="reasoning_tokens",result="measured"} 2"#.to_owned(),
+            r#"nimproxy_usage_observations_total{field="reasoning_tokens",result="unavailable"} 5"#.to_owned(),
+            r#"nimproxy_usage_observations_total{field="reasoning_tokens",result="invalid"} 1"#.to_owned(),
+        ]),
+        "every finalized success/disconnect/stall/unterminated path has exactly one of the closed five-field results"
+    );
+
+    // The existing typed dashboard payload carries registry series directly;
+    // no observation-availability API field is added for this UI state.
+    let now: serde_json::Value = client()
+        .get(proxy.url("/api/dashboard/now"))
+        .header("cookie", &cookie)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(now.get("observation_availability").is_none());
+    assert!(
+        now["metrics"].as_array().unwrap().iter().any(|metric| {
+            metric["metric"] == "nimproxy_usage_observations_total"
+                && metric["labels"]
+                    == serde_json::json!({"field":"completion_tokens","result":"estimated"})
+                && metric["value"] == 1.0
+        }),
+        "dashboard must consume the existing metrics payload, not an invented API field: {now}"
+    );
+
+    // A failed final response is excluded entirely: it must not synthesize an
+    // observation result merely because the request reached the proxy.
+    let no_success_mock = start_mock().await;
+    let no_success_proxy = start_proxy_with(
+        &no_success_mock.url,
+        StoreOpts {
+            strict_passthrough: true,
+            ..Default::default()
+        },
+        &[],
+    )
+    .await;
+    no_success_mock.state.push(Behavior::BadRequest);
+    assert_eq!(
+        client()
+            .post(no_success_proxy.url("/v1/chat/completions"))
+            .json(&chat_body("failed", false))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        reqwest::StatusCode::BAD_REQUEST
+    );
+    assert!(
+        usage_observation_counter_lines(&metrics(&no_success_proxy).await).is_empty(),
+        "non-successful responses are excluded from finalized observations"
+    );
+
+    // The pre-observation retry response is likewise excluded; only its final
+    // successful attempt leaves the five literal final results.
+    let retry_mock = start_mock().await;
+    let retry_proxy = start_proxy(&retry_mock.url, &[]).await;
+    retry_mock.state.push(Behavior::RateLimited(0));
+    retry_mock.state.push(Behavior::Ok);
+    read_sse(
+        client()
+            .post(retry_proxy.url("/v1/chat/completions"))
+            .json(&chat_body("retry", true))
+            .send()
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(
+        usage_observation_counter_lines(&metrics(&retry_proxy).await),
+        BTreeSet::from([
+            r#"nimproxy_usage_observations_total{field="prompt_tokens",result="measured"} 1"#
+                .to_owned(),
+            r#"nimproxy_usage_observations_total{field="completion_tokens",result="measured"} 1"#
+                .to_owned(),
+            r#"nimproxy_usage_observations_total{field="total_tokens",result="unavailable"} 1"#
+                .to_owned(),
+            r#"nimproxy_usage_observations_total{field="cached_tokens",result="unavailable"} 1"#
+                .to_owned(),
+            r#"nimproxy_usage_observations_total{field="reasoning_tokens",result="measured"} 1"#
+                .to_owned(),
+        ]),
+        "pre-observation retry responses do not add observation counters"
+    );
 }
 
 #[tokio::test]

--- a/tests/fixtures/ui/dashboard-now-changed.json
+++ b/tests/fixtures/ui/dashboard-now-changed.json
@@ -198,6 +198,46 @@
     },
     {
       "labels": {
+        "field": "prompt_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 10.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 10.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 10.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 10.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 10.0
+    },
+    {
+      "labels": {
         "le": "0.05",
         "model": "fixture/alpha"
       },
@@ -889,6 +929,46 @@
         },
         "metric": "nimproxy_request_max_tokens_sum",
         "value": 5120.0
+      },
+      {
+        "labels": {
+          "field": "prompt_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 5.0
+      },
+      {
+        "labels": {
+          "field": "completion_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 5.0
+      },
+      {
+        "labels": {
+          "field": "total_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 5.0
+      },
+      {
+        "labels": {
+          "field": "cached_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 5.0
+      },
+      {
+        "labels": {
+          "field": "reasoning_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 5.0
       },
       {
         "labels": {

--- a/tests/fixtures/ui/dashboard-now-observation-tail.json
+++ b/tests/fixtures/ui/dashboard-now-observation-tail.json
@@ -198,46 +198,6 @@
     },
     {
       "labels": {
-        "field": "prompt_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "completion_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "total_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "cached_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "reasoning_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
         "le": "0.05",
         "model": "fixture/alpha"
       },
@@ -740,8 +700,25 @@
   "tail": {
     "base_history_revision": 11,
     "from": 1700003600,
-    "to": 1700003600,
-    "totals": []
+    "to": 1700007200,
+    "totals": [
+      {
+        "labels": {
+          "field": "completion_tokens",
+          "result": "estimated"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 7.0
+      },
+      {
+        "labels": {
+          "field": "prompt_tokens",
+          "result": "invalid"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": -1.0
+      }
+    ]
   },
   "version": "0.6.6"
 }

--- a/tests/fixtures/ui/dashboard-observation-absent.json
+++ b/tests/fixtures/ui/dashboard-observation-absent.json
@@ -44,718 +44,8 @@
           40
         ]
       },
-      "duration_seconds": 1296000,
+      "duration_seconds": 2592000,
       "from": 1697411600,
-      "to": 1698707600,
-      "values": [
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "path": "/v1/chat/completions",
-            "status": "200"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 15.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/zeta",
-            "path": "/v1/chat/completions",
-            "status": "504"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "reason": "stop"
-          },
-          "metric": "nimproxy_finish_reason_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "stream": "true"
-          },
-          "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "mode": "auto"
-          },
-          "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_json_mode_total",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "result": "sticky"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "result": "spill"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "lane": "0"
-          },
-          "metric": "nimproxy_lane_requests_total",
-          "value": 16.0
-        },
-        {
-          "labels": {
-            "lane": "0",
-            "status": "429"
-          },
-          "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_worker_exhausted_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_shed_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_unauthorized_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_login_failures_total",
-          "value": 0.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.05",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_sum",
-          "value": 1.5
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "20",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "40",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "80",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "160",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "320",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_sum",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "le": "0.005",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.01",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.02",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.04",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "0.08",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.16",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.32",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_sum",
-          "value": 0.11599999999999999
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "120",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "300",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_sum",
-          "value": 5.6
-        },
-        {
-          "labels": {
-            "le": "0.001"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.05"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "1"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "15"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "180"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "600"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 2.6205
-        }
-      ]
-    },
-    {
-      "capacity": {
-        "average_rpm": 80.0,
-        "latest_rpms": [
-          40,
-          40
-        ]
-      },
-      "duration_seconds": 1296000,
-      "from": 1698707600,
       "to": 1700003600,
       "values": [
         {
@@ -766,7 +56,7 @@
             "status": "200"
           },
           "metric": "nimproxy_requests_total",
-          "value": 15.0
+          "value": 30.0
         },
         {
           "labels": {
@@ -776,7 +66,7 @@
             "status": "504"
           },
           "metric": "nimproxy_requests_total",
-          "value": 2.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -784,7 +74,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
+          "value": 1200.0
         },
         {
           "labels": {
@@ -793,14 +83,14 @@
             "source": "usage"
           },
           "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
+          "value": 300.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
+          "value": 60.0
         },
         {
           "labels": {
@@ -808,7 +98,7 @@
             "reason": "stop"
           },
           "metric": "nimproxy_finish_reason_total",
-          "value": 13.0
+          "value": 25.0
         },
         {
           "labels": {
@@ -816,49 +106,49 @@
             "stream": "true"
           },
           "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
+          "value": 20.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
+          "value": 8.0
         },
         {
           "labels": {
             "mode": "auto"
           },
           "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_json_mode_total",
-          "value": 2.0
+          "value": 4.0
         },
         {
           "labels": {
             "result": "sticky"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 12.0
+          "value": 24.0
         },
         {
           "labels": {
             "result": "spill"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
             "lane": "0"
           },
           "metric": "nimproxy_lane_requests_total",
-          "value": 17.0
+          "value": 33.0
         },
         {
           "labels": {
@@ -866,7 +156,7 @@
             "status": "429"
           },
           "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -895,96 +185,56 @@
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
+          "value": 15.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
+          "value": 40.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
+          "value": 7.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
+          "value": 10240.0
         },
         {
           "labels": {
@@ -992,7 +242,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1000,7 +250,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1008,7 +258,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1016,7 +266,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1024,7 +274,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1032,7 +282,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1040,7 +290,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1048,7 +298,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1056,7 +306,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1064,7 +314,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1072,21 +322,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_sum",
-          "value": 43.5
+          "value": 45.0
         },
         {
           "labels": {
@@ -1095,7 +345,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1104,7 +354,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1113,7 +363,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1122,7 +372,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1131,7 +381,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1140,7 +390,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1149,7 +399,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1158,7 +408,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1167,7 +417,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1176,7 +426,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1184,7 +434,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1192,7 +442,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_sum",
-          "value": 880.0
+          "value": 910.0
         },
         {
           "labels": {
@@ -1200,7 +450,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1208,7 +458,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1216,7 +466,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1224,7 +474,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1232,7 +482,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1240,7 +490,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1248,7 +498,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1256,21 +506,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_sum",
-          "value": 1.8599999999999999
+          "value": 1.976
         },
         {
           "labels": {
@@ -1278,7 +528,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1286,7 +536,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1294,7 +544,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1302,7 +552,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1310,7 +560,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1318,7 +568,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1326,7 +576,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1334,7 +584,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1342,7 +592,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1350,7 +600,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1358,101 +608,101 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_sum",
-          "value": 417.0
+          "value": 422.6
         },
         {
           "labels": {
             "le": "0.001"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
             "le": "0.05"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
             "le": "0.25"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
             "le": "1"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
             "le": "5"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
             "le": "15"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
             "le": "60"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
             "le": "180"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
             "le": "600"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "le": "+Inf"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 930.0
+          "value": 932.6205
         }
       ]
     }
@@ -1645,46 +895,6 @@
       },
       "metric": "nimproxy_request_max_tokens_sum",
       "value": 10240.0
-    },
-    {
-      "labels": {
-        "field": "prompt_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "completion_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "total_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "cached_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "reasoning_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
     },
     {
       "labels": {

--- a/tests/fixtures/ui/dashboard-observation-estimated.json
+++ b/tests/fixtures/ui/dashboard-observation-estimated.json
@@ -44,718 +44,8 @@
           40
         ]
       },
-      "duration_seconds": 1296000,
+      "duration_seconds": 2592000,
       "from": 1697411600,
-      "to": 1698707600,
-      "values": [
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "path": "/v1/chat/completions",
-            "status": "200"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 15.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/zeta",
-            "path": "/v1/chat/completions",
-            "status": "504"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "reason": "stop"
-          },
-          "metric": "nimproxy_finish_reason_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "stream": "true"
-          },
-          "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "mode": "auto"
-          },
-          "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_json_mode_total",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "result": "sticky"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "result": "spill"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "lane": "0"
-          },
-          "metric": "nimproxy_lane_requests_total",
-          "value": 16.0
-        },
-        {
-          "labels": {
-            "lane": "0",
-            "status": "429"
-          },
-          "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_worker_exhausted_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_shed_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_unauthorized_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_login_failures_total",
-          "value": 0.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.05",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_sum",
-          "value": 1.5
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "20",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "40",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "80",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "160",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "320",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_sum",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "le": "0.005",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.01",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.02",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.04",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "0.08",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.16",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.32",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_sum",
-          "value": 0.11599999999999999
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "120",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "300",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_sum",
-          "value": 5.6
-        },
-        {
-          "labels": {
-            "le": "0.001"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.05"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "1"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "15"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "180"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "600"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 2.6205
-        }
-      ]
-    },
-    {
-      "capacity": {
-        "average_rpm": 80.0,
-        "latest_rpms": [
-          40,
-          40
-        ]
-      },
-      "duration_seconds": 1296000,
-      "from": 1698707600,
       "to": 1700003600,
       "values": [
         {
@@ -766,7 +56,7 @@
             "status": "200"
           },
           "metric": "nimproxy_requests_total",
-          "value": 15.0
+          "value": 30.0
         },
         {
           "labels": {
@@ -776,7 +66,7 @@
             "status": "504"
           },
           "metric": "nimproxy_requests_total",
-          "value": 2.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -784,7 +74,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
+          "value": 1200.0
         },
         {
           "labels": {
@@ -793,14 +83,14 @@
             "source": "usage"
           },
           "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
+          "value": 300.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
+          "value": 60.0
         },
         {
           "labels": {
@@ -808,7 +98,7 @@
             "reason": "stop"
           },
           "metric": "nimproxy_finish_reason_total",
-          "value": 13.0
+          "value": 25.0
         },
         {
           "labels": {
@@ -816,49 +106,49 @@
             "stream": "true"
           },
           "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
+          "value": 20.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
+          "value": 8.0
         },
         {
           "labels": {
             "mode": "auto"
           },
           "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_json_mode_total",
-          "value": 2.0
+          "value": 4.0
         },
         {
           "labels": {
             "result": "sticky"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 12.0
+          "value": 24.0
         },
         {
           "labels": {
             "result": "spill"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
             "lane": "0"
           },
           "metric": "nimproxy_lane_requests_total",
-          "value": 17.0
+          "value": 33.0
         },
         {
           "labels": {
@@ -866,7 +156,7 @@
             "status": "429"
           },
           "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -895,96 +185,56 @@
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
+          "value": 15.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
+          "value": 40.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
+          "value": 7.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
+          "value": 10240.0
         },
         {
           "labels": {
@@ -992,7 +242,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1000,7 +250,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1008,7 +258,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1016,7 +266,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1024,7 +274,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1032,7 +282,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1040,7 +290,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1048,7 +298,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1056,7 +306,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1064,7 +314,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1072,21 +322,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_sum",
-          "value": 43.5
+          "value": 45.0
         },
         {
           "labels": {
@@ -1095,7 +345,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1104,7 +354,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1113,7 +363,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1122,7 +372,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1131,7 +381,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1140,7 +390,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1149,7 +399,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1158,7 +408,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1167,7 +417,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1176,7 +426,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1184,7 +434,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1192,7 +442,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_sum",
-          "value": 880.0
+          "value": 910.0
         },
         {
           "labels": {
@@ -1200,7 +450,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1208,7 +458,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1216,7 +466,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1224,7 +474,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1232,7 +482,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1240,7 +490,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1248,7 +498,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1256,21 +506,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_sum",
-          "value": 1.8599999999999999
+          "value": 1.976
         },
         {
           "labels": {
@@ -1278,7 +528,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1286,7 +536,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1294,7 +544,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1302,7 +552,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1310,7 +560,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1318,7 +568,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1326,7 +576,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1334,7 +584,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1342,7 +592,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1350,7 +600,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1358,101 +608,141 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_sum",
-          "value": 417.0
+          "value": 422.6
         },
         {
           "labels": {
             "le": "0.001"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
             "le": "0.05"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
             "le": "0.25"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
             "le": "1"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
             "le": "5"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
             "le": "15"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
             "le": "60"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
             "le": "180"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
             "le": "600"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "le": "+Inf"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 930.0
+          "value": 932.6205
+        },
+        {
+          "labels": {
+            "field": "prompt_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
         }
       ]
     }
@@ -1645,46 +935,6 @@
       },
       "metric": "nimproxy_request_max_tokens_sum",
       "value": 10240.0
-    },
-    {
-      "labels": {
-        "field": "prompt_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "completion_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "total_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "cached_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "reasoning_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
     },
     {
       "labels": {
@@ -2153,6 +1403,46 @@
       "labels": {},
       "metric": "nimproxy_queue_wait_seconds_sum",
       "value": 932.6205
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
     }
   ],
   "window": {

--- a/tests/fixtures/ui/dashboard-observation-incomplete.json
+++ b/tests/fixtures/ui/dashboard-observation-incomplete.json
@@ -1,10 +1,10 @@
 {
   "config_revision": 7,
   "diagnostics": {
-    "excluded_epochs": 0,
-    "excluded_records": 0,
+    "excluded_epochs": 1,
+    "excluded_records": 1,
     "normalized_series": 1,
-    "skipped_metric_lines": 0,
+    "skipped_metric_lines": 1,
     "valid_checkpoints": 0,
     "valid_samples": 1
   },
@@ -44,718 +44,8 @@
           40
         ]
       },
-      "duration_seconds": 1296000,
-      "from": 1697411600,
-      "to": 1698707600,
-      "values": [
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "path": "/v1/chat/completions",
-            "status": "200"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 15.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/zeta",
-            "path": "/v1/chat/completions",
-            "status": "504"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "reason": "stop"
-          },
-          "metric": "nimproxy_finish_reason_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "stream": "true"
-          },
-          "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "mode": "auto"
-          },
-          "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_json_mode_total",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "result": "sticky"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "result": "spill"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "lane": "0"
-          },
-          "metric": "nimproxy_lane_requests_total",
-          "value": 16.0
-        },
-        {
-          "labels": {
-            "lane": "0",
-            "status": "429"
-          },
-          "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_worker_exhausted_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_shed_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_unauthorized_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_login_failures_total",
-          "value": 0.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.05",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_sum",
-          "value": 1.5
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "20",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "40",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "80",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "160",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "320",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_sum",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "le": "0.005",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.01",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.02",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.04",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "0.08",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.16",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.32",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_sum",
-          "value": 0.11599999999999999
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "120",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "300",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_sum",
-          "value": 5.6
-        },
-        {
-          "labels": {
-            "le": "0.001"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.05"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "1"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "15"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "180"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "600"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 2.6205
-        }
-      ]
-    },
-    {
-      "capacity": {
-        "average_rpm": 80.0,
-        "latest_rpms": [
-          40,
-          40
-        ]
-      },
-      "duration_seconds": 1296000,
-      "from": 1698707600,
+      "duration_seconds": 90000,
+      "from": 1699913600,
       "to": 1700003600,
       "values": [
         {
@@ -766,7 +56,7 @@
             "status": "200"
           },
           "metric": "nimproxy_requests_total",
-          "value": 15.0
+          "value": 30.0
         },
         {
           "labels": {
@@ -776,7 +66,7 @@
             "status": "504"
           },
           "metric": "nimproxy_requests_total",
-          "value": 2.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -784,7 +74,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
+          "value": 1200.0
         },
         {
           "labels": {
@@ -793,14 +83,14 @@
             "source": "usage"
           },
           "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
+          "value": 300.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
+          "value": 60.0
         },
         {
           "labels": {
@@ -808,7 +98,7 @@
             "reason": "stop"
           },
           "metric": "nimproxy_finish_reason_total",
-          "value": 13.0
+          "value": 25.0
         },
         {
           "labels": {
@@ -816,49 +106,49 @@
             "stream": "true"
           },
           "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
+          "value": 20.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
+          "value": 8.0
         },
         {
           "labels": {
             "mode": "auto"
           },
           "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_json_mode_total",
-          "value": 2.0
+          "value": 4.0
         },
         {
           "labels": {
             "result": "sticky"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 12.0
+          "value": 24.0
         },
         {
           "labels": {
             "result": "spill"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
             "lane": "0"
           },
           "metric": "nimproxy_lane_requests_total",
-          "value": 17.0
+          "value": 33.0
         },
         {
           "labels": {
@@ -866,7 +156,7 @@
             "status": "429"
           },
           "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -895,96 +185,56 @@
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
+          "value": 15.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
+          "value": 40.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
+          "value": 7.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
+          "value": 10240.0
         },
         {
           "labels": {
@@ -992,7 +242,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1000,7 +250,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1008,7 +258,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1016,7 +266,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1024,7 +274,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1032,7 +282,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1040,7 +290,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1048,7 +298,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1056,7 +306,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1064,7 +314,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1072,21 +322,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_sum",
-          "value": 43.5
+          "value": 45.0
         },
         {
           "labels": {
@@ -1095,7 +345,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1104,7 +354,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1113,7 +363,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1122,7 +372,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1131,7 +381,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1140,7 +390,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1149,7 +399,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1158,7 +408,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1167,7 +417,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1176,7 +426,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1184,7 +434,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1192,7 +442,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_sum",
-          "value": 880.0
+          "value": 910.0
         },
         {
           "labels": {
@@ -1200,7 +450,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1208,7 +458,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1216,7 +466,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1224,7 +474,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1232,7 +482,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1240,7 +490,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1248,7 +498,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1256,21 +506,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_sum",
-          "value": 1.8599999999999999
+          "value": 1.976
         },
         {
           "labels": {
@@ -1278,7 +528,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1286,7 +536,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1294,7 +544,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1302,7 +552,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1310,7 +560,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1318,7 +568,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1326,7 +576,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1334,7 +584,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1342,7 +592,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1350,7 +600,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1358,101 +608,141 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_sum",
-          "value": 417.0
+          "value": 422.6
         },
         {
           "labels": {
             "le": "0.001"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
             "le": "0.05"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
             "le": "0.25"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
             "le": "1"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
             "le": "5"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
             "le": "15"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
             "le": "60"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
             "le": "180"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
             "le": "600"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "le": "+Inf"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 930.0
+          "value": 932.6205
+        },
+        {
+          "labels": {
+            "field": "prompt_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
         }
       ]
     }
@@ -1645,46 +935,6 @@
       },
       "metric": "nimproxy_request_max_tokens_sum",
       "value": 10240.0
-    },
-    {
-      "labels": {
-        "field": "prompt_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "completion_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "total_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "cached_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "reasoning_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
     },
     {
       "labels": {
@@ -2153,14 +1403,54 @@
       "labels": {},
       "metric": "nimproxy_queue_wait_seconds_sum",
       "value": 932.6205
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
     }
   ],
   "window": {
-    "available_from": 1697411600,
+    "available_from": 1699913600,
     "available_to": 1700003600,
-    "complete": true,
+    "complete": false,
     "default_window_days": 30,
-    "effective_from": 1697411600,
+    "effective_from": 1699913600,
     "effective_to": 1700003600,
     "following_now": false,
     "requested_from": 1697411600,

--- a/tests/fixtures/ui/dashboard-observation-invalid.json
+++ b/tests/fixtures/ui/dashboard-observation-invalid.json
@@ -44,718 +44,8 @@
           40
         ]
       },
-      "duration_seconds": 1296000,
+      "duration_seconds": 2592000,
       "from": 1697411600,
-      "to": 1698707600,
-      "values": [
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "path": "/v1/chat/completions",
-            "status": "200"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 15.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/zeta",
-            "path": "/v1/chat/completions",
-            "status": "504"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "reason": "stop"
-          },
-          "metric": "nimproxy_finish_reason_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "stream": "true"
-          },
-          "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "mode": "auto"
-          },
-          "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_json_mode_total",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "result": "sticky"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "result": "spill"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "lane": "0"
-          },
-          "metric": "nimproxy_lane_requests_total",
-          "value": 16.0
-        },
-        {
-          "labels": {
-            "lane": "0",
-            "status": "429"
-          },
-          "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_worker_exhausted_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_shed_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_unauthorized_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_login_failures_total",
-          "value": 0.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.05",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_sum",
-          "value": 1.5
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "20",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "40",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "80",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "160",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "320",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_sum",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "le": "0.005",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.01",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.02",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.04",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "0.08",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.16",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.32",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_sum",
-          "value": 0.11599999999999999
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "120",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "300",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_sum",
-          "value": 5.6
-        },
-        {
-          "labels": {
-            "le": "0.001"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.05"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "1"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "15"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "180"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "600"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 2.6205
-        }
-      ]
-    },
-    {
-      "capacity": {
-        "average_rpm": 80.0,
-        "latest_rpms": [
-          40,
-          40
-        ]
-      },
-      "duration_seconds": 1296000,
-      "from": 1698707600,
       "to": 1700003600,
       "values": [
         {
@@ -766,7 +56,7 @@
             "status": "200"
           },
           "metric": "nimproxy_requests_total",
-          "value": 15.0
+          "value": 30.0
         },
         {
           "labels": {
@@ -776,7 +66,7 @@
             "status": "504"
           },
           "metric": "nimproxy_requests_total",
-          "value": 2.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -784,7 +74,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
+          "value": 1200.0
         },
         {
           "labels": {
@@ -793,14 +83,14 @@
             "source": "usage"
           },
           "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
+          "value": 300.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
+          "value": 60.0
         },
         {
           "labels": {
@@ -808,7 +98,7 @@
             "reason": "stop"
           },
           "metric": "nimproxy_finish_reason_total",
-          "value": 13.0
+          "value": 25.0
         },
         {
           "labels": {
@@ -816,49 +106,49 @@
             "stream": "true"
           },
           "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
+          "value": 20.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
+          "value": 8.0
         },
         {
           "labels": {
             "mode": "auto"
           },
           "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_json_mode_total",
-          "value": 2.0
+          "value": 4.0
         },
         {
           "labels": {
             "result": "sticky"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 12.0
+          "value": 24.0
         },
         {
           "labels": {
             "result": "spill"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
             "lane": "0"
           },
           "metric": "nimproxy_lane_requests_total",
-          "value": 17.0
+          "value": 33.0
         },
         {
           "labels": {
@@ -866,7 +156,7 @@
             "status": "429"
           },
           "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -895,96 +185,56 @@
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
+          "value": 15.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
+          "value": 40.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
+          "value": 7.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
+          "value": 10240.0
         },
         {
           "labels": {
@@ -992,7 +242,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1000,7 +250,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1008,7 +258,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1016,7 +266,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1024,7 +274,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1032,7 +282,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1040,7 +290,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1048,7 +298,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1056,7 +306,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1064,7 +314,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1072,21 +322,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_sum",
-          "value": 43.5
+          "value": 45.0
         },
         {
           "labels": {
@@ -1095,7 +345,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1104,7 +354,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1113,7 +363,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1122,7 +372,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1131,7 +381,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1140,7 +390,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1149,7 +399,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1158,7 +408,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1167,7 +417,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1176,7 +426,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1184,7 +434,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1192,7 +442,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_sum",
-          "value": 880.0
+          "value": 910.0
         },
         {
           "labels": {
@@ -1200,7 +450,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1208,7 +458,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1216,7 +466,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1224,7 +474,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1232,7 +482,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1240,7 +490,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1248,7 +498,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1256,21 +506,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_sum",
-          "value": 1.8599999999999999
+          "value": 1.976
         },
         {
           "labels": {
@@ -1278,7 +528,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1286,7 +536,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1294,7 +544,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1302,7 +552,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1310,7 +560,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1318,7 +568,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1326,7 +576,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1334,7 +584,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1342,7 +592,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1350,7 +600,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1358,101 +608,141 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_sum",
-          "value": 417.0
+          "value": 422.6
         },
         {
           "labels": {
             "le": "0.001"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
             "le": "0.05"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
             "le": "0.25"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
             "le": "1"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
             "le": "5"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
             "le": "15"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
             "le": "60"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
             "le": "180"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
             "le": "600"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "le": "+Inf"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 930.0
+          "value": 932.6205
+        },
+        {
+          "labels": {
+            "field": "prompt_tokens",
+            "result": "invalid"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "invalid"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "invalid"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "invalid"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "invalid"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
         }
       ]
     }
@@ -1645,46 +935,6 @@
       },
       "metric": "nimproxy_request_max_tokens_sum",
       "value": 10240.0
-    },
-    {
-      "labels": {
-        "field": "prompt_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "completion_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "total_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "cached_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "reasoning_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
     },
     {
       "labels": {
@@ -2153,6 +1403,46 @@
       "labels": {},
       "metric": "nimproxy_queue_wait_seconds_sum",
       "value": 932.6205
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "invalid"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "invalid"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "invalid"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "invalid"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "invalid"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
     }
   ],
   "window": {

--- a/tests/fixtures/ui/dashboard-observation-measured.json
+++ b/tests/fixtures/ui/dashboard-observation-measured.json
@@ -44,718 +44,8 @@
           40
         ]
       },
-      "duration_seconds": 1296000,
+      "duration_seconds": 2592000,
       "from": 1697411600,
-      "to": 1698707600,
-      "values": [
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "path": "/v1/chat/completions",
-            "status": "200"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 15.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/zeta",
-            "path": "/v1/chat/completions",
-            "status": "504"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "reason": "stop"
-          },
-          "metric": "nimproxy_finish_reason_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "stream": "true"
-          },
-          "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "mode": "auto"
-          },
-          "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_json_mode_total",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "result": "sticky"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "result": "spill"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "lane": "0"
-          },
-          "metric": "nimproxy_lane_requests_total",
-          "value": 16.0
-        },
-        {
-          "labels": {
-            "lane": "0",
-            "status": "429"
-          },
-          "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_worker_exhausted_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_shed_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_unauthorized_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_login_failures_total",
-          "value": 0.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.05",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_sum",
-          "value": 1.5
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "20",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "40",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "80",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "160",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "320",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_sum",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "le": "0.005",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.01",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.02",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.04",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "0.08",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.16",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.32",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_sum",
-          "value": 0.11599999999999999
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "120",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "300",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_sum",
-          "value": 5.6
-        },
-        {
-          "labels": {
-            "le": "0.001"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.05"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "1"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "15"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "180"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "600"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 2.6205
-        }
-      ]
-    },
-    {
-      "capacity": {
-        "average_rpm": 80.0,
-        "latest_rpms": [
-          40,
-          40
-        ]
-      },
-      "duration_seconds": 1296000,
-      "from": 1698707600,
       "to": 1700003600,
       "values": [
         {
@@ -766,7 +56,7 @@
             "status": "200"
           },
           "metric": "nimproxy_requests_total",
-          "value": 15.0
+          "value": 30.0
         },
         {
           "labels": {
@@ -776,7 +66,7 @@
             "status": "504"
           },
           "metric": "nimproxy_requests_total",
-          "value": 2.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -784,7 +74,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
+          "value": 1200.0
         },
         {
           "labels": {
@@ -793,14 +83,14 @@
             "source": "usage"
           },
           "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
+          "value": 300.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
+          "value": 60.0
         },
         {
           "labels": {
@@ -808,7 +98,7 @@
             "reason": "stop"
           },
           "metric": "nimproxy_finish_reason_total",
-          "value": 13.0
+          "value": 25.0
         },
         {
           "labels": {
@@ -816,49 +106,49 @@
             "stream": "true"
           },
           "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
+          "value": 20.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
+          "value": 8.0
         },
         {
           "labels": {
             "mode": "auto"
           },
           "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_json_mode_total",
-          "value": 2.0
+          "value": 4.0
         },
         {
           "labels": {
             "result": "sticky"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 12.0
+          "value": 24.0
         },
         {
           "labels": {
             "result": "spill"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
             "lane": "0"
           },
           "metric": "nimproxy_lane_requests_total",
-          "value": 17.0
+          "value": 33.0
         },
         {
           "labels": {
@@ -866,7 +156,7 @@
             "status": "429"
           },
           "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -895,96 +185,56 @@
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
+          "value": 15.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
+          "value": 40.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
+          "value": 7.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
+          "value": 10240.0
         },
         {
           "labels": {
@@ -992,7 +242,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1000,7 +250,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1008,7 +258,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1016,7 +266,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1024,7 +274,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1032,7 +282,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1040,7 +290,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1048,7 +298,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1056,7 +306,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1064,7 +314,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1072,21 +322,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_sum",
-          "value": 43.5
+          "value": 45.0
         },
         {
           "labels": {
@@ -1095,7 +345,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1104,7 +354,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1113,7 +363,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1122,7 +372,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1131,7 +381,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1140,7 +390,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1149,7 +399,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1158,7 +408,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1167,7 +417,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1176,7 +426,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1184,7 +434,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1192,7 +442,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_sum",
-          "value": 880.0
+          "value": 910.0
         },
         {
           "labels": {
@@ -1200,7 +450,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1208,7 +458,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1216,7 +466,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1224,7 +474,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1232,7 +482,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1240,7 +490,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1248,7 +498,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1256,21 +506,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_sum",
-          "value": 1.8599999999999999
+          "value": 1.976
         },
         {
           "labels": {
@@ -1278,7 +528,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1286,7 +536,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1294,7 +544,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1302,7 +552,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1310,7 +560,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1318,7 +568,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1326,7 +576,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1334,7 +584,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1342,7 +592,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1350,7 +600,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1358,101 +608,141 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_sum",
-          "value": 417.0
+          "value": 422.6
         },
         {
           "labels": {
             "le": "0.001"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
             "le": "0.05"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
             "le": "0.25"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
             "le": "1"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
             "le": "5"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
             "le": "15"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
             "le": "60"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
             "le": "180"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
             "le": "600"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "le": "+Inf"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 930.0
+          "value": 932.6205
+        },
+        {
+          "labels": {
+            "field": "prompt_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
         }
       ]
     }
@@ -1645,46 +935,6 @@
       },
       "metric": "nimproxy_request_max_tokens_sum",
       "value": 10240.0
-    },
-    {
-      "labels": {
-        "field": "prompt_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "completion_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "total_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "cached_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "reasoning_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
     },
     {
       "labels": {
@@ -2153,6 +1403,46 @@
       "labels": {},
       "metric": "nimproxy_queue_wait_seconds_sum",
       "value": 932.6205
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
     }
   ],
   "window": {

--- a/tests/fixtures/ui/dashboard-observation-tie-estimated.json
+++ b/tests/fixtures/ui/dashboard-observation-tie-estimated.json
@@ -44,718 +44,8 @@
           40
         ]
       },
-      "duration_seconds": 1296000,
+      "duration_seconds": 2592000,
       "from": 1697411600,
-      "to": 1698707600,
-      "values": [
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "path": "/v1/chat/completions",
-            "status": "200"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 15.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/zeta",
-            "path": "/v1/chat/completions",
-            "status": "504"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "reason": "stop"
-          },
-          "metric": "nimproxy_finish_reason_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "stream": "true"
-          },
-          "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "mode": "auto"
-          },
-          "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_json_mode_total",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "result": "sticky"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "result": "spill"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "lane": "0"
-          },
-          "metric": "nimproxy_lane_requests_total",
-          "value": 16.0
-        },
-        {
-          "labels": {
-            "lane": "0",
-            "status": "429"
-          },
-          "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_worker_exhausted_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_shed_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_unauthorized_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_login_failures_total",
-          "value": 0.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.05",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_sum",
-          "value": 1.5
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "20",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "40",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "80",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "160",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "320",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_sum",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "le": "0.005",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.01",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.02",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.04",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "0.08",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.16",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.32",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_sum",
-          "value": 0.11599999999999999
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "120",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "300",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_sum",
-          "value": 5.6
-        },
-        {
-          "labels": {
-            "le": "0.001"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.05"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "1"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "15"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "180"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "600"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 2.6205
-        }
-      ]
-    },
-    {
-      "capacity": {
-        "average_rpm": 80.0,
-        "latest_rpms": [
-          40,
-          40
-        ]
-      },
-      "duration_seconds": 1296000,
-      "from": 1698707600,
       "to": 1700003600,
       "values": [
         {
@@ -766,7 +56,7 @@
             "status": "200"
           },
           "metric": "nimproxy_requests_total",
-          "value": 15.0
+          "value": 30.0
         },
         {
           "labels": {
@@ -776,7 +66,7 @@
             "status": "504"
           },
           "metric": "nimproxy_requests_total",
-          "value": 2.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -784,7 +74,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
+          "value": 1200.0
         },
         {
           "labels": {
@@ -793,14 +83,14 @@
             "source": "usage"
           },
           "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
+          "value": 300.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
+          "value": 60.0
         },
         {
           "labels": {
@@ -808,7 +98,7 @@
             "reason": "stop"
           },
           "metric": "nimproxy_finish_reason_total",
-          "value": 13.0
+          "value": 25.0
         },
         {
           "labels": {
@@ -816,49 +106,49 @@
             "stream": "true"
           },
           "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
+          "value": 20.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
+          "value": 8.0
         },
         {
           "labels": {
             "mode": "auto"
           },
           "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_json_mode_total",
-          "value": 2.0
+          "value": 4.0
         },
         {
           "labels": {
             "result": "sticky"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 12.0
+          "value": 24.0
         },
         {
           "labels": {
             "result": "spill"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
             "lane": "0"
           },
           "metric": "nimproxy_lane_requests_total",
-          "value": 17.0
+          "value": 33.0
         },
         {
           "labels": {
@@ -866,7 +156,7 @@
             "status": "429"
           },
           "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -895,96 +185,56 @@
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
+          "value": 15.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
+          "value": 40.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
+          "value": 7.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
+          "value": 10240.0
         },
         {
           "labels": {
@@ -992,7 +242,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1000,7 +250,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1008,7 +258,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1016,7 +266,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1024,7 +274,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1032,7 +282,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1040,7 +290,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1048,7 +298,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1056,7 +306,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1064,7 +314,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1072,21 +322,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_sum",
-          "value": 43.5
+          "value": 45.0
         },
         {
           "labels": {
@@ -1095,7 +345,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1104,7 +354,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1113,7 +363,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1122,7 +372,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1131,7 +381,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1140,7 +390,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1149,7 +399,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1158,7 +408,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1167,7 +417,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1176,7 +426,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1184,7 +434,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1192,7 +442,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_sum",
-          "value": 880.0
+          "value": 910.0
         },
         {
           "labels": {
@@ -1200,7 +450,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1208,7 +458,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1216,7 +466,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1224,7 +474,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1232,7 +482,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1240,7 +490,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1248,7 +498,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1256,21 +506,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_sum",
-          "value": 1.8599999999999999
+          "value": 1.976
         },
         {
           "labels": {
@@ -1278,7 +528,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1286,7 +536,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1294,7 +544,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1302,7 +552,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1310,7 +560,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1318,7 +568,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1326,7 +576,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1334,7 +584,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1342,7 +592,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1350,7 +600,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1358,101 +608,181 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_sum",
-          "value": 417.0
+          "value": 422.6
         },
         {
           "labels": {
             "le": "0.001"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
             "le": "0.05"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
             "le": "0.25"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
             "le": "1"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
             "le": "5"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
             "le": "15"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
             "le": "60"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
             "le": "180"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
             "le": "600"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "le": "+Inf"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 930.0
+          "value": 932.6205
+        },
+        {
+          "labels": {
+            "field": "prompt_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "prompt_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
         }
       ]
     }
@@ -1645,46 +975,6 @@
       },
       "metric": "nimproxy_request_max_tokens_sum",
       "value": 10240.0
-    },
-    {
-      "labels": {
-        "field": "prompt_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "completion_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "total_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "cached_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "reasoning_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
     },
     {
       "labels": {
@@ -2153,6 +1443,86 @@
       "labels": {},
       "metric": "nimproxy_queue_wait_seconds_sum",
       "value": 932.6205
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
     }
   ],
   "window": {

--- a/tests/fixtures/ui/dashboard-observation-tie-invalid.json
+++ b/tests/fixtures/ui/dashboard-observation-tie-invalid.json
@@ -44,718 +44,8 @@
           40
         ]
       },
-      "duration_seconds": 1296000,
+      "duration_seconds": 2592000,
       "from": 1697411600,
-      "to": 1698707600,
-      "values": [
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "path": "/v1/chat/completions",
-            "status": "200"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 15.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/zeta",
-            "path": "/v1/chat/completions",
-            "status": "504"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "reason": "stop"
-          },
-          "metric": "nimproxy_finish_reason_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "stream": "true"
-          },
-          "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "mode": "auto"
-          },
-          "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_json_mode_total",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "result": "sticky"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "result": "spill"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "lane": "0"
-          },
-          "metric": "nimproxy_lane_requests_total",
-          "value": 16.0
-        },
-        {
-          "labels": {
-            "lane": "0",
-            "status": "429"
-          },
-          "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_worker_exhausted_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_shed_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_unauthorized_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_login_failures_total",
-          "value": 0.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.05",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_sum",
-          "value": 1.5
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "20",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "40",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "80",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "160",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "320",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_sum",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "le": "0.005",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.01",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.02",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.04",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "0.08",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.16",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.32",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_sum",
-          "value": 0.11599999999999999
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "120",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "300",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_sum",
-          "value": 5.6
-        },
-        {
-          "labels": {
-            "le": "0.001"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.05"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "1"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "15"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "180"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "600"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 2.6205
-        }
-      ]
-    },
-    {
-      "capacity": {
-        "average_rpm": 80.0,
-        "latest_rpms": [
-          40,
-          40
-        ]
-      },
-      "duration_seconds": 1296000,
-      "from": 1698707600,
       "to": 1700003600,
       "values": [
         {
@@ -766,7 +56,7 @@
             "status": "200"
           },
           "metric": "nimproxy_requests_total",
-          "value": 15.0
+          "value": 30.0
         },
         {
           "labels": {
@@ -776,7 +66,7 @@
             "status": "504"
           },
           "metric": "nimproxy_requests_total",
-          "value": 2.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -784,7 +74,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
+          "value": 1200.0
         },
         {
           "labels": {
@@ -793,14 +83,14 @@
             "source": "usage"
           },
           "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
+          "value": 300.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
+          "value": 60.0
         },
         {
           "labels": {
@@ -808,7 +98,7 @@
             "reason": "stop"
           },
           "metric": "nimproxy_finish_reason_total",
-          "value": 13.0
+          "value": 25.0
         },
         {
           "labels": {
@@ -816,49 +106,49 @@
             "stream": "true"
           },
           "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
+          "value": 20.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
+          "value": 8.0
         },
         {
           "labels": {
             "mode": "auto"
           },
           "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_json_mode_total",
-          "value": 2.0
+          "value": 4.0
         },
         {
           "labels": {
             "result": "sticky"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 12.0
+          "value": 24.0
         },
         {
           "labels": {
             "result": "spill"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
             "lane": "0"
           },
           "metric": "nimproxy_lane_requests_total",
-          "value": 17.0
+          "value": 33.0
         },
         {
           "labels": {
@@ -866,7 +156,7 @@
             "status": "429"
           },
           "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -895,96 +185,56 @@
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
+          "value": 15.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
+          "value": 40.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
+          "value": 7.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
+          "value": 10240.0
         },
         {
           "labels": {
@@ -992,7 +242,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1000,7 +250,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1008,7 +258,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1016,7 +266,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1024,7 +274,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1032,7 +282,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1040,7 +290,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1048,7 +298,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1056,7 +306,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1064,7 +314,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1072,21 +322,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_sum",
-          "value": 43.5
+          "value": 45.0
         },
         {
           "labels": {
@@ -1095,7 +345,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1104,7 +354,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1113,7 +363,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1122,7 +372,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1131,7 +381,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1140,7 +390,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1149,7 +399,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1158,7 +408,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1167,7 +417,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1176,7 +426,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1184,7 +434,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1192,7 +442,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_sum",
-          "value": 880.0
+          "value": 910.0
         },
         {
           "labels": {
@@ -1200,7 +450,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1208,7 +458,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1216,7 +466,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1224,7 +474,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1232,7 +482,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1240,7 +490,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1248,7 +498,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1256,21 +506,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_sum",
-          "value": 1.8599999999999999
+          "value": 1.976
         },
         {
           "labels": {
@@ -1278,7 +528,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1286,7 +536,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1294,7 +544,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1302,7 +552,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1310,7 +560,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1318,7 +568,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1326,7 +576,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1334,7 +584,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1342,7 +592,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1350,7 +600,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1358,101 +608,261 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_sum",
-          "value": 417.0
+          "value": 422.6
         },
         {
           "labels": {
             "le": "0.001"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
             "le": "0.05"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
             "le": "0.25"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
             "le": "1"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
             "le": "5"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
             "le": "15"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
             "le": "60"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
             "le": "180"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
             "le": "600"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "le": "+Inf"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 930.0
+          "value": 932.6205
+        },
+        {
+          "labels": {
+            "field": "prompt_tokens",
+            "result": "invalid"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "invalid"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "invalid"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "invalid"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "invalid"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "prompt_tokens",
+            "result": "unavailable"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "unavailable"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "unavailable"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "unavailable"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "unavailable"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "prompt_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "prompt_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
         }
       ]
     }
@@ -1645,46 +1055,6 @@
       },
       "metric": "nimproxy_request_max_tokens_sum",
       "value": 10240.0
-    },
-    {
-      "labels": {
-        "field": "prompt_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "completion_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "total_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "cached_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "reasoning_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
     },
     {
       "labels": {
@@ -2153,6 +1523,166 @@
       "labels": {},
       "metric": "nimproxy_queue_wait_seconds_sum",
       "value": 932.6205
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "invalid"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "invalid"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "invalid"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "invalid"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "invalid"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "unavailable"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "unavailable"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "unavailable"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "unavailable"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "unavailable"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
     }
   ],
   "window": {

--- a/tests/fixtures/ui/dashboard-observation-tie-unavailable.json
+++ b/tests/fixtures/ui/dashboard-observation-tie-unavailable.json
@@ -44,718 +44,8 @@
           40
         ]
       },
-      "duration_seconds": 1296000,
+      "duration_seconds": 2592000,
       "from": 1697411600,
-      "to": 1698707600,
-      "values": [
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "path": "/v1/chat/completions",
-            "status": "200"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 15.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/zeta",
-            "path": "/v1/chat/completions",
-            "status": "504"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "reason": "stop"
-          },
-          "metric": "nimproxy_finish_reason_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "stream": "true"
-          },
-          "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "mode": "auto"
-          },
-          "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_json_mode_total",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "result": "sticky"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "result": "spill"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "lane": "0"
-          },
-          "metric": "nimproxy_lane_requests_total",
-          "value": 16.0
-        },
-        {
-          "labels": {
-            "lane": "0",
-            "status": "429"
-          },
-          "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_worker_exhausted_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_shed_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_unauthorized_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_login_failures_total",
-          "value": 0.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.05",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_sum",
-          "value": 1.5
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "20",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "40",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "80",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "160",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "320",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_sum",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "le": "0.005",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.01",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.02",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.04",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "0.08",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.16",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.32",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_sum",
-          "value": 0.11599999999999999
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "120",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "300",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_sum",
-          "value": 5.6
-        },
-        {
-          "labels": {
-            "le": "0.001"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.05"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "1"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "15"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "180"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "600"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 2.6205
-        }
-      ]
-    },
-    {
-      "capacity": {
-        "average_rpm": 80.0,
-        "latest_rpms": [
-          40,
-          40
-        ]
-      },
-      "duration_seconds": 1296000,
-      "from": 1698707600,
       "to": 1700003600,
       "values": [
         {
@@ -766,7 +56,7 @@
             "status": "200"
           },
           "metric": "nimproxy_requests_total",
-          "value": 15.0
+          "value": 30.0
         },
         {
           "labels": {
@@ -776,7 +66,7 @@
             "status": "504"
           },
           "metric": "nimproxy_requests_total",
-          "value": 2.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -784,7 +74,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
+          "value": 1200.0
         },
         {
           "labels": {
@@ -793,14 +83,14 @@
             "source": "usage"
           },
           "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
+          "value": 300.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
+          "value": 60.0
         },
         {
           "labels": {
@@ -808,7 +98,7 @@
             "reason": "stop"
           },
           "metric": "nimproxy_finish_reason_total",
-          "value": 13.0
+          "value": 25.0
         },
         {
           "labels": {
@@ -816,49 +106,49 @@
             "stream": "true"
           },
           "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
+          "value": 20.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
+          "value": 8.0
         },
         {
           "labels": {
             "mode": "auto"
           },
           "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_json_mode_total",
-          "value": 2.0
+          "value": 4.0
         },
         {
           "labels": {
             "result": "sticky"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 12.0
+          "value": 24.0
         },
         {
           "labels": {
             "result": "spill"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
             "lane": "0"
           },
           "metric": "nimproxy_lane_requests_total",
-          "value": 17.0
+          "value": 33.0
         },
         {
           "labels": {
@@ -866,7 +156,7 @@
             "status": "429"
           },
           "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -895,96 +185,56 @@
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
+          "value": 15.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
+          "value": 40.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
+          "value": 7.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
+          "value": 10240.0
         },
         {
           "labels": {
@@ -992,7 +242,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1000,7 +250,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1008,7 +258,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1016,7 +266,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1024,7 +274,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1032,7 +282,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1040,7 +290,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1048,7 +298,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1056,7 +306,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1064,7 +314,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1072,21 +322,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_sum",
-          "value": 43.5
+          "value": 45.0
         },
         {
           "labels": {
@@ -1095,7 +345,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1104,7 +354,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1113,7 +363,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1122,7 +372,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1131,7 +381,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1140,7 +390,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1149,7 +399,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1158,7 +408,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1167,7 +417,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1176,7 +426,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1184,7 +434,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1192,7 +442,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_sum",
-          "value": 880.0
+          "value": 910.0
         },
         {
           "labels": {
@@ -1200,7 +450,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1208,7 +458,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1216,7 +466,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1224,7 +474,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1232,7 +482,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1240,7 +490,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1248,7 +498,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1256,21 +506,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_sum",
-          "value": 1.8599999999999999
+          "value": 1.976
         },
         {
           "labels": {
@@ -1278,7 +528,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1286,7 +536,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1294,7 +544,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1302,7 +552,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1310,7 +560,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1318,7 +568,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1326,7 +576,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1334,7 +584,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1342,7 +592,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1350,7 +600,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1358,101 +608,221 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_sum",
-          "value": 417.0
+          "value": 422.6
         },
         {
           "labels": {
             "le": "0.001"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
             "le": "0.05"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
             "le": "0.25"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
             "le": "1"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
             "le": "5"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
             "le": "15"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
             "le": "60"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
             "le": "180"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
             "le": "600"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "le": "+Inf"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 930.0
+          "value": 932.6205
+        },
+        {
+          "labels": {
+            "field": "prompt_tokens",
+            "result": "unavailable"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "unavailable"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "unavailable"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "unavailable"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "unavailable"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "prompt_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "estimated"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "prompt_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
         }
       ]
     }
@@ -1645,46 +1015,6 @@
       },
       "metric": "nimproxy_request_max_tokens_sum",
       "value": 10240.0
-    },
-    {
-      "labels": {
-        "field": "prompt_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "completion_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "total_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "cached_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "reasoning_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
     },
     {
       "labels": {
@@ -2153,6 +1483,126 @@
       "labels": {},
       "metric": "nimproxy_queue_wait_seconds_sum",
       "value": 932.6205
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "unavailable"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "unavailable"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "unavailable"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "unavailable"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "unavailable"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "estimated"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
     }
   ],
   "window": {

--- a/tests/fixtures/ui/dashboard-observation-unavailable.json
+++ b/tests/fixtures/ui/dashboard-observation-unavailable.json
@@ -44,718 +44,8 @@
           40
         ]
       },
-      "duration_seconds": 1296000,
+      "duration_seconds": 2592000,
       "from": 1697411600,
-      "to": 1698707600,
-      "values": [
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "path": "/v1/chat/completions",
-            "status": "200"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 15.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/zeta",
-            "path": "/v1/chat/completions",
-            "status": "504"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "reason": "stop"
-          },
-          "metric": "nimproxy_finish_reason_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "stream": "true"
-          },
-          "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "mode": "auto"
-          },
-          "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_json_mode_total",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "result": "sticky"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "result": "spill"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "lane": "0"
-          },
-          "metric": "nimproxy_lane_requests_total",
-          "value": 16.0
-        },
-        {
-          "labels": {
-            "lane": "0",
-            "status": "429"
-          },
-          "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_worker_exhausted_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_shed_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_unauthorized_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_login_failures_total",
-          "value": 0.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.05",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_sum",
-          "value": 1.5
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "20",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "40",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "80",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "160",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "320",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_sum",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "le": "0.005",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.01",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.02",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.04",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "0.08",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.16",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.32",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_sum",
-          "value": 0.11599999999999999
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "120",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "300",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_sum",
-          "value": 5.6
-        },
-        {
-          "labels": {
-            "le": "0.001"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.05"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "1"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "15"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "180"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "600"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 2.6205
-        }
-      ]
-    },
-    {
-      "capacity": {
-        "average_rpm": 80.0,
-        "latest_rpms": [
-          40,
-          40
-        ]
-      },
-      "duration_seconds": 1296000,
-      "from": 1698707600,
       "to": 1700003600,
       "values": [
         {
@@ -766,7 +56,7 @@
             "status": "200"
           },
           "metric": "nimproxy_requests_total",
-          "value": 15.0
+          "value": 30.0
         },
         {
           "labels": {
@@ -776,7 +66,7 @@
             "status": "504"
           },
           "metric": "nimproxy_requests_total",
-          "value": 2.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -784,7 +74,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
+          "value": 1200.0
         },
         {
           "labels": {
@@ -793,14 +83,14 @@
             "source": "usage"
           },
           "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
+          "value": 300.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
+          "value": 60.0
         },
         {
           "labels": {
@@ -808,7 +98,7 @@
             "reason": "stop"
           },
           "metric": "nimproxy_finish_reason_total",
-          "value": 13.0
+          "value": 25.0
         },
         {
           "labels": {
@@ -816,49 +106,49 @@
             "stream": "true"
           },
           "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
+          "value": 20.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
+          "value": 8.0
         },
         {
           "labels": {
             "mode": "auto"
           },
           "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_json_mode_total",
-          "value": 2.0
+          "value": 4.0
         },
         {
           "labels": {
             "result": "sticky"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 12.0
+          "value": 24.0
         },
         {
           "labels": {
             "result": "spill"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
             "lane": "0"
           },
           "metric": "nimproxy_lane_requests_total",
-          "value": 17.0
+          "value": 33.0
         },
         {
           "labels": {
@@ -866,7 +156,7 @@
             "status": "429"
           },
           "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -895,96 +185,56 @@
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
+          "value": 15.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
+          "value": 40.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
+          "value": 7.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
+          "value": 10240.0
         },
         {
           "labels": {
@@ -992,7 +242,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1000,7 +250,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1008,7 +258,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1016,7 +266,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1024,7 +274,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1032,7 +282,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1040,7 +290,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1048,7 +298,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1056,7 +306,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1064,7 +314,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1072,21 +322,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_sum",
-          "value": 43.5
+          "value": 45.0
         },
         {
           "labels": {
@@ -1095,7 +345,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1104,7 +354,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1113,7 +363,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1122,7 +372,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1131,7 +381,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1140,7 +390,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1149,7 +399,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1158,7 +408,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1167,7 +417,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1176,7 +426,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1184,7 +434,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1192,7 +442,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_sum",
-          "value": 880.0
+          "value": 910.0
         },
         {
           "labels": {
@@ -1200,7 +450,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1208,7 +458,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1216,7 +466,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1224,7 +474,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1232,7 +482,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1240,7 +490,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1248,7 +498,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1256,21 +506,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_sum",
-          "value": 1.8599999999999999
+          "value": 1.976
         },
         {
           "labels": {
@@ -1278,7 +528,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1286,7 +536,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1294,7 +544,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1302,7 +552,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1310,7 +560,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1318,7 +568,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1326,7 +576,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1334,7 +584,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1342,7 +592,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1350,7 +600,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1358,101 +608,141 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_sum",
-          "value": 417.0
+          "value": 422.6
         },
         {
           "labels": {
             "le": "0.001"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
             "le": "0.05"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
             "le": "0.25"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
             "le": "1"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
             "le": "5"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
             "le": "15"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
             "le": "60"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
             "le": "180"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
             "le": "600"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "le": "+Inf"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 930.0
+          "value": 932.6205
+        },
+        {
+          "labels": {
+            "field": "prompt_tokens",
+            "result": "unavailable"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "unavailable"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "unavailable"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "unavailable"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "unavailable"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 9.0
         }
       ]
     }
@@ -1645,46 +935,6 @@
       },
       "metric": "nimproxy_request_max_tokens_sum",
       "value": 10240.0
-    },
-    {
-      "labels": {
-        "field": "prompt_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "completion_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "total_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "cached_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "reasoning_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
     },
     {
       "labels": {
@@ -2153,6 +1403,46 @@
       "labels": {},
       "metric": "nimproxy_queue_wait_seconds_sum",
       "value": 932.6205
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "unavailable"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "unavailable"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "unavailable"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "unavailable"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "unavailable"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 9.0
     }
   ],
   "window": {

--- a/tests/fixtures/ui/dashboard-observation-zero.json
+++ b/tests/fixtures/ui/dashboard-observation-zero.json
@@ -44,718 +44,8 @@
           40
         ]
       },
-      "duration_seconds": 1296000,
+      "duration_seconds": 2592000,
       "from": 1697411600,
-      "to": 1698707600,
-      "values": [
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "path": "/v1/chat/completions",
-            "status": "200"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 15.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/zeta",
-            "path": "/v1/chat/completions",
-            "status": "504"
-          },
-          "metric": "nimproxy_requests_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "reason": "stop"
-          },
-          "metric": "nimproxy_finish_reason_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client",
-            "stream": "true"
-          },
-          "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "mode": "auto"
-          },
-          "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_json_mode_total",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "result": "sticky"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 12.0
-        },
-        {
-          "labels": {
-            "result": "spill"
-          },
-          "metric": "nimproxy_affinity_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "lane": "0"
-          },
-          "metric": "nimproxy_lane_requests_total",
-          "value": 16.0
-        },
-        {
-          "labels": {
-            "lane": "0",
-            "status": "429"
-          },
-          "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_worker_exhausted_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_shed_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_unauthorized_total",
-          "value": 0.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_login_failures_total",
-          "value": 0.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "client": "fixture-client"
-          },
-          "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.05",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_ttft_seconds_sum",
-          "value": 1.5
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "20",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "40",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "80",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "160",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "320",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha",
-            "source": "usage"
-          },
-          "metric": "nimproxy_tokens_per_second_sum",
-          "value": 30.0
-        },
-        {
-          "labels": {
-            "le": "0.005",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.01",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.02",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "0.04",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "0.08",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.16",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "0.32",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_tpot_seconds_sum",
-          "value": 0.11599999999999999
-        },
-        {
-          "labels": {
-            "le": "0.25",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "1",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "2",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "10",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "30",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "120",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "300",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf",
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "model": "fixture/alpha"
-          },
-          "metric": "nimproxy_upstream_seconds_sum",
-          "value": 5.6
-        },
-        {
-          "labels": {
-            "le": "0.001"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
-        },
-        {
-          "labels": {
-            "le": "0.05"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
-        },
-        {
-          "labels": {
-            "le": "0.25"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
-        },
-        {
-          "labels": {
-            "le": "1"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 4.0
-        },
-        {
-          "labels": {
-            "le": "5"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "15"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "60"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "180"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "600"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "le": "+Inf"
-          },
-          "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
-        },
-        {
-          "labels": {},
-          "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 2.6205
-        }
-      ]
-    },
-    {
-      "capacity": {
-        "average_rpm": 80.0,
-        "latest_rpms": [
-          40,
-          40
-        ]
-      },
-      "duration_seconds": 1296000,
-      "from": 1698707600,
       "to": 1700003600,
       "values": [
         {
@@ -766,7 +56,7 @@
             "status": "200"
           },
           "metric": "nimproxy_requests_total",
-          "value": 15.0
+          "value": 30.0
         },
         {
           "labels": {
@@ -776,7 +66,7 @@
             "status": "504"
           },
           "metric": "nimproxy_requests_total",
-          "value": 2.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -784,7 +74,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_prompt_tokens_total",
-          "value": 600.0
+          "value": 1200.0
         },
         {
           "labels": {
@@ -793,14 +83,14 @@
             "source": "usage"
           },
           "metric": "nimproxy_completion_tokens_total",
-          "value": 150.0
+          "value": 300.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_reasoning_tokens_total",
-          "value": 30.0
+          "value": 60.0
         },
         {
           "labels": {
@@ -808,7 +98,7 @@
             "reason": "stop"
           },
           "metric": "nimproxy_finish_reason_total",
-          "value": 13.0
+          "value": 25.0
         },
         {
           "labels": {
@@ -816,49 +106,49 @@
             "stream": "true"
           },
           "metric": "nimproxy_stream_requests_total",
-          "value": 10.0
+          "value": 20.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tool_calls_total",
-          "value": 4.0
+          "value": 8.0
         },
         {
           "labels": {
             "mode": "auto"
           },
           "metric": "nimproxy_tool_choice_total",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_json_mode_total",
-          "value": 2.0
+          "value": 4.0
         },
         {
           "labels": {
             "result": "sticky"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 12.0
+          "value": 24.0
         },
         {
           "labels": {
             "result": "spill"
           },
           "metric": "nimproxy_affinity_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
             "lane": "0"
           },
           "metric": "nimproxy_lane_requests_total",
-          "value": 17.0
+          "value": 33.0
         },
         {
           "labels": {
@@ -866,7 +156,7 @@
             "status": "429"
           },
           "metric": "nimproxy_lane_cooldown_total",
-          "value": 1.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -895,96 +185,56 @@
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_tools_sum",
-          "value": 7.5
+          "value": 15.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_messages_sum",
-          "value": 20.0
+          "value": 40.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_temperature_sum",
-          "value": 3.5
+          "value": 7.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "client": "fixture-client"
           },
           "metric": "nimproxy_request_max_tokens_sum",
-          "value": 5120.0
-        },
-        {
-          "labels": {
-            "field": "prompt_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "completion_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "total_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "cached_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
-        },
-        {
-          "labels": {
-            "field": "reasoning_tokens",
-            "result": "measured"
-          },
-          "metric": "nimproxy_usage_observations_total",
-          "value": 5.0
+          "value": 10240.0
         },
         {
           "labels": {
@@ -992,7 +242,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1000,7 +250,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1008,7 +258,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1016,7 +266,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1024,7 +274,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1032,7 +282,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1040,7 +290,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1048,7 +298,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1056,7 +306,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1064,7 +314,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1072,21 +322,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_ttft_seconds_sum",
-          "value": 43.5
+          "value": 45.0
         },
         {
           "labels": {
@@ -1095,7 +345,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1104,7 +354,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1113,7 +363,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1122,7 +372,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1131,7 +381,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1140,7 +390,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1149,7 +399,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1158,7 +408,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1167,7 +417,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1176,7 +426,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1184,7 +434,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1192,7 +442,7 @@
             "source": "usage"
           },
           "metric": "nimproxy_tokens_per_second_sum",
-          "value": 880.0
+          "value": 910.0
         },
         {
           "labels": {
@@ -1200,7 +450,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1208,7 +458,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1216,7 +466,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1224,7 +474,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1232,7 +482,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1240,7 +490,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1248,7 +498,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1256,21 +506,21 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_tpot_seconds_sum",
-          "value": 1.8599999999999999
+          "value": 1.976
         },
         {
           "labels": {
@@ -1278,7 +528,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
@@ -1286,7 +536,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
@@ -1294,7 +544,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
@@ -1302,7 +552,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
@@ -1310,7 +560,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
@@ -1318,7 +568,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
@@ -1326,7 +576,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
@@ -1334,7 +584,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
@@ -1342,7 +592,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 4.0
+          "value": 9.0
         },
         {
           "labels": {
@@ -1350,7 +600,7 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
@@ -1358,101 +608,141 @@
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "model": "fixture/alpha"
           },
           "metric": "nimproxy_upstream_seconds_sum",
-          "value": 417.0
+          "value": 422.6
         },
         {
           "labels": {
             "le": "0.001"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 1.0
         },
         {
           "labels": {
             "le": "0.05"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 2.0
         },
         {
           "labels": {
             "le": "0.25"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 3.0
         },
         {
           "labels": {
             "le": "1"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 4.0
         },
         {
           "labels": {
             "le": "5"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 0.0
+          "value": 5.0
         },
         {
           "labels": {
             "le": "15"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 1.0
+          "value": 6.0
         },
         {
           "labels": {
             "le": "60"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 2.0
+          "value": 7.0
         },
         {
           "labels": {
             "le": "180"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 3.0
+          "value": 8.0
         },
         {
           "labels": {
             "le": "600"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {
             "le": "+Inf"
           },
           "metric": "nimproxy_queue_wait_seconds_bucket",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_count",
-          "value": 5.0
+          "value": 10.0
         },
         {
           "labels": {},
           "metric": "nimproxy_queue_wait_seconds_sum",
-          "value": 930.0
+          "value": 932.6205
+        },
+        {
+          "labels": {
+            "field": "prompt_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 0.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 0.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 0.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 0.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 0.0
         }
       ]
     }
@@ -1645,46 +935,6 @@
       },
       "metric": "nimproxy_request_max_tokens_sum",
       "value": 10240.0
-    },
-    {
-      "labels": {
-        "field": "prompt_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "completion_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "total_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "cached_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
-    },
-    {
-      "labels": {
-        "field": "reasoning_tokens",
-        "result": "measured"
-      },
-      "metric": "nimproxy_usage_observations_total",
-      "value": 10.0
     },
     {
       "labels": {
@@ -2153,6 +1403,46 @@
       "labels": {},
       "metric": "nimproxy_queue_wait_seconds_sum",
       "value": 932.6205
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 0.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 0.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 0.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 0.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 0.0
     }
   ],
   "window": {

--- a/tests/fixtures/ui/dashboard-partial.json
+++ b/tests/fixtures/ui/dashboard-partial.json
@@ -238,6 +238,46 @@
         },
         {
           "labels": {
+            "field": "prompt_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 5.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 5.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 5.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 5.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 5.0
+        },
+        {
+          "labels": {
             "le": "0.05",
             "model": "fixture/alpha"
           },
@@ -908,6 +948,46 @@
         },
         {
           "labels": {
+            "field": "prompt_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 5.0
+        },
+        {
+          "labels": {
+            "field": "completion_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 5.0
+        },
+        {
+          "labels": {
+            "field": "total_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 5.0
+        },
+        {
+          "labels": {
+            "field": "cached_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 5.0
+        },
+        {
+          "labels": {
+            "field": "reasoning_tokens",
+            "result": "measured"
+          },
+          "metric": "nimproxy_usage_observations_total",
+          "value": 5.0
+        },
+        {
+          "labels": {
             "le": "0.05",
             "model": "fixture/alpha"
           },
@@ -1565,6 +1645,46 @@
       },
       "metric": "nimproxy_request_max_tokens_sum",
       "value": 10240.0
+    },
+    {
+      "labels": {
+        "field": "prompt_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 10.0
+    },
+    {
+      "labels": {
+        "field": "completion_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 10.0
+    },
+    {
+      "labels": {
+        "field": "total_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 10.0
+    },
+    {
+      "labels": {
+        "field": "cached_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 10.0
+    },
+    {
+      "labels": {
+        "field": "reasoning_tokens",
+        "result": "measured"
+      },
+      "metric": "nimproxy_usage_observations_total",
+      "value": 10.0
     },
     {
       "labels": {

--- a/tests/fixtures/ui/scenarios.json
+++ b/tests/fixtures/ui/scenarios.json
@@ -815,6 +815,46 @@
           },
           {
             "labels": {
+              "field": "prompt_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "completion_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "total_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "cached_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "reasoning_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
               "le": "0.05",
               "model": "fixture/alpha"
             },
@@ -1485,6 +1525,46 @@
           },
           {
             "labels": {
+              "field": "prompt_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "completion_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "total_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "cached_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "reasoning_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
               "le": "0.05",
               "model": "fixture/alpha"
             },
@@ -2142,6 +2222,46 @@
         },
         "metric": "nimproxy_request_max_tokens_sum",
         "value": 10240.0
+      },
+      {
+        "labels": {
+          "field": "prompt_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "completion_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "total_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "cached_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "reasoning_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
       },
       {
         "labels": {
@@ -2857,6 +2977,46 @@
       },
       {
         "labels": {
+          "field": "prompt_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "completion_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "total_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "cached_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "reasoning_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
           "le": "0.05",
           "model": "fixture/alpha"
         },
@@ -3560,6 +3720,46 @@
         },
         "metric": "nimproxy_request_max_tokens_sum",
         "value": 10240.0
+      },
+      {
+        "labels": {
+          "field": "prompt_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "completion_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "total_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "cached_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "reasoning_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
       },
       {
         "labels": {
@@ -4267,6 +4467,46 @@
         },
         "metric": "nimproxy_request_max_tokens_sum",
         "value": 10240.0
+      },
+      {
+        "labels": {
+          "field": "prompt_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "completion_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "total_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "cached_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "reasoning_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
       },
       {
         "labels": {
@@ -5017,6 +5257,46 @@
           },
           {
             "labels": {
+              "field": "prompt_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "completion_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "total_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "cached_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "reasoning_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
               "le": "0.05",
               "model": "fixture/alpha"
             },
@@ -5687,6 +5967,46 @@
           },
           {
             "labels": {
+              "field": "prompt_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "completion_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "total_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "cached_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
+              "field": "reasoning_tokens",
+              "result": "measured"
+            },
+            "metric": "nimproxy_usage_observations_total",
+            "value": 5.0
+          },
+          {
+            "labels": {
               "le": "0.05",
               "model": "fixture/alpha"
             },
@@ -6344,6 +6664,46 @@
         },
         "metric": "nimproxy_request_max_tokens_sum",
         "value": 10240.0
+      },
+      {
+        "labels": {
+          "field": "prompt_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "completion_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "total_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "cached_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
+      },
+      {
+        "labels": {
+          "field": "reasoning_tokens",
+          "result": "measured"
+        },
+        "metric": "nimproxy_usage_observations_total",
+        "value": 10.0
       },
       {
         "labels": {


### PR DESCRIPTION
Closes #105

Adds the bounded finalized usage-observation counter and one honest Overview quality row without changing API, OpenAPI, history format, request, response, scheduling, or existing metric contracts.

Proof:
- independent review approved with no findings
- 17 observation tests and focused real-proxy E2E
- 69 browser states plus pseudolocale
- 191 unit, 112 E2E with one intentional ignore, and 7 OpenAPI tests
- Clippy with warnings denied, format, i18n, locale, syntax, agent-guide, and diff gates clean