### PR TITLE
fix: accept safe sanitizer checkout modes

### DIFF
--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -4717,6 +4717,31 @@ git commit -m "feat: expose usage observation quality"
 
 **GitHub issue title:** `v0.6.6: run the foundation release gate`
 
+#### Execution record
+
+- 2026-08-01: **Scope delta — Outcome:** make Task 14's committed sanitized
+  fixture check portable to an ordinary current-owner Git checkout, without
+  weakening private capture, staging, or temporary-publication modes. **Proof:**
+  issue #127 first adds a named RED sanitizer self-test that requires an exact
+  public five-file set at non-executable `0664` to pass strict `--check` and
+  the existing manifest-refresh authoring path, while current-owner `0666` and
+  executable fixture leaves still fail with `fixture-set-invalid` and manifest
+  leaves still fail with `manifest-invalid`; the unchanged real fixture check
+  reproduces the host checkout failure before GREEN. **Constraint:**
+  public sanitized fixture and manifest leaves remain current-owner regular
+  files with owner read/write, no execute bits, and no world-write; raw input,
+  staging, and private temporary leaves retain their exact owner-only modes,
+  and fixture/manifest bytes and schemas do not move. **Ponytail Rung:** 6 —
+  extend the existing sanitizer operational self-test before one private
+  destination-only predicate is considered. **Plan → Act → Verify:** recorded
+  `sanitize-checkout-mode` before any validator change; it directly retains all
+  four hostile strict-validation controls and their existing fixture versus
+  manifest error taxonomy. Its 2026-08-01 RED run exits 1 with that sole named
+  control after 33 oracle controls, while the unchanged committed fixture check
+  exits 1 with `fixture-set-invalid` on this `0664` checkout. Python compile,
+  agent-guide check, `cargo fmt --check`, and `git diff --check` exit 0. Only a
+  later dedicated GREEN change may alter destination validation.
+
 **Files:**
 
 - Modify: `README.md`

--- a/docs/plans/v0.6.6-foundation-implementation.md
+++ b/docs/plans/v0.6.6-foundation-implementation.md
@@ -4742,6 +4742,25 @@ git commit -m "feat: expose usage observation quality"
   agent-guide check, `cargo fmt --check`, and `git diff --check` exit 0. Only a
   later dedicated GREEN change may alter destination validation.
 
+- 2026-08-01: **GREEN result — Outcome:** the committed sanitized fixture set
+  now checks from this ordinary current-owner `0664` Git checkout while the
+  frozen hostile-mode boundary remains intact. **Proof:** the private
+  destination-leaf predicate is selected only by explicit public callers for
+  strict check, manifest refresh, and existing-destination update; sanitizer
+  self-test exits 0 with 33 oracle controls and a compliant candidate, strict
+  committed fixture check exits 0, and the retained fixture/manifest
+  `0666`/`0744` controls pass. **Constraint:** public callers require a
+  current-owner regular leaf, owner read/write, no execute bit, and no
+  world-write; the default staging validator retains its pre-issue
+  `0600`/`0644` policy and private `0600` writes. Raw input, directories,
+  fixture/manifest bytes, schemas, and public error taxonomy remain unchanged.
+  **Ponytail Rung:** 6 — one opt-in keyword plus the private predicate at the
+  existing shared validator. **Plan → Act → Verify:** the named control first
+  proves default validation rejects all-`0664` as `fixture-set-invalid`, then
+  proves the explicit public wrapper and refresh accept it; ran Python compile,
+  sanitizer and capture self-tests, strict fixture check, agent-guide check,
+  `cargo fmt --check`, and `git diff --check`; each exits 0.
+
 **Files:**
 
 - Modify: `README.md`

--- a/scripts/sanitize_nim_capture.py
+++ b/scripts/sanitize_nim_capture.py
@@ -1319,6 +1319,77 @@ def operational_cases(sentinel):
         if not fixture_rejected or not manifest_rejected:
             checks.append("sanitize-refresh-destination-mode")
 
