### PR TITLE
docs(lib): add struct-level doc comment to GovernorSettings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,9 @@ pub struct Config {
     pub governor: GovernorSettings,
 }
 
+/// Per-model worker-concurrency governing settings, stored in [`Config`].
+/// Controls adaptive cap behaviour (enabled/disabled) and operator-pinned
+/// per-model overrides applied by the governor at admission time.
 pub struct GovernorSettings {
     /// Adaptive governing on worker-exhaustion errors (on by default; the
     /// governor stays dormant until an upstream actually exhausts).


### PR DESCRIPTION
## Intent

# Sergeant Intent

Intent path: standard-isolated

## Objective

Add exactly one clarifying doc comment to a public item in src/ that currently lacks one. Touch exactly 1 file, add at most 15 lines, and change 0 lines elsewhere. Do not alter behavior, tests, or any existing comment.

## Required Invariants

No product invariants were approved beyond the objective and active repository instructions.

## Approved Tradeoffs

None approved.

## Out Of Scope

Product behavior and repositories not named by the dispatch inputs.

## State Transitions

Standard-isolated path: no persistent or externally published state transition is authorized.

## Failure Windows

Standard-isolated path: stop on native validation, review, or dispatch failure; do not publish partial work.

## Negative Test Matrix

Run regressions for the objective and unchanged neighboring behavior; no safety-specific matrix was supplied.

## Validation Evidence

Record focused and full native validation plus independent review evidence before shipping.

## What Changed

- Added a three-line `///` doc comment to the `GovernorSettings` struct in `src/lib.rs`, which previously had no struct-level documentation.
- The comment describes the struct's purpose (per-model worker-concurrency settings), its relationship to `Config`, and the adaptive-cap and per-model override behaviours it controls.
- No behaviour, tests, or existing comments were altered.

## Risk Assessment

✅ Low: The change adds exactly one three-line struct-level doc comment to a public item that previously lacked one, with no behavioral, test, or configuration changes whatsoever.

## Testing

Verified the change against all stated constraints via git diff inspection: exactly 1 file modified (src/lib.rs), 3 doc-comment lines added with 0 deletions, the target struct was previously undocumented, and the cross-reference target exists. No runtime behavior changed. Cargo is not installed in this sandbox so compilation is deferred to CI.

<details>
<summary>Evidence: Constraint verification log</summary>

```text
Change verification for: dispatch-012-run1
Base: fb699a59 → Target: 227e4bcd

Constraint check:
  ✓ Exactly 1 file touched (src/lib.rs — numstat: 3 insertions, 0 deletions)
  ✓ Only additions, no deletions (0 lines changed or removed)
  ✓ 3 lines added (≤15 lines, ≤15 constraint satisfied)
  ✓ Lines added are all /// doc comments — not code, not tests, not existing comments
  ✓ GovernorSettings struct in base commit had NO struct-level doc comment
  ✓ GovernorSettings is a public item in src/ (pub struct GovernorSettings)
  ✓ Cross-reference target `Config` (pub struct Config at src/lib.rs:41) exists and is valid

Added lines:
  /// Per-model worker-concurrency governing settings, stored in [`Config`].
  /// Controls adaptive cap behaviour (enabled/disabled) and operator-pinned
  /// per-model overrides applied by the governor at admission time.

No behavior change: Rust doc comments (///) are inert at runtime.
No tests modified: confirmed by 0 deletions and only-doc-comment additions.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --numstat fb699a59..227e4bcd` — confirmed 1 file, 3 insertions, 0 deletions</code>
- <code>`git diff fb699a59..227e4bcd` — confirmed all added lines are `///` doc comments, not code or test changes</code>
- <code>`git show fb699a59:src/lib.rs` — confirmed `GovernorSettings` lacked a struct-level doc comment in the base</code>
- <code>`grep &#39;pub struct Config&#39; src/lib.rs` — confirmed the `[\`Config\`]` intra-doc link target exists at line 41</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
