### PR TITLE
chore: reconcile main into the v0.6.6 release baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master (toolchain via input)
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (toolchain via input)
         with:
           toolchain: stable
           components: rustfmt, clippy
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master (toolchain via input)
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (toolchain via input)
         with:
           toolchain: stable
           components: llvm-tools-preview
@@ -98,7 +98,7 @@ jobs:
       # minimum, not stable. Keep this toolchain in lockstep with
       # `rust-version` in Cargo.toml.
       - run: rm rust-toolchain.toml
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master (toolchain via input)
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (toolchain via input)
         with:
           toolchain: "1.87"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           toolchain: stable
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7 # v2.85.0
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
         with:
           tool: cargo-llvm-cov
       # The e2e suite spawns the real binary; the test harness forwards the
@@ -196,7 +196,7 @@ jobs:
       # new low-noise rules can't block unrelated PRs.
       - name: zizmor (SARIF → code scanning)
         uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
-      - uses: taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7 # v2.85.0
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
         with:
           tool: zizmor@1 # gate pinned to the same major the SARIF action bundles
       - name: zizmor (gate on high severity)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
       # diagnostics), so no setup steps are cargo-culted here. The queries
       # still run on all non-macro code; expect the "extracted with errors"
       # metric to drop as the extractor matures with CodeQL bundle updates.
-      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      - uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: rust
           build-mode: none
@@ -52,6 +52,6 @@ jobs:
           # fixture-credential noise in the test/fuzz trees (paths-ignore is
           # honored for Rust under build-mode: none).
           config-file: ./.github/codeql/codeql-config.yml
-      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      - uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:rust"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
       # cargo-fuzz needs nightly; the explicit +nightly below outranks the
       # repo's rust-toolchain.toml (channel = stable).
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master (toolchain via input)
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (toolchain via input)
         with:
           toolchain: nightly
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: fuzz
-      - uses: taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7 # v2.85.0
+      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
         with:
           tool: cargo-fuzz
       - name: Fuzz each target for 60s

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
           persist-credentials: false
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Log in to GHCR
-        uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c # v4.5.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -196,7 +196,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Log in to GHCR
-        uses: docker/login-action@06fb636fac595d6fb4b28a5dfcb21a6f5091859c # v4.5.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -40,6 +40,6 @@ jobs:
           path: results.sarif
           retention-days: 5
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif

--- a/docs/superpowers/plans/2026-08-08-v0.6.6-phase-0-baseline-reconciliation.md
+++ b/docs/superpowers/plans/2026-08-08-v0.6.6-phase-0-baseline-reconciliation.md
@@ -1,0 +1,520 @@
+# v0.6.6 Phase 0 Baseline Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reconcile the current `main` workflow dependency updates into `release/v0.6.6` while preserving every v0.6.6-specific release gate and producing one fully validated Phase 0 PR.
+
+**Architecture:** Reuse the isolated planning branch, attach it to a Phase 0 issue, and merge the pinned `main` head with a real two-parent merge commit. Accept Git's clean merges in four workflow files; resolve the single `ci.yml` conflict by retaining the release version and applying only the incoming action-pin updates. The existing all-PR workflows provide the one complete baseline gate before merge.
+
+**Tech Stack:** Git, Git worktrees, GitHub CLI, GitHub Actions YAML, Python 3 with PyYAML
+
+## Global Constraints
+
+- The integration branch is `release/v0.6.6`; only PR #72 may target `main`.
+- The observed planning baseline is `origin/release/v0.6.6` at `58b63d564050acd6d0060e05173e3c2f83292b95` and `origin/main` at `6ac25bf457709ce9832bbebe32a64f28331d94c1`.
+- If either remote SHA differs after a fresh fetch, stop and report the new commits; do not silently widen or regenerate this plan.
+- Preserve the release branch's eleven added `fmt, clippy, tests` gate steps while importing the action-pin updates from `main`.
+- Do not modify Rust source, tests, configuration behavior, or release knowledge in this task.
+- The approved design and this plan travel in the reconciliation PR so they do not cause a separate docs-only full-CI run.
+- Use one implementer and one fresh independent reviewer, sequentially, with no nested delegation.
+- The complete existing check set, including smoke fuzz, must pass on the PR before merge.
+- Dependabot remains frozen for the duration of the remediation program.
+- Tagging or publishing v0.6.6 is outside this task.
+
+## File responsibility map
+
+- `docs/superpowers/specs/2026-08-08-v0.6.6-remediation-program-design.md` — approved program contract; already committed and unchanged by execution.
+- `docs/superpowers/plans/2026-08-08-v0.6.6-phase-0-baseline-reconciliation.md` — this executable reconciliation plan; unchanged after its review and commit.
+- `.github/workflows/ci.yml` — retain the release-only gates and import three `dtolnay/rust-toolchain` and two `taiki-e/install-action` pin updates.
+- `.github/workflows/codeql.yml` — accept two clean CodeQL v4.37.4 pin updates.
+- `.github/workflows/fuzz.yml` — accept the clean Rust-toolchain and `taiki-e/install-action` pin updates.
+- `.github/workflows/release.yml` — accept two clean Docker login-action v4.6.0 pin updates.
+- `.github/workflows/scorecard.yml` — accept the clean CodeQL upload pin update.
+
+The five incoming commits are:
+
+1. `45a36b72d6425f97a189f9ce7477a312fc517d7b` — actions group update
+2. `923a4c46fb19afc6d8904861a9c48a2cfff3b63c` — Rust-toolchain update
+3. `fb699a59d618ea606ccdd0043aa99cfd16ea5f21` — merge PR #159
+4. `7d7b8f0689393ff92a01c1a61f5d4ce28930b92e` — synchronize the Rust-toolchain update branch
+5. `6ac25bf457709ce9832bbebe32a64f28331d94c1` — merge PR #160
+
+---
+
+### Task 1: Create the tracked reconciliation work item
+
+**Files:**
+- Read: `docs/superpowers/specs/2026-08-08-v0.6.6-remediation-program-design.md`
+- Read: `docs/superpowers/plans/2026-08-08-v0.6.6-phase-0-baseline-reconciliation.md`
+- Modify externally: GitHub issue #131 and one new v0.6.6 issue
+
+**Interfaces:**
+- Consumes: approved design commit and clean isolated planning worktree
+- Produces: one uniquely titled GitHub issue and the task branch `work/v0.6.6-phase0-main-reconciliation`
+
+- [ ] **Step 1: Load the required execution skills**
+
+Read `superpowers:using-git-worktrees`, then `superpowers:subagent-driven-development`. Verify that the existing worktree is safe to reuse before dispatching an implementer.
+
+- [ ] **Step 2: Refresh and prove the pinned baseline**
+
+Run:
+
+```bash
+git fetch origin --prune
+test "$(git rev-parse origin/release/v0.6.6)" = "58b63d564050acd6d0060e05173e3c2f83292b95"
+test "$(git rev-parse origin/main)" = "6ac25bf457709ce9832bbebe32a64f28331d94c1"
+git merge-base --is-ancestor origin/release/v0.6.6 HEAD
+git status --short --branch
+```
+
+Expected: both SHA assertions pass, the release head is an ancestor of the planning branch, and the worktree is clean.
+
+- [ ] **Step 3: Reproduce the planned conflict without changing the worktree**
+
+Run:
+
+```bash
+git merge-tree --write-tree origin/release/v0.6.6 origin/main
+```
+
+Expected: exit status `1`; the only reported conflict is `.github/workflows/ci.yml`; the other four workflow files auto-merge.
+
+- [ ] **Step 4: Create the Phase 0 issue**
+
+Run the following as the program owner, preserving the returned URL:
+
+```bash
+reconciliation_issue_url=$(gh issue create \
+  --repo miztertea/nim-proxy \
+  --title "v0.6.6 Phase 0: reconcile main into the release baseline" \
+  --label dependencies \
+  --label github_actions \
+  --milestone v0.6.6 \
+  --body '## Outcome
+
+Reconcile the current main workflow dependency updates into release/v0.6.6 before post-integration remediation begins.
+
+## Proof
+
+- A two-parent merge imports main at 6ac25bf457709ce9832bbebe32a64f28331d94c1.
+- The release-only CI gates remain present.
+- Only the five expected workflow files plus the approved program spec and reconciliation plan differ from the pre-merge release head.
+- The complete PR check set, including smoke fuzz, passes.
+
+## Constraint
+
+Do not change Rust behavior, tests, release knowledge, or any action version beyond the five commits already on main. The PR targets release/v0.6.6; main remains untouched.
+
+## Ponytail Rung
+
+Use Git native merge behavior. Resolve the one ci.yml conflict by retaining the release file and applying only the incoming action-pin updates.
+
+## Parent
+
+#131')
+reconciliation_issue_number=${reconciliation_issue_url##*/}
+echo "$reconciliation_issue_url"
+```
+
+Expected: GitHub returns one issue URL in milestone `v0.6.6` with the `dependencies` and `github_actions` labels.
+
+- [ ] **Step 5: Link the work item from the umbrella issue**
+
+Run:
+
+```bash
+reconciliation_issue_number=$(gh issue list \
+  --repo miztertea/nim-proxy \
+  --state open \
+  --search '"v0.6.6 Phase 0: reconcile main into the release baseline" in:title' \
+  --json number,title \
+  --jq '.[] | select(.title == "v0.6.6 Phase 0: reconcile main into the release baseline") | .number')
+test "$reconciliation_issue_number" -gt 0
+gh issue comment 131 \
+  --repo miztertea/nim-proxy \
+  --body "Phase 0 baseline reconciliation started: #${reconciliation_issue_number}. Dependabot remains frozen until the remediation program completes."
+```
+
+Expected: the new comment on #131 links the Phase 0 issue.
+
+- [ ] **Step 6: Rename and verify the isolated task branch**
+
+Run from the existing planning worktree:
+
+```bash
+git branch -m work/v0.6.6-phase0-main-reconciliation
+git status --short --branch
+```
+
+Expected: the branch is `work/v0.6.6-phase0-main-reconciliation`, it remains based on the pinned release head, and the worktree is clean.
+
+---
+
+### Task 2: Merge `main` and resolve the release-gate conflict
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify through clean merge: `.github/workflows/codeql.yml`
+- Modify through clean merge: `.github/workflows/fuzz.yml`
+- Modify through clean merge: `.github/workflows/release.yml`
+- Modify through clean merge: `.github/workflows/scorecard.yml`
+
+**Interfaces:**
+- Consumes: task branch from Task 1, release head `58b63d5`, and main head `6ac25bf`
+- Produces: reviewed staged merge resolution whose second parent is `6ac25bf457709ce9832bbebe32a64f28331d94c1`
+
+- [ ] **Step 1: Start the real merge without committing**
+
+Run:
+
+```bash
+git merge --no-ff --no-commit 6ac25bf457709ce9832bbebe32a64f28331d94c1
+git diff --name-only --diff-filter=U
+```
+
+Expected: Git stops before commit and prints only `.github/workflows/ci.yml` as unresolved.
+
+- [ ] **Step 2: Restore the release version of the conflicted workflow**
+
+Run:
+
+```bash
+git checkout --ours .github/workflows/ci.yml
+```
+
+Expected: `ci.yml` contains the eleven release-specific gates and the old action pins before the next step.
+
+- [ ] **Step 3: Apply only the incoming pins to `ci.yml`**
+
+Use `apply_patch` to make these exact substitutions in `.github/workflows/ci.yml`:
+
+```diff
+-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master (toolchain via input)
++      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (toolchain via input)
+```
+
+Apply that substitution at all three `dtolnay/rust-toolchain` steps. Then apply this substitution at both `taiki-e/install-action` steps:
+
+```diff
+-      - uses: taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7 # v2.85.0
++      - uses: taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf # v2.85.5
+```
+
+- [ ] **Step 4: Mark the conflict resolved and prove the changed paths**
+
+Run:
+
+```bash
+git add .github/workflows/ci.yml
+git diff --name-only --diff-filter=U
+git diff --cached --name-only
+```
+
+Expected: no unresolved paths remain. The staged merge changes exactly these five workflow files:
+
+```text
+.github/workflows/ci.yml
+.github/workflows/codeql.yml
+.github/workflows/fuzz.yml
+.github/workflows/release.yml
+.github/workflows/scorecard.yml
+```
+
+- [ ] **Step 5: Verify the four cleanly merged files equal `main`**
+
+Run:
+
+```bash
+git diff --exit-code 6ac25bf457709ce9832bbebe32a64f28331d94c1 -- \
+  .github/workflows/codeql.yml \
+  .github/workflows/fuzz.yml \
+  .github/workflows/release.yml \
+  .github/workflows/scorecard.yml
+```
+
+Expected: exit status `0` with no diff.
+
+- [ ] **Step 6: Verify the imported action pins and retired pins**
+
+Run:
+
+```bash
+test "$(rg -o 'dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772' .github/workflows/{ci,fuzz}.yml | wc -l)" -eq 4
+test "$(rg -o 'taiki-e/install-action@6a1bd70eaac3c8bdf093356838d7ee09fda951cf' .github/workflows/{ci,fuzz}.yml | wc -l)" -eq 3
+test "$(rg -o 'github/codeql-action/(init|analyze|upload-sarif)@f205ea1c3313d32999d8d6a48b4f6530d4437b38' .github/workflows/{codeql,scorecard}.yml | wc -l)" -eq 3
+test "$(rg -o 'docker/login-action@dbcb813823bdd20940b903addbd779551569679f' .github/workflows/release.yml | wc -l)" -eq 2
+! rg '2c7215f132e9ebf062739d9130488b56d53c060c|7572810d7dd469b651bb7793945692cf78da5dd7|e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81|06fb636fac595d6fb4b28a5dfcb21a6f5091859c' \
+  .github/workflows/{ci,codeql,fuzz,release,scorecard}.yml
+```
+
+Expected: all count assertions pass and none of the retired pins remain in the five changed workflows.
+
+- [ ] **Step 7: Verify every release-only CI gate survived**
+
+Run:
+
+```bash
+for release_gate in \
+  'Agent guide contract' \
+  'OpenAPI spec is in sync' \
+  'Rust-owned UI fixtures are in sync' \
+  'Embedded presentation source boundaries and JS syntax' \
+  'Formatter output is unchanged' \
+  'i18n lint self-test' \
+  'i18n catalog and untagged-string lint' \
+  'locale-v1 self-test' \
+  'locale-v1 validation' \
+  'Pseudolocale is current' \
+  'Dashboard renders and survives being driven'
+do
+  rg -F --quiet "$release_gate" .github/workflows/ci.yml
+done
+```
+
+Expected: every exact gate name is found.
+
+- [ ] **Step 8: Parse the workflows and check the staged patch**
+
+Run:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import yaml
+
+paths = (
+    Path('.github/workflows/ci.yml'),
+    Path('.github/workflows/codeql.yml'),
+    Path('.github/workflows/fuzz.yml'),
+    Path('.github/workflows/release.yml'),
+    Path('.github/workflows/scorecard.yml'),
+)
+for path in paths:
+    parsed = yaml.safe_load(path.read_text())
+    assert isinstance(parsed, dict), path
+    assert 'jobs' in parsed, path
+print(f'parsed {len(paths)} workflow files')
+PY
+git diff --cached --check
+```
+
+Expected: `parsed 5 workflow files`; `git diff --cached --check` prints nothing.
+
+- [ ] **Step 9: Freeze and independently review the staged merge**
+
+Run:
+
+```bash
+git diff --cached --binary | sha256sum
+```
+
+Dispatch one fresh reviewer with the issue contract, the checksum, the five-file staged patch, and Steps 5–8 proof. The reviewer checks only that the incoming pins match `main`, the release-only gates remain, the merge changes no other implementation, and the proof is sufficient. Do not commit until that review passes. Any repair re-runs Steps 4–9 and counts against the program's two-round cap.
+
+- [ ] **Step 10: Commit the reviewed merge**
+
+Run:
+
+```bash
+git commit -m "chore: reconcile main into v0.6.6 release"
+git rev-list --parents -n 1 HEAD
+test "$(git rev-parse HEAD^2)" = "6ac25bf457709ce9832bbebe32a64f28331d94c1"
+git show --check --stat --oneline HEAD
+```
+
+Expected: the commit has two parents, its second parent is the pinned `main` head, and `git show --check` reports no whitespace errors.
+
+---
+
+### Task 3: Publish, validate, and integrate the reconciliation PR
+
+**Files:**
+- Publish: the approved spec, this plan, and the five reconciled workflow files
+- Modify externally: the Phase 0 issue, issue #131, and one PR into `release/v0.6.6`
+
+**Interfaces:**
+- Consumes: the reviewed merge commit from Task 2 and the uniquely titled Phase 0 issue
+- Produces: merged Phase 0 PR, closed Phase 0 issue, and recorded full-gate evidence
+
+- [ ] **Step 1: Verify the complete PR file boundary**
+
+Run:
+
+```bash
+git diff --name-only 58b63d564050acd6d0060e05173e3c2f83292b95..HEAD
+```
+
+Expected: exactly these seven paths:
+
+```text
+.github/workflows/ci.yml
+.github/workflows/codeql.yml
+.github/workflows/fuzz.yml
+.github/workflows/release.yml
+.github/workflows/scorecard.yml
+docs/superpowers/plans/2026-08-08-v0.6.6-phase-0-baseline-reconciliation.md
+docs/superpowers/specs/2026-08-08-v0.6.6-remediation-program-design.md
+```
+
+- [ ] **Step 2: Push the reviewed task branch**
+
+Run:
+
+```bash
+git push -u origin work/v0.6.6-phase0-main-reconciliation
+```
+
+Expected: the remote branch points at the reviewed merge commit.
+
+- [ ] **Step 3: Open the reconciliation PR**
+
+Run:
+
+```bash
+reconciliation_issue_number=$(gh issue list \
+  --repo miztertea/nim-proxy \
+  --state open \
+  --search '"v0.6.6 Phase 0: reconcile main into the release baseline" in:title' \
+  --json number,title \
+  --jq '.[] | select(.title == "v0.6.6 Phase 0: reconcile main into the release baseline") | .number')
+test "$reconciliation_issue_number" -gt 0
+reconciliation_pr_url=$(gh pr create \
+  --repo miztertea/nim-proxy \
+  --base release/v0.6.6 \
+  --head work/v0.6.6-phase0-main-reconciliation \
+  --title "chore: reconcile main into the v0.6.6 release baseline" \
+  --body "## Outcome
+
+Reconciles the current main workflow dependency updates into release/v0.6.6 while retaining the release-only validation gates.
+
+## Proof
+
+- Two-parent merge with main at 6ac25bf457709ce9832bbebe32a64f28331d94c1
+- Eleven release-only CI gates retained
+- Five incoming workflow files plus the approved design and plan
+- Independent staged-diff review passed
+- Complete GitHub check set required before merge
+
+## Constraint
+
+No Rust behavior, tests, release knowledge, or unapproved dependency versions change.
+
+## Ponytail Rung
+
+Native Git merge with one explicit conflict resolution.
+
+Tracks #${reconciliation_issue_number}
+Parent: #131")
+echo "$reconciliation_pr_url"
+```
+
+Expected: one non-draft PR targets `release/v0.6.6`.
+
+- [ ] **Step 4: Record the independent review evidence**
+
+Run:
+
+```bash
+reconciliation_pr_url=$(gh pr list \
+  --repo miztertea/nim-proxy \
+  --state open \
+  --base release/v0.6.6 \
+  --head work/v0.6.6-phase0-main-reconciliation \
+  --json url \
+  --jq '.[0].url')
+test -n "$reconciliation_pr_url"
+gh pr comment "$reconciliation_pr_url" \
+  --repo miztertea/nim-proxy \
+  --body "Independent pre-commit review: PASS. Scope checked against the frozen five-workflow merge resolution; incoming pins match main, all eleven release-only gates remain, and no implementation files changed."
+```
+
+Expected: the PR contains a durable summary of the independent review.
+
+- [ ] **Step 5: Wait for the complete check set**
+
+Run:
+
+```bash
+reconciliation_pr_url=$(gh pr list \
+  --repo miztertea/nim-proxy \
+  --state open \
+  --base release/v0.6.6 \
+  --head work/v0.6.6-phase0-main-reconciliation \
+  --json url \
+  --jq '.[0].url')
+test -n "$reconciliation_pr_url"
+gh pr checks "$reconciliation_pr_url" --watch --interval 30 --fail-fast
+gh pr checks "$reconciliation_pr_url" --json name,state,bucket,startedAt,completedAt,link
+```
+
+Expected: all checks pass, including `fmt, clippy, tests`, `coverage`, `msrv`, `cargo-deny`, `gitleaks`, `docker build`, `workflow lint`, `dependency review`, `CodeQL`, `codeql (rust)`, `zizmor`, and `smoke fuzz`. Do not retry a failure until its cause is classified.
+
+- [ ] **Step 6: Merge the green PR and verify integration**
+
+Run:
+
+```bash
+reconciliation_pr_url=$(gh pr list \
+  --repo miztertea/nim-proxy \
+  --state open \
+  --base release/v0.6.6 \
+  --head work/v0.6.6-phase0-main-reconciliation \
+  --json url \
+  --jq '.[0].url')
+test -n "$reconciliation_pr_url"
+git fetch origin --prune
+test "$(git rev-parse origin/release/v0.6.6)" = "58b63d564050acd6d0060e05173e3c2f83292b95"
+test "$(git rev-parse origin/main)" = "6ac25bf457709ce9832bbebe32a64f28331d94c1"
+reviewed_head=$(git rev-parse HEAD)
+reconciliation_pr_head=$(gh pr view "$reconciliation_pr_url" \
+  --repo miztertea/nim-proxy \
+  --json headRefOid \
+  --jq '.headRefOid')
+test "$reconciliation_pr_head" = "$reviewed_head"
+gh pr merge "$reconciliation_pr_url" \
+  --repo miztertea/nim-proxy \
+  --merge \
+  --match-head-commit "$reviewed_head"
+git fetch origin --prune
+git merge-base --is-ancestor "$reviewed_head" origin/release/v0.6.6
+gh pr view "$reconciliation_pr_url" --repo miztertea/nim-proxy --json state,mergedAt,mergeCommit,url
+```
+
+Expected: both remote heads still match the reviewed baseline, the PR head
+equals the independently reviewed local head, the guarded merge succeeds, the
+PR state is `MERGED`, `mergedAt` and `mergeCommit` are populated, and the
+reviewed head is an ancestor of the remote integration branch.
+
+- [ ] **Step 7: Close and index the completed work item**
+
+Run:
+
+```bash
+reconciliation_issue_number=$(gh issue list \
+  --repo miztertea/nim-proxy \
+  --state open \
+  --search '"v0.6.6 Phase 0: reconcile main into the release baseline" in:title' \
+  --json number,title \
+  --jq '.[] | select(.title == "v0.6.6 Phase 0: reconcile main into the release baseline") | .number')
+test "$reconciliation_issue_number" -gt 0
+reconciliation_pr_url=$(gh pr list \
+  --repo miztertea/nim-proxy \
+  --state merged \
+  --base release/v0.6.6 \
+  --head work/v0.6.6-phase0-main-reconciliation \
+  --json url \
+  --jq '.[0].url')
+test -n "$reconciliation_pr_url"
+gh issue close "$reconciliation_issue_number" \
+  --repo miztertea/nim-proxy \
+  --comment "Resolved by ${reconciliation_pr_url}; the full baseline check set passed before merge into release/v0.6.6."
+gh issue comment 131 \
+  --repo miztertea/nim-proxy \
+  --body "Phase 0 baseline reconciliation complete: ${reconciliation_pr_url}. Next gate: write and approve the just-in-time change-aware CI spec and plan before implementation."
+```
+
+Expected: the Phase 0 issue is closed and #131 points to the merged evidence and next gate.
+
+- [ ] **Step 8: Report the checkpoint and stop**
+
+Report the issue, PR, merge commit, all check conclusions, observed runner durations, independent-review rounds, and any scope delta from fresh output. Do not begin the change-aware CI implementation; return to its just-in-time brainstorming/spec gate first.

--- a/docs/superpowers/specs/2026-08-08-v0.6.6-remediation-program-design.md
+++ b/docs/superpowers/specs/2026-08-08-v0.6.6-remediation-program-design.md
@@ -1,0 +1,330 @@
+# v0.6.6 Remediation Program Design
+
+**Status:** Approved design
+**Date:** 2026-08-08
+**Integration branch:** `release/v0.6.6`
+**Umbrella issue:** [#131](https://github.com/miztertea/nim-proxy/issues/131)
+**Final integration PR:** [#72](https://github.com/miztertea/nim-proxy/pull/72)
+
+## Purpose
+
+Complete the 22 blocking findings from the v0.6.6 post-integration review
+without repeating the repository-wide investigation and validation that made
+the previous pass unnecessarily expensive. The program must preserve one
+reviewable PR per issue, keep `main` untouched until the final integration PR,
+and spend full-suite CI time only where it provides cumulative release
+evidence.
+
+GitHub is authoritative for live issue, PR, branch, and check state. This
+document defines the program structure and decision rules rather than a second
+status ledger.
+
+## Goals
+
+- Reconcile the current `main` baseline into `release/v0.6.6` before
+  remediation begins.
+- Make CI select checks from the changed surface while failing closed for
+  unknown or high-risk changes.
+- Resolve every blocker in #132 through #153 through an isolated issue branch
+  and PR into `release/v0.6.6`.
+- Run the complete release suite at workstream boundaries, at #153, and on the
+  current head of #72.
+- Use bounded, sequential implementation and review passes so cost and scope
+  remain observable.
+- Reconcile project knowledge with the behavior actually shipped by the
+  release branch.
+
+## Non-goals
+
+- The v0.6.7 improvements in #154 through #156 are not part of this program.
+- The program does not redesign unrelated subsystems or fold newly discovered
+  bugs into an existing issue PR.
+- Merging #72 does not itself authorize tagging or publishing v0.6.6.
+- The historical foundation plan is not rewritten or used as the per-agent
+  execution brief.
+- CI optimization does not weaken the final release gate.
+
+## Program architecture
+
+The work proceeds as a sequential staged train:
+
+1. Baseline reconciliation
+2. Change-aware CI routing
+3. History durability and availability
+4. SSE and observation correctness
+5. Control and security
+6. Presentation and localization
+7. Knowledge reconciliation
+8. Foundation release gate
+9. Owner review and merge of #72
+10. Separate owner-approved tag and release activity
+
+Issue #131 is the execution index. It links the subordinate issues, PRs,
+workstream gate evidence, and concise progress reports. It does not duplicate
+the subordinate acceptance criteria.
+
+Each phase or workstream receives a small just-in-time spec and plan before it
+starts. Investigation is likewise just in time: the issue contract,
+applicable knowledge, and directly relevant code are loaded after prior
+workstreams have established the current integration baseline.
+
+## Phase 0: establish the baseline
+
+Phase 0 creates two separately tracked issues and two PRs into
+`release/v0.6.6`. Both Phase 0 issues follow the same bounded implementation,
+independent-review, and merge lifecycle defined for remediation issues below.
+
+### Baseline reconciliation
+
+Create a task branch from the current integration branch and merge the current
+`main` into it. Conflict resolution preserves v0.6.6-specific behavior and
+release gates unless an incoming commit contains an explicit, verified
+replacement. The PR records:
+
+- The imported `main` commits.
+- Each conflict and its resolution.
+- The release-specific behavior retained.
+- Focused verification and the full baseline result.
+
+Merging this PR establishes the common ancestry that should remove #72's
+current merge conflict. The owner will not merge further Dependabot PRs while
+the remediation program is active. Other `main` changes are not silently
+incorporated mid-program; divergence is checked again before #153 and is
+either explicitly reconciled or explicitly deferred.
+
+### Change-aware CI
+
+Create a second task branch from the reconciled integration head. A native
+changed-file classifier determines the affected surfaces from the PR diff.
+Every PR starts CI; workflow-level path exclusions are not used for required
+checks because a missing workflow can leave a required context pending.
+
+The classifier follows these rules:
+
+| Changed surface | Required validation |
+| --- | --- |
+| Documentation and knowledge | Link, schema, knowledge, and documentation checks |
+| Rust behavior | Formatting, linting, relevant tests, and coverage |
+| Presentation and i18n | JavaScript syntax, locale/catalog checks, and targeted render modes |
+| Dependency metadata | Dependency review, `cargo-deny`, MSRV, and affected builds/tests |
+| Workflow configuration | Workflow lint and proof of the affected routing behavior |
+| Container/runtime packaging | Docker build and applicable Rust checks |
+| Security-sensitive paths | Complete release suite, including all security checks |
+| Fuzz-sensitive paths | Existing targeted fuzz checks |
+| Unknown or ambiguous paths | Complete release suite |
+
+Secret scanning remains an always-on baseline because secrets can appear in
+documentation and configuration as well as source code.
+
+The check contexts required by the `main` ruleset remain present. Irrelevant
+jobs conclude as explicit successful skips or lightweight routing results;
+the required workflow does not disappear.
+
+The `ci:full` PR label forces every release check, and applying the label
+triggers a new run. A PR targeting `main`, an unknown surface, or any
+security-sensitive change also forces the full gate. A classifier failure
+fails CI without authorizing any skipped validation. The CI-routing PR runs
+the complete existing suite once before merge.
+
+## Workstream map
+
+Every blocking issue belongs to exactly one workstream.
+
+### 1. History durability and availability
+
+- [#134](https://github.com/miztertea/nim-proxy/issues/134) — history-open failure and startup availability
+- [#135](https://github.com/miztertea/nim-proxy/issues/135) — canonical history file permissions
+- [#136](https://github.com/miztertea/nim-proxy/issues/136) — compaction temporary-file cleanup
+- [#140](https://github.com/miztertea/nim-proxy/issues/140) — clock rollback and canonical persistence
+- [#139](https://github.com/miztertea/nim-proxy/issues/139) — poisoned history-store visibility
+
+The final PR carries `ci:full` and promotes the cumulative workstream only
+after the complete suite passes.
+
+### 2. SSE and observation correctness
+
+- [#133](https://github.com/miztertea/nim-proxy/issues/133) — bounded per-stream observer state
+- [#137](https://github.com/miztertea/nim-proxy/issues/137) — deadline finalization
+- [#141](https://github.com/miztertea/nim-proxy/issues/141) — null usage-details classification
+- [#142](https://github.com/miztertea/nim-proxy/issues/142) — complete finish-reason accounting
+
+The final PR carries `ci:full`.
+
+### 3. Control and security
+
+- [#138](https://github.com/miztertea/nim-proxy/issues/138) — client-key name disclosure
+- [#144](https://github.com/miztertea/nim-proxy/issues/144) — authorization before PBKDF2 work
+- [#145](https://github.com/miztertea/nim-proxy/issues/145) — secure session-cookie behavior
+- [#143](https://github.com/miztertea/nim-proxy/issues/143) — server-settings save semantics
+- [#150](https://github.com/miztertea/nim-proxy/issues/150) — control-plane concurrency and disclosure
+
+#150 carries `ci:full` and is the workstream promotion PR.
+
+### 4. Presentation and localization
+
+- [#132](https://github.com/miztertea/nim-proxy/issues/132) — capacity-table sorting
+- [#146](https://github.com/miztertea/nim-proxy/issues/146) — prose detection in i18n validation
+- [#147](https://github.com/miztertea/nim-proxy/issues/147) — standard-vocabulary lint consistency
+- [#148](https://github.com/miztertea/nim-proxy/issues/148) — render/style fault isolation
+- [#149](https://github.com/miztertea/nim-proxy/issues/149) — operator feedback and diagnostic accuracy
+- [#151](https://github.com/miztertea/nim-proxy/issues/151) — locale-canonical, script-independent serving
+
+#151 carries `ci:full` and is the workstream promotion PR.
+
+### 5. Knowledge reconciliation
+
+- [#152](https://github.com/miztertea/nim-proxy/issues/152) — reconcile knowledge with shipped code
+
+#152 carries `ci:full`. Knowledge is updated here rather than duplicated in
+every earlier PR.
+
+### 6. Foundation release gate
+
+- [#153](https://github.com/miztertea/nim-proxy/issues/153) — close gate gaps and rerun the foundation release gate
+
+#153 carries `ci:full` and supplies the final accumulated evidence before the
+owner reviews #72.
+
+## Issue lifecycle
+
+Each remediation issue follows the same bounded loop:
+
+1. Refresh the integration branch, push the current shared baseline, and
+   create an isolated task worktree and branch from it.
+2. Read the issue, applicable governing knowledge, and directly relevant
+   implementation and tests.
+3. Write a brief containing the operating environment, Outcome, Proof,
+   Constraint, Ponytail Rung, allowed scope, exclusions, and exhaustion
+   behavior.
+4. Assign one implementer. Behavioral work first captures the named
+   regression failing, then produces an uncommitted green change and focused
+   verification evidence.
+5. Freeze the diff and assign one fresh independent reviewer. The reviewer
+   examines the issue contract, patch, proof, and the most doubtful claim; the
+   reviewer does not repeat the whole repository review.
+6. Permit no more than two repair/review rounds across the issue's entire
+   lifecycle. Every substantive revision after the initial review—including
+   a response to local proof, PR review, or CI—counts as a repair round,
+   re-enters the same implementer/reviewer loop, and receives independent
+   review before another commit. Scope expansion, unresolved disagreement,
+   agent drift, or exhaustion of the two rounds stops for an owner-visible
+   decision.
+7. Commit only after independent review passes. The final commit contains the
+   regression check and fix, preserving the red-to-green evidence in the task
+   record.
+8. Push and open one PR into `release/v0.6.6`. Merge only after routed CI and
+   PR review pass.
+9. Preserve issue, PR, commit, and proof links. Remove the worktree only after
+   integration is safe and recorded.
+
+No nested delegation or workstream fan-out is permitted. Only one issue is
+active end to end at a time: the next task branch is created only after the
+preceding PR merges into the integration branch. This prevents shared-state
+conflicts, stale branch ancestry, and repeated context loading.
+
+## Failure and scope handling
+
+The system fails closed:
+
+- A classifier error fails CI rather than granting a skip.
+- Unknown, ambiguous, cross-cutting, or explicitly high-risk changes receive
+  full CI.
+- A branch update after review invalidates the affected review evidence; the
+  new delta is reviewed again.
+- CI is not retried repeatedly until the failure is classified as introduced,
+  baseline, flaky, or infrastructure-related.
+- A confirmed baseline failure blocks the affected workstream and is recorded
+  as such.
+- An out-of-scope defect receives a new issue and does not expand the current
+  PR.
+- Two unsuccessful repair/review rounds, persistent disagreement, or an
+  expanding brief triggers a stop and owner-visible options.
+
+These rules apply under cost pressure. Cost does not authorize skipping a
+test, review, issue boundary, or release gate.
+
+## Verification strategy
+
+### CI-routing acceptance
+
+Phase 0 proves routing with representative fixtures or synthetic file lists
+for documentation, Rust, presentation/i18n, dependencies, workflows,
+containers, security-sensitive paths, unknown paths, `ci:full`, and a PR
+targeting `main`. It also induces a classifier error and proves that the
+workflow fails without authorizing skipped validation. Verification
+demonstrates both selected and deliberately skipped jobs and confirms that
+every required context reaches a terminal conclusion.
+
+### Issue acceptance
+
+Every behavioral issue requires:
+
+- A captured failing regression before the implementation change.
+- The same regression passing after the change.
+- The issue's focused proof commands passing from fresh output.
+- Independent review of the frozen diff and evidence.
+- Routed PR checks passing.
+- No unrelated changes in the PR.
+
+Documentation-only work uses structural validation and review. Layout changes
+also receive human inspection.
+
+### Workstream promotion
+
+The final PR of each workstream runs the complete release suite, including
+fuzzing. The next workstream does not begin until that cumulative gate passes.
+
+### Final acceptance
+
+#153 establishes all of the following before #72 is presented for merge:
+
+- All 22 blocking issues have accepted, merged PR evidence.
+- Every workstream promotion gate passed.
+- Project knowledge describes the behavior on the integration branch.
+- No unexplained divergence from `main` remains.
+- #72 is mergeable and its current head passes every required release check.
+
+The owner performs the final review and merge of #72. Tagging and publishing
+v0.6.6 remain a separate owner-approved release step.
+
+## Durable artifacts and reporting
+
+The program produces:
+
+- This umbrella design and its program plan.
+- Small, just-in-time specs and plans for Phase 0 and each workstream.
+- One issue and PR per independently reviewable change.
+- Issue #131 links to live workstream and gate evidence.
+- Issue #152 performs the single authoritative knowledge reconciliation.
+
+The existing 5,585-line foundation plan remains historical evidence. It is
+not copied into agent briefs. The previously claimed post-integration
+remediation plan does not exist and must not be cited as an artifact.
+
+At every workstream boundary, the owner receives a compact checkpoint with:
+
+- Issues and PRs completed.
+- Agent passes and repair rounds.
+- CI runs and observed runner time.
+- Scope changes, failures, and newly discovered risks.
+- Token totals when the platform exposes them; otherwise agent-pass and
+  repair-round counts as the auditable cost proxy.
+
+If these measures show that the process is escaping its bounds, the next
+workstream does not begin until the owner chooses among explicit options.
+
+## Success criteria
+
+The remediation program is complete when:
+
+1. Both Phase 0 PRs are merged into `release/v0.6.6`.
+2. Every issue from #132 through #153 has its own accepted PR merged into
+   `release/v0.6.6`.
+3. Ordinary PRs run only the checks justified by their changed surfaces,
+   while unknown, security-sensitive, and promotion changes route to full
+   validation.
+4. All workstream, #153, and #72 full gates pass on their relevant current
+   heads.
+5. #72 is conflict-free and ready for the owner's final review and merge.
+6. Release knowledge matches the code that would enter `main`.
+7. No v0.6.7 work or unrelated remediation has entered the release train.


### PR DESCRIPTION
## Outcome

Reconciles the current main workflow dependency updates into release/v0.6.6 while retaining the release-only validation gates.

## Proof

- Two-parent merge with main at 6ac25bf457709ce9832bbebe32a64f28331d94c1
- Eleven release-only CI gates retained
- Five incoming workflow files plus the approved design and plan
- Independent staged-diff review passed
- Complete GitHub check set required before merge

## Constraint

No Rust behavior, tests, release knowledge, or unapproved dependency versions change.

## Ponytail Rung

Native Git merge with one explicit conflict resolution.

Tracks #162
Parent: #131