+        # A public fixture checkout may retain group write from a normal Git
+        # umask. It stays safe when every leaf is current-owner, regular,
+        # non-executable, and not world-writable; refresh validates that same
+        # existing public set before replacing only its private temporary.
+        checkout_destination = root / "destination-checkout-mode"
+        write_output(input_dir, checkout_destination)
+        checkout_leaves = [checkout_destination / (case + ".json") for case in CASES]
+        checkout_leaves.append(checkout_destination / "manifest.json")
+        for path in checkout_leaves:
+            os.chmod(path, 0o664)
+        try:
+            validate_destination(checkout_destination)
+        except SanitizeError as error:
+            checkout_check_error = str(error)
+        else:
+            checkout_check_error = None
+        checkout_refresh_result = main(["--refresh-manifest", str(checkout_destination)])
+        try:
+            validate_destination(checkout_destination)
+        except SanitizeError as error:
+            checkout_refresh_error = str(error)
+        else:
+            checkout_refresh_error = None
+
+        world_writable_destination = root / "destination-world-writable"
+        write_output(input_dir, world_writable_destination)
+        world_writable_fixture = world_writable_destination / "buffered-basic.json"
+        world_writable_manifest = world_writable_destination / "manifest.json"
+        os.chmod(world_writable_fixture, 0o666)
+        try:
+            validate_destination(world_writable_destination)
+        except SanitizeError as error:
+            world_writable_fixture_error = str(error)
+        else:
+            world_writable_fixture_error = None
+        os.chmod(world_writable_fixture, 0o600)
+        os.chmod(world_writable_manifest, 0o666)
+        try:
+            validate_destination(world_writable_destination)
+        except SanitizeError as error:
+            world_writable_manifest_error = str(error)
+        else:
+            world_writable_manifest_error = None
+
+        executable_destination = root / "destination-executable"
+        write_output(input_dir, executable_destination)
+        executable_fixture = executable_destination / "buffered-basic.json"
+        executable_manifest = executable_destination / "manifest.json"
+        os.chmod(executable_fixture, 0o744)
+        try:
+            validate_destination(executable_destination)
+        except SanitizeError as error:
+            executable_fixture_error = str(error)
+        else:
+            executable_fixture_error = None
+        os.chmod(executable_fixture, 0o600)
+        os.chmod(executable_manifest, 0o744)
+        try:
+            validate_destination(executable_destination)
+        except SanitizeError as error:
+            executable_manifest_error = str(error)
+        else:
+            executable_manifest_error = None
+        if (checkout_check_error is not None or checkout_refresh_result != 0
+                or checkout_refresh_error is not None
+                or world_writable_fixture_error != "fixture-set-invalid"
+                or executable_fixture_error != "fixture-set-invalid"
+                or world_writable_manifest_error != "manifest-invalid"
+                or executable_manifest_error != "manifest-invalid"):
+            checks.append("sanitize-checkout-mode")
+
         # The destination must be a real directory, both for update and check.
         input_dir = root / "raw-destination"
         operational_raw_set(input_dir)

--- a/scripts/sanitize_nim_capture.py
+++ b/scripts/sanitize_nim_capture.py
@@ -547,7 +547,18 @@ def _open_destination(destination, create=False):
         raise SanitizeError("fixture-boundary") from error
 
 
-def _validate_destination_fd(descriptor, allow_stale_evidence=False):
+def _is_public_destination_leaf(metadata):
+    mode = stat.S_IMODE(metadata.st_mode)
+    return bool(
+        stat.S_ISREG(metadata.st_mode)
+        and metadata.st_uid == os.getuid()
+        and mode & stat.S_IRUSR
+        and mode & stat.S_IWUSR
+        and not mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH | stat.S_IWOTH)
+    )
+
+
+def _validate_destination_fd(descriptor, allow_stale_evidence=False, allow_checkout_modes=False):
     try:
         names = set(os.listdir(descriptor))
     except OSError as error:
@@ -562,8 +573,11 @@ def _validate_destination_fd(descriptor, allow_stale_evidence=False):
         try:
             file_descriptor = os.open(filename, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=descriptor)
             metadata = os.fstat(file_descriptor)
-            if (not stat.S_ISREG(metadata.st_mode) or metadata.st_uid != os.getuid()
-                    or stat.S_IMODE(metadata.st_mode) not in {0o600, 0o644}):
+            valid_leaf = (_is_public_destination_leaf(metadata) if allow_checkout_modes else (
+                stat.S_ISREG(metadata.st_mode) and metadata.st_uid == os.getuid()
+                and stat.S_IMODE(metadata.st_mode) in {0o600, 0o644}
+            ))
+            if not valid_leaf:
                 raise SanitizeError("fixture-set-invalid")
             content_parts = []
             while True:
@@ -580,8 +594,11 @@ def _validate_destination_fd(descriptor, allow_stale_evidence=False):
     try:
         manifest_descriptor = os.open("manifest.json", os.O_RDONLY | os.O_NOFOLLOW, dir_fd=descriptor)
         manifest_metadata = os.fstat(manifest_descriptor)
-        if (not stat.S_ISREG(manifest_metadata.st_mode) or manifest_metadata.st_uid != os.getuid()
-                or stat.S_IMODE(manifest_metadata.st_mode) not in {0o600, 0o644}):
+        valid_manifest = (_is_public_destination_leaf(manifest_metadata) if allow_checkout_modes else (
+            stat.S_ISREG(manifest_metadata.st_mode) and manifest_metadata.st_uid == os.getuid()
+            and stat.S_IMODE(manifest_metadata.st_mode) in {0o600, 0o644}
+        ))
+        if not valid_manifest:
             raise SanitizeError("manifest-invalid")
         manifest_content = b"".join(iter(lambda: os.read(manifest_descriptor, 64 * 1024), b""))
         os.close(manifest_descriptor)
@@ -612,7 +629,7 @@ def validate_destination(destination):
     try:
         if descriptor is None:
             raise SanitizeError("fixture-set-invalid")
-        _validate_destination_fd(descriptor)
+        _validate_destination_fd(descriptor, allow_checkout_modes=True)
     finally:
         if descriptor is not None:
             os.close(descriptor)
@@ -625,7 +642,9 @@ def refresh_manifest(destination):
     try:
         if descriptor is None:
             raise SanitizeError("fixture-set-invalid")
-        fixtures, contents = _validate_destination_fd(descriptor, allow_stale_evidence=True)
+        fixtures, contents = _validate_destination_fd(
+            descriptor, allow_stale_evidence=True, allow_checkout_modes=True
+        )
         manifest = manifest_for(fixtures, contents)
         manifest_content = (json.dumps(
             manifest, ensure_ascii=True, sort_keys=True, separators=(",", ":")
@@ -749,7 +768,9 @@ def write_output(input_dir, destination):
     staging_name = None
     try:
         if existing is not None:
-            _validate_destination_fd(existing, allow_stale_evidence=True)
+            _validate_destination_fd(
+                existing, allow_stale_evidence=True, allow_checkout_modes=True
+            )
         staging_name, staging_descriptor = _create_staging_at(parent)
         for filename in sorted(contents):
             _write_private_at(staging_descriptor, filename, contents[filename])
@@ -1329,6 +1350,17 @@ def operational_cases(sentinel):
         checkout_leaves.append(checkout_destination / "manifest.json")
         for path in checkout_leaves:
             os.chmod(path, 0o664)
+        checkout_parent, checkout_descriptor = _open_destination(checkout_destination)
+        try:
+            try:
+                _validate_destination_fd(checkout_descriptor)
+            except SanitizeError as error:
+                checkout_default_error = str(error)
+            else:
+                checkout_default_error = None
+        finally:
+            os.close(checkout_descriptor)
+            os.close(checkout_parent)
         try:
             validate_destination(checkout_destination)
         except SanitizeError as error:
@@ -1382,7 +1414,8 @@ def operational_cases(sentinel):
             executable_manifest_error = str(error)
         else:
             executable_manifest_error = None
-        if (checkout_check_error is not None or checkout_refresh_result != 0
+        if (checkout_default_error != "fixture-set-invalid" or checkout_check_error is not None
+                or checkout_refresh_result != 0
                 or checkout_refresh_error is not None
                 or world_writable_fixture_error != "fixture-set-invalid"
                 or executable_fixture_error != "fixture-set-invalid"


### PR DESCRIPTION
## Outcome

Make the committed sanitized NIM fixture check portable to ordinary current-owner Git checkouts such as 0664, without weakening hostile-mode rejection or private staging behavior.

## Proof

- committed RED control reproduces the 0664 checkout rejection
- fixture and manifest 0666/0744 leaves remain rejected
- default shared validation rejects 0664; only explicit public callers opt in
- sanitizer self-test: 33 oracle controls, candidate compliant
- capture self-test: 56 controls
- load self-test: 23 cases
- cargo test: 191 unit, 112 E2E passed with 1 intentional ignore, 7 OpenAPI
- cargo clippy --all-targets -- -D warnings
- cargo fmt --check
- independent RED and GREEN reviews approved

## Constraint

No fixture or manifest bytes, schemas, evidence, raw capture boundary, staging policy, private temporary mode, or public error taxonomy changed.

Tracks #127.