### PR TITLE
ci: route v0.6.6 validation from changed surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 # Least privilege by default; jobs opt into more only if they need it.
 permissions:
@@ -19,14 +20,140 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  changes:
+    name: change routing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      stable: ${{ steps.filter.outputs.stable }}
+      presentation: ${{ steps.filter.outputs.presentation }}
+      coverage: ${{ steps.filter.outputs.coverage }}
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - name: Route changed paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: step-security/paths-filter@9098a7821b83402dbe267c0c801e7d580ce74f92 # v4.0.2
+        with:
+          predicate-quantifier: every
+          filters: |
+            stable:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!knowledge/**'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/CODEOWNERS'
+              - '!scripts/check_agent_guide.py'
+              - '!fuzz/**'
+              - '!deny.toml'
+              - '!.github/dependabot.yml'
+              - '!Dockerfile'
+              - '!.dockerignore'
+              - '!docker-compose*.yml'
+              - '!src/web/**'
+              - '!scripts/render_check.js'
+              - '!scripts/formatter_fixture.js'
+              - '!scripts/check_i18n.py'
+              - '!scripts/locale_v1.py'
+              - '!scripts/gen_pseudolocale.py'
+              - '!tests/fixtures/locales/**'
+              - '!tests/fixtures/formatters-en-US.txt'
+            presentation:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!knowledge/**'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/CODEOWNERS'
+              - '!scripts/check_agent_guide.py'
+              - '!fuzz/**'
+              - '!deny.toml'
+              - '!.github/dependabot.yml'
+              - '!Cargo.toml'
+              - '!Cargo.lock'
+              - '!rust-toolchain.toml'
+              - '!Dockerfile'
+              - '!.dockerignore'
+              - '!docker-compose*.yml'
+              - '!src/dispatch.rs'
+              - '!src/governor.rs'
+              - '!src/history.rs'
+              - '!src/history/**'
+              - '!src/lib.rs'
+              - '!src/observation.rs'
+              - '!src/pool.rs'
+              - '!openapi.json'
+              - '!tests/e2e.rs'
+              - '!tests/openapi.rs'
+              - '!tests/support/**'
+              - '!tests/fixtures/api/**'
+              - '!tests/fixtures/history-v1/**'
+              - '!tests/fixtures/nim-observations/**'
+            coverage:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!knowledge/**'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/CODEOWNERS'
+              - '!scripts/check_agent_guide.py'
+              - '!fuzz/**'
+              - '!deny.toml'
+              - '!.github/dependabot.yml'
+              - '!Cargo.toml'
+              - '!Cargo.lock'
+              - '!rust-toolchain.toml'
+              - '!Dockerfile'
+              - '!.dockerignore'
+              - '!docker-compose*.yml'
+              - '!src/web/**'
+              - '!scripts/render_check.js'
+              - '!scripts/formatter_fixture.js'
+              - '!scripts/check_i18n.py'
+              - '!scripts/locale_v1.py'
+              - '!scripts/gen_pseudolocale.py'
+              - '!tests/fixtures/locales/**'
+              - '!tests/fixtures/formatters-en-US.txt'
+            docker:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!knowledge/**'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/CODEOWNERS'
+              - '!scripts/check_agent_guide.py'
+              - '!fuzz/**'
+              - '!deny.toml'
+              - '!.github/dependabot.yml'
+              - '!src/web/**'
+              - '!scripts/render_check.js'
+              - '!scripts/formatter_fixture.js'
+              - '!scripts/check_i18n.py'
+              - '!scripts/locale_v1.py'
+              - '!scripts/gen_pseudolocale.py'
+              - '!tests/fixtures/locales/**'
+              - '!tests/fixtures/formatters-en-US.txt'
+
   check:
     name: fmt, clippy, tests
+    needs: changes
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
+      - name: Require successful change routing
+        if: needs.changes.result != 'success'
+        run: exit 1
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -35,26 +162,63 @@ jobs:
           python3 scripts/check_agent_guide.py --selftest
           python3 scripts/check_agent_guide.py
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master (toolchain via input)
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.base_ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+          needs.changes.outputs.stable == 'true' ||
+          needs.changes.outputs.presentation == 'true'
         with:
           toolchain: stable
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.base_ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+          needs.changes.outputs.stable == 'true' ||
+          needs.changes.outputs.presentation == 'true'
       - name: Format
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.base_ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+          needs.changes.outputs.stable == 'true'
         run: cargo fmt --check
       - name: Clippy
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.base_ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+          needs.changes.outputs.stable == 'true'
         run: cargo clippy --all-targets -- -D warnings
       - name: Tests (unit + integration)
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.base_ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+          needs.changes.outputs.stable == 'true'
         run: cargo test
       # openapi.json is generated from the handlers. Regenerate it here and
       # fail on any difference, so the committed spec cannot drift from the
       # code that serves the requests — `cargo test` alone would catch it, but
       # only if the contributor remembered to commit the regenerated file.
       - name: OpenAPI spec is in sync
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.base_ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+          needs.changes.outputs.stable == 'true'
         run: |
           UPDATE_OPENAPI=1 cargo test --test openapi
           git diff --exit-code -- openapi.json \
             || { echo "::error::openapi.json is stale — run 'UPDATE_OPENAPI=1 cargo test --test openapi' and commit it"; exit 1; }
       - name: Rust-owned UI fixtures are in sync
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.base_ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+          needs.changes.outputs.stable == 'true'
         # Fixture bytes are serialized from the production response types. The
         # update command is deliberate; a diff after it catches an omitted
         # generated fixture in the same way the OpenAPI gate catches its spec.
@@ -64,6 +228,11 @@ jobs:
           git diff --exit-code -- tests/fixtures/ui \
             || { echo "::error::UI fixtures are stale — run 'UPDATE_UI_FIXTURES=1 cargo test api::tests::ui_fixtures --lib' and commit tests/fixtures/ui"; exit 1; }
       - name: Embedded presentation source boundaries and JS syntax
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.base_ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+          needs.changes.outputs.presentation == 'true'
         # cargo test asserts on served HTML text and never parses the
         # JavaScript. These checks also keep executable/style source external
         # to HTML and reject every external-origin dependency.
@@ -76,6 +245,11 @@ jobs:
           node scripts/render_check.js --syntax-only
           node scripts/render_check.js --interaction-selftest
       - name: Formatter output is unchanged
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.base_ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+          needs.changes.outputs.presentation == 'true'
         # Pins number/duration/date/percent output against a golden fixture.
         # TZ and locale are fixed because these formatters read the catalog
         # locale and the system zone; an unpinned run encodes the runner.
@@ -84,26 +258,56 @@ jobs:
           LC_ALL: en_US.UTF-8
         run: node scripts/formatter_fixture.js --check
       - name: i18n lint self-test
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.base_ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+          needs.changes.outputs.presentation == 'true'
         # Same reason as locale-v1's below, and this one was missing while the
         # lint shipped three separate blind spots. Every case here is a real
         # false negative that once reported `i18n OK`.
         run: python3 scripts/check_i18n.py --selftest
       - name: i18n catalog and untagged-string lint
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.base_ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+          needs.changes.outputs.presentation == 'true'
         run: python3 scripts/check_i18n.py
       - name: locale-v1 self-test
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.base_ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+          needs.changes.outputs.presentation == 'true'
         # Proves every check can fail before trusting any of them.
         run: python3 scripts/locale_v1.py --selftest
       - name: locale-v1 validation
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.base_ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+          needs.changes.outputs.presentation == 'true'
         run: |
           python3 scripts/locale_v1.py --update-public
           git diff --exit-code -- tests/fixtures/locales/public-en-US.json \
             || { echo "::error::public-en-US.json is stale — run 'python3 scripts/locale_v1.py --update-public' and commit it"; exit 1; }
           python3 scripts/locale_v1.py --all
       - name: Pseudolocale is current
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.base_ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+          needs.changes.outputs.presentation == 'true'
         # en-XA is generated, never hand-edited; a stale one silently stops
         # testing the strings that changed.
         run: python3 scripts/gen_pseudolocale.py --check
       - name: Dashboard renders and survives being driven
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.base_ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+          needs.changes.outputs.presentation == 'true'
         # `node --check` above proves the scripts parse; this starts the real
         # binary and requests its served page/assets, replays captured API
         # payloads through CDP, walks every tab, and hovers every chart. Any
@@ -139,6 +343,13 @@ jobs:
 
   coverage:
     name: coverage
+    needs: changes
+    if: >-
+      needs.changes.result == 'success' &&
+      (github.event_name != 'pull_request' ||
+       github.base_ref == 'main' ||
+       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+       needs.changes.outputs.coverage == 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Harden runner
@@ -169,6 +380,13 @@ jobs:
 
   msrv:
     name: msrv
+    needs: changes
+    if: >-
+      needs.changes.result == 'success' &&
+      (github.event_name != 'pull_request' ||
+       github.base_ref == 'main' ||
+       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+       needs.changes.outputs.stable == 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Harden runner
@@ -317,6 +535,13 @@ jobs:
 
   docker:
     name: docker build
+    needs: changes
+    if: >-
+      needs.changes.result == 'success' &&
+      (github.event_name != 'pull_request' ||
+       github.base_ref == 'main' ||
+       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+       needs.changes.outputs.docker == 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Harden runner

--- a/docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md
+++ b/docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md
@@ -1,909 +1,463 @@
 # v0.6.6 Change-Aware CI Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` task-by-task. Maintain the ignored SDD workspace ledger; use one implementer and a fresh independent reviewer per task, sequentially, with no nested delegation. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
 
-**Goal:** Implement fail-closed, change-aware pull-request CI routing while preserving existing required check names and proving both reduced routing and full release validation before merge into `release/v0.6.6`.
+**Goal:** Route only the existing expensive pull-request CI work affected by a change while preserving every required context and full release gate.
 
-**Architecture:** A Python-standard-library classifier is the only source of path/risk policy. `ci.yml`, `codeql.yml`, and `fuzz.yml` add small scope jobs that run classifier self-tests, derive one shared output contract from the live pull-request diff, and use job-level conditions or guarded step groups without workflow-level PR path filters. Two small standard-library documentation checkers provide meaningful docs-only proof; GitHub Actions probes prove selected skips and failure propagation on the real PR.
+**Architecture:** Modify only .github/workflows/ci.yml. One SHA-pinned step-security/paths-filter action emits four Boolean path outputs; native GitHub expressions combine them with non-PR, target-main, and ci:full overrides. Existing CodeQL, fuzz, cheap checks, and security checks remain unchanged.
 
-**Tech Stack:** Python 3 standard library, Git, GitHub CLI, GitHub Actions YAML, existing Rust/Node CI tools.
+**Tech Stack:** GitHub Actions, step-security/paths-filter v4.0.2, installed PyYAML for local syntax parsing, existing actionlint/zizmor CI.
 
 ## Global Constraints
 
-- Integration branch: `release/v0.6.6`; only PR #72 targets `main`.
-- Design commit: `e1f67ca`; integration base: `6b6fde466bc28e5b2e9bca14be8eb43212c39160`.
-- The freshly queried `main` ruleset `18516333` has nine required contexts. Preserve their check names unchanged.
-- PR #72 is `CLEAN`/`MERGEABLE` with twelve green checks and remains unmerged; do not merge it.
-- PR #163 establishes the pre-change baseline at approximately 28 runner-minutes; record it as historical evidence, not a new measurement.
-- Do not use workflow-level path filters for a required PR workflow. Required contexts must reach terminal outcomes.
-- All scope jobs run `ci_scope.py --selftest` before classifying the live event. Unknown, malformed, empty, security-sensitive, workflow-policy, `ci:full`, `main`-targeting, and non-PR changes must fail closed or select full validation.
-- Create no non-stdlib runtime dependencies. Ponytail Rung is 2 for existing workflows/scripts/testing conventions, falling to 3 only for `scripts/ci_scope.py`, `scripts/check_markdown_links.py`, and `scripts/check_knowledge.py`.
-- The plan is immutable once its independent plan review passes: commit this plan once before execution. Execution state never edits or commits the plan; it lives in the ignored SDD workspace and durable GitHub issue/PR comments.
-- Every substantive task gets one independent precommit review and one SDD postcommit review. The SDD skill’s default five rounds is explicitly overridden: one global counter starts at `repairs_used: 0`, `repairs_remaining: 2`; every task, CI, review, or final repair increments that same counter. At exhaustion stop with evidence and request an owner decision.
-- Before every push run the task’s named proof plus `cargo fmt --check`; skipped expensive Rust/render/fuzz checks are explicitly reported, never silently inferred.
-- The temporary live probe is reviewed, committed, run, evidenced, then removed in a separately reviewed commit. It must not be in the merged tree.
-- Natural-path observation on the first ordinary remediation PR after merge is supplementary only; Phase 0 completion cannot wait for it.
+- Integration branch is release/v0.6.6; only PR #72 targets main.
+- Preserve the nine required names: fmt, clippy, tests; coverage; msrv; cargo-deny; gitleaks; workflow lint; dependency review; docker build; codeql (rust).
+- The only new runtime brick is step-security/paths-filter at commit 9098a7821b83402dbe267c0c801e7d580ce74f92.
+- Add no classifier, parser, validator, fixture harness, probe workflow, synthetic commit, or second policy file.
+- Modify only ci.yml. codeql.yml and fuzz.yml remain byte-for-byte unchanged.
+- Unknown, workflow-policy, and security-sensitive paths are never excluded and therefore select every expensive group.
+- Non-PR CI, PRs targeting main, and PRs labeled exactly ci:full run every expensive group.
+- cargo-deny, gitleaks, workflow lint, dependency review, and CodeQL remain always-on under their current event conditions.
+- A failed or cancelled changes job makes fmt, clippy, tests fail.
+- Historical classifier rounds remain issue evidence. This replacement starts the normal two-repair lifecycle at repairs_used: 0 and repairs_remaining: 2.
+- No task merges PR #72 or tags, publishes, or releases v0.6.6.
 
-## File responsibility map
+## File Responsibility Map
 
-- `scripts/ci_scope.py` — sole deterministic classifier and self-tests.
-- `scripts/check_markdown_links.py` — local tracked-Markdown link checker and self-tests.
-- `scripts/check_knowledge.py` — OKF schema checker and self-tests, without a legacy allowlist.
-- `knowledge/decisions/dashboard-operator-console-redesign.md` — normalize Decision headings only.
-- `knowledge/decisions/input-sanitizing-and-xss.md` — normalize Decision headings only.
-- `knowledge/decisions/message-catalog-and-escaping.md` — normalize Decision headings only.
-- `.github/workflows/ci.yml` — scope job, guarded required check, and routing conditions.
-- `.github/workflows/codeql.yml` — scope job and guarded CodeQL condition.
-- `.github/workflows/fuzz.yml` — scope job, no top-level PR path filter, and guarded fuzz condition.
-- `.github/workflows/ci-routing-probe.yml` — temporary, real-classifier Actions proof; added then removed before final validation.
-- `docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md` — immutable task contract, reviewed and committed once before execution.
-
-## SDD workspace and task-package protocol
-
-Before execution, independently review this completed plan and commit it once as `docs: add change-aware CI execution plan`. Resolve the plan-scoped ignored workspace, then create the ledger and all task artifacts there:
-
-```bash
-plan=docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md
-sdd_skill=/home/tchawes/.codex/plugins/cache/openai-curated-remote/superpowers/6.2.0/skills/subagent-driven-development
-workspace=$("$sdd_skill/scripts/sdd-workspace" "$plan")
-```
-
-Then use `apply_patch` to create `$workspace/progress.md` with first line `# SDD ledger — plan: docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md`, then `repairs_used: 0` and `repairs_remaining: 2`. Expected: `workspace` is the git-ignored `.superpowers/sdd/2026-08-08-v0.6.6-change-aware-ci/` directory and `progress.md` is its only global recovery record. For each task, use `task-brief`, an implementer report, `review-package`, reviewer report, and (when needed) re-review report in that workspace. The manager uses `apply_patch` to record implementer/reviewer identities, frozen diff digest, named proof, commit SHA, review verdict, scope delta, exact final-reviewed SHA, and repair-counter update in `progress.md`; GitHub issue/PR comments retain durable URLs. Each package authorizes only its listed files/actions; the implementer stops on ambiguity, out-of-scope discovery, non-determinable fact, or failed proof. A reviewer inspects a frozen package before commit; reviewer-report writes are separate ignored files and therefore never change the reviewed digest.
+- .github/workflows/ci.yml — the only tracked implementation file.
+- scripts/ci_scope.py — abandoned uncommitted candidate; remove it before implementation and never execute it.
+- .github/workflows/codeql.yml — unchanged required SAST.
+- .github/workflows/fuzz.yml — unchanged native path routing and manual full-gate entry point.
+- Issue #164 — Phase 0 history and acceptance evidence.
+- Issue #131 — umbrella progress links.
 
 ---
 
-### Task 1: Create the tracked Phase 0 CI-routing work item and SDD ledger
+### Task 1: Implement and review the one-file routing change
 
 **Files:**
 
-- Modify externally: repository label `ci:full`, one new GitHub issue, and umbrella issue #131
+- Modify: .github/workflows/ci.yml
+- Delete uncommitted candidate: scripts/ci_scope.py
+- Verify unchanged: .github/workflows/codeql.yml
+- Verify unchanged: .github/workflows/fuzz.yml
 
-**Outcome:** One uniquely titled Phase 0 issue, the `ci:full` label, and an ignored SDD workspace ledger exist before implementation begins.
+**Outcome:** ci.yml routes stable, presentation, coverage, MSRV, and Docker work while all required contexts remain terminal and routing failure blocks merge.
 
-**Proof:** Fresh GitHub reads show the exact label description, exactly one matching open issue, and #131 linking it; `progress.md` names this plan and records Task 1 evidence.
+**Proof:** The abandoned script is absent and was never in HEAD; YAML parses; existing agent-guide proof and cargo formatting pass; only ci.yml is in the implementation diff; independent review verifies filters, conditions, names, and fail-closed behavior.
 
-**Constraint:** Do not create a PR, change workflows, apply `ci:full` to #72, or start implementation. Preserve the known integration base `6b6fde466bc28e5b2e9bca14be8eb43212c39160`.
+**Constraint:** Reuse every existing job and step body. Add conditions only around the existing stable and presentation groups and the coverage, MSRV, and Docker jobs.
 
-**Ponytail Rung:** 2 — reuse the existing Phase 0 issue/ledger convention and GitHub CLI; no new mechanism.
+**Ponytail Rung:** Rung 1 deletes the bespoke classifier. Rung 2 reuses existing jobs. Rung 4 supplies expressions and job outputs. Rung 7 permits only the pinned maintained action.
 
 **Interfaces:**
 
-- Consumes: design commit `e1f67ca`, integration base `6b6fde466bc28e5b2e9bca14be8eb43212c39160`, and this approved plan.
-- Produces: `ci:full` (description exactly `Run every v0.6.6 release gate`), issue number `${ci_routing_issue_number}`, and branch `work/v0.6.6-phase0-ci-routing` ready for Task 2.
+- Produces job outputs changes.outputs.stable, presentation, coverage, and docker.
+- Stable selects Rust behavior, Rust tests/fixtures, Cargo/toolchain metadata, and every full trigger.
+- Presentation selects presentation/i18n inputs and every full trigger.
+- Coverage selects Rust behavior and every full trigger.
+- Docker selects Rust behavior, Cargo/toolchain metadata, container inputs, and every full trigger.
 
-- [ ] **Step 1: Load and constrain the SDD session**
-
-Read `superpowers:using-git-worktrees` and `superpowers:subagent-driven-development`. Run the workspace setup from the preceding section, then run `"$sdd_skill/scripts/task-brief" "$plan" 1` and dispatch only that brief. Record the Task 1 implementer, frozen evidence digest, reviewer, URLs, and result in `"$workspace/progress.md"`; authorize the two external creates only and require stop-on-ambiguity evidence.
-
-- [ ] **Step 2: Prove the pinned starting point and failure path**
-
-Run:
-
-```bash
-git fetch origin --prune
-test "$(git rev-parse origin/release/v0.6.6)" = "6b6fde466bc28e5b2e9bca14be8eb43212c39160"
-git status --short --branch
-gh label list --repo miztertea/nim-proxy --limit 200 --search ci:full
-gh issue list --repo miztertea/nim-proxy --state open \
-  --search '"v0.6.6 Phase 0: change-aware CI routing" in:title' \
-  --json number,title,url
-```
-
-Expected: the SHA assertion passes; the worktree has only the approved plan change; the output either shows no `ci:full` label or a label whose description must be inspected before reuse; and it shows zero matching open issues. If a matching issue or incompatible label already exists, stop and report its URL/description rather than creating a duplicate.
-
-- [ ] **Step 3: Create or verify the exact full-suite override label**
+- [ ] **Step 1: Prove and remove the abandoned candidate**
 
 Run:
 
-```bash
-gh label create ci:full --repo miztertea/nim-proxy \
-  --description "Run every v0.6.6 release gate" --color 0E8A16 --force
-gh label list --repo miztertea/nim-proxy --limit 200 --search ci:full \
-  --json name,description,color --jq '.[] | select(.name == "ci:full")'
-```
-
-Expected: exactly one `ci:full` label has the stated description. This is the green path after Step 2’s absent/incorrect-label detection.
-
-- [ ] **Step 4: Create the uniquely titled tracking issue and link #131**
-
-Run:
-
-```bash
-ci_routing_issue_url=$(gh issue create --repo miztertea/nim-proxy \
-  --title "v0.6.6 Phase 0: change-aware CI routing" \
-  --milestone v0.6.6 \
-  --body '## Outcome
-
-Implement fail-closed change-aware CI routing before remediation issue work starts.
-
-## Proof
-
-- A shared standard-library classifier drives CI, CodeQL, and fuzz routing.
-- Real PR probes prove selected skips and classifier-failure propagation.
-- ci:full starts a twelve-check full gate on the final reviewed head.
-
-## Constraint
-
-Preserve existing required check names; do not use workflow-level path filters for required PR workflows; main remains untouched.
-
-## Ponytail Rung
-
-Reuse existing workflows, scripts, and test strategy; add only the three approved standard-library scripts.
-
-Parent: #131')
-ci_routing_issue_number=${ci_routing_issue_url##*/}
-test "$ci_routing_issue_number" -gt 0
-gh issue comment 131 --repo miztertea/nim-proxy \
-  --body "Phase 0 change-aware CI routing started: ${ci_routing_issue_url}. The implementation PR will target release/v0.6.6; PR #163’s approximately 28 runner-minute baseline will be retained as evidence."
-```
-
-Expected: one issue URL is returned and #131 has the linking comment. On API failure, retain command output in the ledger and stop; do not proceed with a local-only substitute.
-
-- [ ] **Step 5: Freeze the ledger update and obtain the independent precommit review**
-
-Run:
-
-```bash
-git status --short
-gh label list --repo miztertea/nim-proxy --limit 200 --search ci:full --json name,description,color
-```
-
-Give a fresh independent reviewer the Task 1 brief, the separate implementer report, label JSON, issue/#131 URLs, and a separate read-only evidence package. The reviewer verifies unique external state, the pinned base, and that no implementation work began. Record `PASS` or the concrete rejection in `progress.md`; each repair increments the same global counter and recomputes `repairs_remaining`.
-
-- [ ] **Step 6: Conduct the SDD task-completion review**
-
-Dispatch a different fresh reviewer with the Task 1 brief, report, and evidence package. The reviewer returns `PASS` or one concrete repair package; record the verdict in `progress.md` and a durable issue comment before Task 2 starts. Task 1 has no repository commit; do not invent one.
-
-### Task 2: Implement and prove the fail-closed classifier
-
-**Files:**
-
-- Create: `scripts/ci_scope.py`
-- Test: committed in-script `--selftest` fixtures; no separate framework or dependency
-
-**Outcome:** The shared classifier deterministically maps normalized changed paths and PR metadata to the exact 18 Boolean outputs plus a closed reason, failing rather than reducing validation on malformed input.
-
-**Proof:** Its self-test first observes each negative fixture exit nonzero and then passes all positive/overlap/full-routing fixtures; `--assert-known` accepts every tracked path; Python compilation passes.
-
-**Constraint:** Implement only Python standard library; no YAML-embedded path policy; keep all result names exactly as the approved design states.
-
-**Ponytail Rung:** 3 — a small stdlib script is required because no existing repository tool supplies this single shared Actions interface.
-
-**Interfaces:**
-
-```python
-@dataclass(frozen=True)
-class Scope:
-    docs: bool; rust: bool; presentation: bool; dependencies: bool
-    workflow: bool; container: bool; security: bool; fuzz: bool
-    full: bool; reason: str
-
-def classify(paths: tuple[str, ...], *, event_name: str,
-             base_ref: str, labels: tuple[str, ...]) -> Scope: ...
-def job_outputs(scope: Scope) -> dict[str, bool]: ...
-```
-
-It writes all nine surface keys, all nine job keys, and `reason`; Booleans are literal lowercase `true`/`false`.
-
-- [ ] **Step 1: Write executable red fixtures before classification code**
-
-Create `scripts/ci_scope.py` with argument parsing, temporary-directory fixtures, and a deliberately raising/stub `classify`. The `--selftest` must invoke the CLI and assert nonzero exits for malformed label JSON, non-array labels, non-string labels, missing/unreadable PR paths file, invalid UTF-8, empty/absolute/trailing-slash/backslash/dot-component paths, an injected internal exception, and a malformed workflow fixture missing `always()`. It must assert expected output dictionaries for docs-only, Rust, static presentation-only, dependency (including `stable=true`), container, fuzz, overlap, target-main, `ci:full`, non-PR, unknown, empty, security, workflow, duplicate-normalization, classifier-policy paths, and a valid three-workflow fixture accepted by `--check-workflows`.
-
-Run:
-
-```bash
-python3 scripts/ci_scope.py --selftest
-```
-
-Expected: FAIL because the classifier is deliberately unimplemented; the self-test output identifies the first missing expected classification rather than treating a failure as a skip.
-
-- [ ] **Step 2: Implement canonical input parsing and classification**
-
-Implement only standard-library `argparse`, `dataclasses`, `json`, `pathlib`, `subprocess`, `sys`, and `tempfile`. The exact interfaces are `classify(paths: tuple[str, ...], *, event_name: str, base_ref: str, labels: tuple[str, ...]) -> Scope` and `job_outputs(scope: Scope) -> dict[str, bool]`; `Scope` has `docs, rust, presentation, dependencies, workflow, container, security, fuzz, full, reason` fields. For a pull request, require a readable NUL file and validate each decoded path; deduplicate and lexically sort paths. For non-PR events, return full scope without consuming label/path inputs. Decode labels only as `list[str]`.
-
-Classify root Markdown/policy text, `docs/**`, `knowledge/**`, `examples/**`, issue/PR templates, `CODEOWNERS`, and the three check scripts as docs; `src/**` except `src/web/**`, Rust integration tests/non-presentation fixtures, `openapi.json`, and `rust-toolchain.toml` as Rust; `src/web/**`, `src/presentation.rs`, render/formatter/i18n/locale/pseudolocale scripts and UI/locale/formatter fixtures as presentation; `Cargo.toml`, `Cargo.lock`, `deny.toml`, `.github/dependabot.yml` as dependencies; `.github/workflows/**`, `.github/codeql/**`, `.github/release.yml`, `scripts/ci_scope.py`, and `scripts/test_release_contract.py` as workflow; `Dockerfile`, `.dockerignore`, and `docker-compose*.yml` as container; `fuzz/**`, `src/proxy.rs`, `src/config.rs`, and `.github/workflows/fuzz.yml` as fuzz; `src/api.rs`, `src/auth.rs`, `src/config.rs`, `src/main.rs`, `src/proxy.rs`, `src/routes.rs`, `src/settings.rs`, and `.github/codeql/**` as security. Other known operational scripts select full; every unknown path selects full.
-
-Use first-match full reasons exactly `non-pr`, `target-main`, `full-label`, `workflow-policy`, `security-path`, `unknown-path`, `empty-diff`, then `routed`. Emit nine surface keys plus nine job keys: `stable=rust|dependencies|full`, `coverage=rust|full`, `msrv=rust|dependencies|full`, `deny=dependencies|full`, `workflow_lint=workflow|full`, `dependency_review=dependencies|workflow|full`, `docker=container|dependencies|full`, `codeql=rust|full`, `smoke_fuzz=fuzz|full`, and closed `reason`. Make `--github-output` append deterministic output lines and stdout print sorted JSON otherwise. Make `--assert-known` enumerate tracked paths with `git ls-files -z` and reject any without a rule. Add `--check-workflows ROOT`: parse the three YAML files as text and fail unless they have the exact five PR activities, `scope` job, required job names, scope output references, no required-workflow path filter, fuzz no top-level PR `paths`, `always()` guards, and the expected job/step conditions; it never invokes a shell or GitHub API.
-
-- [ ] **Step 3: Run the green and explicit failure-path proofs**
-
-Run:
-
-```bash
-python3 scripts/ci_scope.py --selftest
-python3 -m py_compile scripts/ci_scope.py
-python3 scripts/ci_scope.py --event-name pull_request --base-ref release/v0.6.6 \
-  --labels-json '[]' --paths-file <(printf 'docs/readme.md\0')
-python3 scripts/ci_scope.py --event-name pull_request --base-ref release/v0.6.6 \
-  --labels-json '{bad json}' --paths-file <(printf 'docs/readme.md\0'); test "$?" -ne 0
-python3 scripts/ci_scope.py --event-name pull_request --base-ref release/v0.6.6 \
-  --labels-json '[]' --paths-file <(git ls-files -z) --assert-known
-```
-
-Expected: self-test and compilation pass; the docs fixture reports `docs=true`, `full=false`, and all keys; malformed JSON exits nonzero; the tracked inventory passes. If process substitution is unavailable, use a named `mktemp` file and remove it after the command.
-
-- [ ] **Step 4: Freeze, independently review, and commit**
-
-Run:
-
-```bash
-git diff -- scripts/ci_scope.py
-git diff --binary | sha256sum
-git diff --check
-```
-
-An independent precommit reviewer verifies the full reason precedence, every required path family, no unknown/malformed route can reduce scope, exactly 18 Boolean outputs plus `reason`, deterministic normalization, and standard-library-only imports. Record the digest and verdict in the SDD ledger. On PASS:
-
-```bash
-git add scripts/ci_scope.py
-git commit -m "feat(ci): add fail-closed change classifier"
-git show --check --stat --oneline HEAD
-```
-
-Expected: a script-only commit with no whitespace errors.
-
-- [ ] **Step 5: Conduct the SDD postcommit review**
-
-A fresh postcommit reviewer runs the Step 3 proof on the committed SHA and inspects `git show HEAD -- scripts/ci_scope.py`. They record PASS or one bounded repair package in the ledger. A repair must re-run red evidence, green evidence, independent review, and commit; stop after global repair round 2 with the failing output.
-
-### Task 3: Implement and prove repository-local Markdown-link validation
-
-**Files:**
-
-- Create: `scripts/check_markdown_links.py`
-- Test: committed in-script `--selftest` fixtures
-
-**Outcome:** Documentation-only changes receive a deterministic check of tracked repository-local Markdown targets without validating external URLs or anchors.
-
-**Proof:** Negative fixture branches fail before the checker passes its tracked-file scan and compiles.
-
-**Constraint:** Split literal `#` then literal `?` before percent decoding; do not validate anchors, fetch URLs, or traverse outside the repository.
-
-**Ponytail Rung:** 3 — the repository has no Markdown-link checker and the approved design requires one stdlib implementation.
-
-**Interfaces:** `python3 scripts/check_markdown_links.py [--selftest] [--root PATH]` exits 0 only when all tracked Markdown files have valid repository-local targets.
-
-- [ ] **Step 1: Create red fixtures that exercise every branch**
-
-Write a standard-library script using `argparse`, `pathlib`, `re`, `tempfile`, and `urllib.parse`; start its scanner as an intentional failure. Its `--selftest` creates fixtures for a valid local link, encoded space, encoded `%23`, encoded `%3F`, ordinary query, missing target, repository escape, external URL, and fragment-only link.
-
-Run:
-
-```bash
-python3 scripts/check_markdown_links.py --selftest
-```
-
-Expected: FAIL while the scanner is stubbed, proving the test harness detects an invalid checker rather than accepting empty output.
-
-- [ ] **Step 2: Implement the bounded local-link scan**
-
-Enumerate tracked `*.md` paths via `git ls-files -z -- '*.md'`. Extract normal Markdown link destinations while ignoring image-only syntax only if the destination parser already sees it as a local link. For each raw destination: split on the first literal `#`, split the preceding text on the first literal `?`, then percent-decode that remaining path; ignore blank fragment-only paths and parsed URLs with a scheme. Resolve a target relative to the source file, reject it when `relative_to(root)` fails, and reject absent targets. Report source path plus raw destination for every problem and exit nonzero.
-
-- [ ] **Step 3: Prove the red branches and green repository scan**
-
-Run:
-
-```bash
-python3 scripts/check_markdown_links.py --selftest
-python3 -m py_compile scripts/check_markdown_links.py
-python3 scripts/check_markdown_links.py
-tmp=$(mktemp -d)
-git -C "$tmp" init -q
-printf '[bad](../outside.md)\n' > "$tmp/escape.md"
-git -C "$tmp" add escape.md
-python3 scripts/check_markdown_links.py --root "$tmp"; test "$?" -ne 0
-rm -rf "$tmp"
-```
-
-Expected: self-test reports each negative fixture as observed, compilation succeeds, the tracked repository scan exits 0, and the explicit escape fixture exits nonzero.
-
-- [ ] **Step 4: Freeze, independently review, and commit**
-
-Run:
-
-```bash
-git diff -- scripts/check_markdown_links.py
-git diff --binary | sha256sum
-git diff --check
-```
-
-The precommit reviewer independently checks operation order around encoded `#`/`?`, repository escape refusal, no network behavior, and one positive plus all stated negative fixtures. Record the frozen digest and PASS in the ledger, then run:
-
-```bash
-git add scripts/check_markdown_links.py
-git commit -m "test(docs): validate local Markdown links"
-git show --check --stat --oneline HEAD
-```
-
-Expected: script-only commit, no whitespace errors.
-
-- [ ] **Step 5: Conduct the SDD postcommit review**
-
-A fresh reviewer runs Step 3 on the committed SHA, confirms no external URL was fetched, and records PASS or one bounded repair package. Any repair re-enters the red/green/review sequence and stops after the global two-round cap.
-
-### Task 4: Implement knowledge-schema validation and normalize the three Decision exceptions
-
-**Files:**
-
-- Create: `scripts/check_knowledge.py`
-- Modify: `knowledge/decisions/dashboard-operator-console-redesign.md`
-- Modify: `knowledge/decisions/input-sanitizing-and-xss.md`
-- Modify: `knowledge/decisions/message-catalog-and-escaping.md`
-
-**Outcome:** The repository has a dependency-free knowledge schema gate and all Decision pages satisfy the declared Context → Options → Choice → Consequences sequence without an exception list.
-
-**Proof:** One self-test fixture trips each rule; the checker then accepts every tracked knowledge page and a direct malformed Decision fixture fails.
-
-**Constraint:** Normalize exactly the three named legacy Decision pages. Do not revise their durable substance, frontmatter identity, index, or log; do not add a grandfather list.
-
-**Ponytail Rung:** 3 for the required stdlib validator; 2 for repairing existing headings under the established OKF contract.
-
-**Interfaces:** `python3 scripts/check_knowledge.py [--selftest] [--root PATH]` scans tracked `knowledge/**/*.md` and exits nonzero with path-and-rule diagnostics.
-
-- [ ] **Step 1: Write red checker fixtures**
-
-Create `scripts/check_knowledge.py` with `--selftest` before implementing validation. Fixtures must include one valid page and separate invalid cases for missing/unterminated/unparseable frontmatter, empty `type`, wrong `index.md` type, wrong `log.md` type, unsupported concept type, non-kebab concept filename, missing `Context`, missing `Options`, missing `Choice`, missing `Consequences`, and out-of-order Decision headings.
-
-Run:
-
-```bash
-python3 scripts/check_knowledge.py --selftest
-```
-
-Expected: FAIL while validation is unimplemented; each fixture is named so a no-op checker cannot pass.
-
-- [ ] **Step 2: Implement the bounded schema parser and normalize only the exceptions**
-
-Use only Python standard library. Parse the repository’s bounded YAML frontmatter subset sufficiently to require an opening delimiter at byte 0, a closing delimiter, colon key/value lines, and a nonempty `type`. Require `Index` for every file named `index.md`, `Log` for `knowledge/log.md`, and one of `Decision`, `Research Finding`, `Component`, or `Runbook` otherwise. Require kebab-case concept filenames and ordered Decision headings.
-
-Use `apply_patch` for the three documents:
-
-- In `dashboard-operator-console-redesign.md`, rename `## Options & Choice` to `## Options`; insert `## Choice` immediately before `## Consequences` and summarize the four already-selected choices without changing their text.
-- In `input-sanitizing-and-xss.md`, insert `## Options` between Context and Choice with the accurate option statement that the documented alternative was not to rely on one sink-only defense.
-- In `message-catalog-and-escaping.md`, insert `## Options` between Context and Choice with the accurate rejected alternatives already described in Context: global raw `message()` or further partial JavaScript parsing.
-
-Do not alter any other `knowledge/decisions/*.md` path.
-
-- [ ] **Step 3: Run red then green schema proof**
-
-Run:
-
-```bash
-python3 scripts/check_knowledge.py --selftest
-python3 -m py_compile scripts/check_knowledge.py
-python3 scripts/check_knowledge.py
-tmp=$(mktemp -d)
-git -C "$tmp" init -q
-mkdir -p "$tmp/knowledge/decisions"
-printf '%s\n' '---' 'type: Decision' '---' '# Bad' '## Context' '## Choice' '## Consequences' > "$tmp/knowledge/decisions/not-options.md"
-git -C "$tmp" add knowledge/decisions/not-options.md
-python3 scripts/check_knowledge.py --root "$tmp"; test "$?" -ne 0
-rm -rf "$tmp"
-```
-
-Expected: self-test and compilation pass; tracked inventory passes; direct missing-Options fixture exits nonzero; no grandfather exception exists.
-
-- [ ] **Step 4: Freeze, independently review, and commit**
-
-Run:
-
-```bash
-git diff -- scripts/check_knowledge.py knowledge/decisions/dashboard-operator-console-redesign.md \
-  knowledge/decisions/input-sanitizing-and-xss.md knowledge/decisions/message-catalog-and-escaping.md
-git diff --binary | sha256sum
-git diff --check
-```
-
-The independent precommit reviewer checks every self-test rule, frontmatter/type mapping, heading ordering, and that exactly three Decision files changed structurally with no content drift. Record digest/PASS in the ledger, then run:
-
-```bash
-git add scripts/check_knowledge.py knowledge/decisions/dashboard-operator-console-redesign.md \
-  knowledge/decisions/input-sanitizing-and-xss.md knowledge/decisions/message-catalog-and-escaping.md
-git commit -m "test(knowledge): enforce OKF schema"
-git show --check --stat --oneline HEAD
-```
-
-Expected: one bounded script-and-heading commit with no whitespace errors.
-
-- [ ] **Step 5: Conduct the SDD postcommit review**
-
-A new reviewer repeats Step 3 at the committed SHA and uses `git diff HEAD^ HEAD -- knowledge/decisions` to verify exactly three legacy exceptions were normalized. Record PASS or one repair package; repairs repeat red, green, independent review, and commit and stop at the global cap.
-
-### Task 5: Wire all three workflows to the shared classifier and preserve contexts
-
-**Files:**
-
-- Modify: `.github/workflows/ci.yml`
-- Modify: `.github/workflows/codeql.yml`
-- Modify: `.github/workflows/fuzz.yml`
-- Consume: `scripts/ci_scope.py`, `scripts/check_markdown_links.py`, `scripts/check_knowledge.py`
-
-**Outcome:** Every PR starts all required workflows; each scope job proves the classifier before classification; the existing check names remain while irrelevant jobs are terminal successful skips and classifier failure cannot authorize a skip.
-
-**Proof:** Workflow syntax parses; static contract assertions verify exact PR activities, no required workflow path filters, all required names, `always()` guards, shared classifier invocations, and all routing conditions.
-
-**Constraint:** Preserve existing actions, permissions, concurrency, job names, security hardening, and full-suite behavior. Do not duplicate classifier path lists in YAML. Remove only fuzz’s top-level PR `paths` filter.
-
-**Ponytail Rung:** 2 — modify the existing three workflows and reuse their job bodies/check names.
-
-**Interfaces:** Each scope job outputs `steps.classify.outputs` from `ci_scope.py`; downstream references use `needs.scope.outputs.<job-key>`. The exact activity list is `opened`, `synchronize`, `reopened`, `labeled`, `unlabeled`.
-
-- [ ] **Step 1: Write the workflow-contract failure script before YAML changes**
-
-Run the committed regression before changing YAML and retain its failure output in the ignored Task 5 report.
-
-```bash
-python3 scripts/ci_scope.py --check-workflows .
-test "$?" -ne 0
-```
-
-Expected: the check fails because scope jobs, the five activities, and required fail-closed guards are absent and fuzz retains its forbidden top-level filter.
-
-- [ ] **Step 2: Add the identical event plumbing and scope-job shape**
-
-Using `apply_patch`, give all three workflows the exact pull-request activity set. Each `scope` job hardens the runner and checks out with `fetch-depth: 0` and `persist-credentials: false`. Its `env:` contains `EVENT_NAME: ${{ github.event_name }}`, `BASE_SHA: ${{ github.event.pull_request.base.sha }}`, `HEAD_SHA: ${{ github.event.pull_request.head.sha }}`, `BASE_REF: ${{ github.event.pull_request.base.ref }}`, and `LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}`. For non-PR variants set `BASE_SHA: ''`, `HEAD_SHA: ${{ github.sha }}`, `BASE_REF: ''`, and `LABELS_JSON: '[]'`; expressions are only environment values, never shell source.
-
-```bash
-python3 scripts/ci_scope.py --selftest
-if [ "$EVENT_NAME" = pull_request ]; then
-  test -n "$BASE_SHA"; test -n "$HEAD_SHA"
-  git diff --name-only -z "$BASE_SHA" "$HEAD_SHA" > changed-paths.z
-  python3 scripts/ci_scope.py --event-name "$EVENT_NAME" --base-ref "$BASE_REF" \
-    --labels-json "$LABELS_JSON" --paths-file changed-paths.z --github-output "$GITHUB_OUTPUT"
-else
-  python3 scripts/ci_scope.py --event-name "$EVENT_NAME" --base-ref '' \
-    --labels-json "$LABELS_JSON" --github-output "$GITHUB_OUTPUT"
+~~~bash
+if git cat-file -e HEAD:scripts/ci_scope.py 2>/dev/null; then
+  echo "candidate unexpectedly exists in HEAD" >&2
+  exit 1
 fi
-```
+test -f scripts/ci_scope.py
+~~~
 
-Expose exactly `docs,rust,presentation,dependencies,workflow,container,security,fuzz,full,stable,coverage,msrv,deny,workflow_lint,dependency_review,docker,codeql,smoke_fuzz,reason` via `jobs.scope.outputs`. Do not put a path rule in YAML.
+Expected: HEAD lookup fails and the uncommitted candidate exists. Remove its intent-to-add index entry first:
 
-- [ ] **Step 3: Route the existing jobs with fail-closed guards**
+~~~bash
+git restore --staged -- scripts/ci_scope.py
+test -z "$(git ls-files --stage -- scripts/ci_scope.py)"
+~~~
 
-In `ci.yml`, retain `fmt, clippy, tests`; set `needs: scope`, `if: always()`, checkout `fetch-depth: 0`/credential-free, and job-local `env: EVENT_NAME: ${{ github.event_name }}, BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}, HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}, BEFORE_SHA: ${{ github.event.before || '' }}`. Its first step is `test "${{ needs.scope.result }}" = success`; exact whitespace shell is `if [ "$EVENT_NAME" = pull_request ]; then git diff --check "$BASE_SHA" "$HEAD_SHA"; elif [ -n "$BEFORE_SHA" ] && git cat-file -e "$BEFORE_SHA^{commit}" 2>/dev/null; then git diff --check "$BEFORE_SHA" "$HEAD_SHA"; else git show --check --format= --no-renames "$HEAD_SHA"; fi`. Keep summary/agent-guide/Markdown checks unconditional; use `if: ${{ needs.scope.outputs.docs == 'true' }}` for knowledge, `stable` for all stable Rust setup/build/test steps, and `presentation` for presentation steps. Set `coverage`, `msrv`, `cargo-deny`, `workflow lint`, and `docker build` to `if: ${{ needs.scope.result == 'success' && needs.scope.outputs.<exact-key> == 'true' }}`; keep gitleaks unconditional.
+Then use apply_patch to delete only scripts/ci_scope.py and run:
 
-In `codeql.yml`, keep name `codeql (rust)`, set `needs: scope` and job condition `if: always() && (needs.scope.result != 'success' || needs.scope.outputs.codeql == 'true')`; first guard is `test "${{ needs.scope.result }}" = success`, then analysis steps are `if: ${{ needs.scope.outputs.codeql == 'true' }}`. In `fuzz.yml`, delete top-level PR `paths`; `smoke fuzz` has `needs: scope` and exact job condition `if: always() && (needs.scope.result != 'success' || needs.scope.outputs.smoke_fuzz == 'true')`; its first guard fails on scope failure and every fuzz setup/run step is `if: ${{ needs.scope.outputs.smoke_fuzz == 'true' }}`. Set `dependency review` to `if: ${{ github.event_name == 'pull_request' && needs.scope.result == 'success' && needs.scope.outputs.dependency_review == 'true' }}`. Thus normal false is a terminal job skip, while scope failure is exposed.
+~~~bash
+test ! -e scripts/ci_scope.py
+git status --short
+~~~
 
-- [ ] **Step 4: Run local green, failure-path, and boundary proof**
+Expected: the candidate disappears from both the worktree and index; only already committed history remains before ci.yml is edited.
+
+- [ ] **Step 2: Add the changes job and exact filters**
+
+Change the CI pull-request trigger to:
+
+~~~yaml
+pull_request:
+  types: [opened, synchronize, reopened, labeled, unlabeled]
+~~~
+
+Insert changes before check:
+
+~~~yaml
+changes:
+  name: change routing
+  runs-on: ubuntu-latest
+  permissions:
+    contents: read
+    pull-requests: read
+  outputs:
+    stable: ${{ steps.filter.outputs.stable }}
+    presentation: ${{ steps.filter.outputs.presentation }}
+    coverage: ${{ steps.filter.outputs.coverage }}
+    docker: ${{ steps.filter.outputs.docker }}
+  steps:
+    - name: Harden runner
+      uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+      with:
+        egress-policy: audit
+    - name: Route changed paths
+      id: filter
+      if: github.event_name == 'pull_request'
+      uses: step-security/paths-filter@9098a7821b83402dbe267c0c801e7d580ce74f92 # v4.0.2
+      with:
+        predicate-quantifier: every
+        filters: |
+          stable:
+            - '**'
+            - '!**/*.md'
+            - '!docs/**'
+            - '!knowledge/**'
+            - '!.github/ISSUE_TEMPLATE/**'
+            - '!.github/CODEOWNERS'
+            - '!scripts/check_agent_guide.py'
+            - '!fuzz/**'
+            - '!deny.toml'
+            - '!.github/dependabot.yml'
+            - '!Dockerfile'
+            - '!.dockerignore'
+            - '!docker-compose*.yml'
+            - '!src/web/**'
+            - '!scripts/render_check.js'
+            - '!scripts/formatter_fixture.js'
+            - '!scripts/check_i18n.py'
+            - '!scripts/locale_v1.py'
+            - '!scripts/gen_pseudolocale.py'
+            - '!tests/fixtures/locales/**'
+            - '!tests/fixtures/formatters-en-US.txt'
+          presentation:
+            - '**'
+            - '!**/*.md'
+            - '!docs/**'
+            - '!knowledge/**'
+            - '!.github/ISSUE_TEMPLATE/**'
+            - '!.github/CODEOWNERS'
+            - '!scripts/check_agent_guide.py'
+            - '!fuzz/**'
+            - '!deny.toml'
+            - '!.github/dependabot.yml'
+            - '!Cargo.toml'
+            - '!Cargo.lock'
+            - '!rust-toolchain.toml'
+            - '!Dockerfile'
+            - '!.dockerignore'
+            - '!docker-compose*.yml'
+            - '!src/dispatch.rs'
+            - '!src/governor.rs'
+            - '!src/history.rs'
+            - '!src/history/**'
+            - '!src/lib.rs'
+            - '!src/observation.rs'
+            - '!src/pool.rs'
+            - '!openapi.json'
+            - '!tests/e2e.rs'
+            - '!tests/openapi.rs'
+            - '!tests/support/**'
+            - '!tests/fixtures/api/**'
+            - '!tests/fixtures/history-v1/**'
+            - '!tests/fixtures/nim-observations/**'
+          coverage:
+            - '**'
+            - '!**/*.md'
+            - '!docs/**'
+            - '!knowledge/**'
+            - '!.github/ISSUE_TEMPLATE/**'
+            - '!.github/CODEOWNERS'
+            - '!scripts/check_agent_guide.py'
+            - '!fuzz/**'
+            - '!deny.toml'
+            - '!.github/dependabot.yml'
+            - '!Cargo.toml'
+            - '!Cargo.lock'
+            - '!rust-toolchain.toml'
+            - '!Dockerfile'
+            - '!.dockerignore'
+            - '!docker-compose*.yml'
+            - '!src/web/**'
+            - '!scripts/render_check.js'
+            - '!scripts/formatter_fixture.js'
+            - '!scripts/check_i18n.py'
+            - '!scripts/locale_v1.py'
+            - '!scripts/gen_pseudolocale.py'
+            - '!tests/fixtures/locales/**'
+            - '!tests/fixtures/formatters-en-US.txt'
+          docker:
+            - '**'
+            - '!**/*.md'
+            - '!docs/**'
+            - '!knowledge/**'
+            - '!.github/ISSUE_TEMPLATE/**'
+            - '!.github/CODEOWNERS'
+            - '!scripts/check_agent_guide.py'
+            - '!fuzz/**'
+            - '!deny.toml'
+            - '!.github/dependabot.yml'
+            - '!src/web/**'
+            - '!scripts/render_check.js'
+            - '!scripts/formatter_fixture.js'
+            - '!scripts/check_i18n.py'
+            - '!scripts/locale_v1.py'
+            - '!scripts/gen_pseudolocale.py'
+            - '!tests/fixtures/locales/**'
+            - '!tests/fixtures/formatters-en-US.txt'
+~~~
+
+No workflow-policy or security-sensitive path appears in an exclusion. New paths therefore match every filter.
+
+- [ ] **Step 3: Guard and route existing work**
+
+Give check:
+
+~~~yaml
+needs: changes
+if: always()
+~~~
+
+Its first executable step after Harden runner is:
+
+~~~yaml
+- name: Require successful change routing
+  if: needs.changes.result != 'success'
+  run: exit 1
+~~~
+
+Use this full override in every routed condition:
+
+~~~text
+github.event_name != 'pull_request' || github.base_ref == 'main' || contains(github.event.pull_request.labels.*.name, 'ci:full')
+~~~
+
+Apply the following exact routing:
+
+- Stable toolchain and Rust cache: full override OR stable OR presentation.
+- Format, Clippy, Tests, OpenAPI sync, and Rust-owned UI fixture sync: full override OR stable.
+- Every existing presentation/render/i18n/locale step: full override OR presentation.
+- coverage job: needs changes; require changes success AND (full override OR coverage).
+- msrv job: needs changes; require changes success AND (full override OR stable).
+- docker job: needs changes; require changes success AND (full override OR docker).
+- Leave deny, gitleaks, lint-workflows, dependency-review, CodeQL, and fuzz unchanged.
+
+For example, coverage receives:
+
+~~~yaml
+needs: changes
+if: >-
+  needs.changes.result == 'success' &&
+  (github.event_name != 'pull_request' ||
+   github.base_ref == 'main' ||
+   contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+   needs.changes.outputs.coverage == 'true')
+~~~
+
+Use the same expression shape for stable and docker outputs. Step-level conditions omit the changes-result term because the guarded check job already requires a successful changes dependency.
+
+- [ ] **Step 4: Run local proof**
 
 Run:
 
-```bash
-python3 scripts/ci_scope.py --selftest
-python3 scripts/check_markdown_links.py --selftest
-python3 scripts/check_knowledge.py --selftest
-python3 -m py_compile scripts/ci_scope.py scripts/check_markdown_links.py scripts/check_knowledge.py
-python3 scripts/ci_scope.py --event-name pull_request --base-ref main --labels-json '[]' --paths-file <(printf 'docs/a.md\0')
+~~~bash
+python3 - <<'PY'
+from pathlib import Path
+import yaml
+value = yaml.safe_load(Path(".github/workflows/ci.yml").read_text())
+assert isinstance(value, dict)
+print("parsed .github/workflows/ci.yml")
+PY
+python3 scripts/check_agent_guide.py --selftest
+python3 scripts/check_agent_guide.py
+cargo fmt --check
 git diff --check
-ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "parsed #{p}" }' \
-  .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml
-```
+git diff --exit-code -- .github/workflows/codeql.yml .github/workflows/fuzz.yml
+git diff --name-only
+~~~
 
-Expected: all script self-tests/compilation/YAML parsing pass; the target-`main` command emits `full=true` and `reason=target-main`; `git diff --check` is silent. Then run `python3 scripts/ci_scope.py --check-workflows .`; it now exits 0 and is added to the always-on CI check job so later workflow drift is protected. Do not run cargo, render, Docker, or fuzz suites locally.
+Expected: parsing and existing proofs pass; CodeQL/fuzz have no diff; the only implementation path is .github/workflows/ci.yml.
 
-- [ ] **Step 5: Freeze, independently review, and commit**
+- [ ] **Step 5: Independently review and commit**
 
-Run:
+Freeze the diff and reviewed head:
 
-```bash
-git diff -- .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml
-git diff --binary | sha256sum
+~~~bash
+git diff --binary -- .github/workflows/ci.yml | sha256sum
 git diff --check
-```
+~~~
 
-The precommit reviewer checks exact names against ruleset `18516333`, all `always()` failure guards, all five pull-request activities, absent required-workflow filters, no copied path policy, preserved gitleaks, static-presentation no-Rust setup, dependency stable routing, and fuzz label override. Record digest/PASS, then run:
+The independent reviewer checks the four filters against the tracked inventory, every required name, the routing-failure guard, metadata overrides, unchanged cheap/security jobs, and unchanged CodeQL/fuzz. After PASS:
 
-```bash
-git add .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml
+~~~bash
+git add .github/workflows/ci.yml
 git commit -m "ci: route validation from changed surfaces"
 git show --check --stat --oneline HEAD
-```
+~~~
 
-Expected: three-workflow commit, no whitespace errors.
+Expected: one workflow implementation commit.
 
-- [ ] **Step 6: Conduct the SDD postcommit review**
-
-A new reviewer re-runs Step 4 and reviews `git show HEAD -- .github/workflows`. They must explicitly verify that a failed scope cannot produce a green required context and that a `ci:full` label will trigger a new PR event. Record PASS or one repair package; repairs follow the global two-round limit.
-
-### Task 6: Integrate, locally validate, independently review, and publish the implementation PR
+### Task 2: Publish the Phase 0 PR
 
 **Files:**
 
-- Publish: all Task 1–5 committed files
-- Modify externally: one PR into `release/v0.6.6`, its body/comments, and issue #131
+- Publish existing branch work/v0.6.6-phase0-ci-routing
+- Update issue #164 and issue #131
+- Create one PR into release/v0.6.6
 
-**Outcome:** A single implementation PR with the exact intended diff exists, links the tracking issue, carries `ci:full`, and has local proof plus an independent pre-push review recorded before live probes.
+**Outcome:** A reviewed one-workflow implementation PR exists, targets the integration branch, and carries ci:full.
 
-**Proof:** The branch diff contains only the task outputs; all three script self-tests, compilation, known-path inventory, YAML parsing, `git diff --check`, and `cargo fmt --check` have fresh output; GitHub reads show the PR targets the integration branch and has the override label.
+**Proof:** Fresh GitHub reads show exact base/head, label, issue links, reviewed SHA, and intended file list.
 
-**Constraint:** Do not run expensive Rust tests, render, Docker, coverage, CodeQL, or fuzz locally. Do not merge or claim a label-triggered run proves the final head yet.
+**Constraint:** Do not target main or merge PR #72.
 
-**Ponytail Rung:** 2 — use existing Git/GitHub PR workflow and test strategy.
+**Ponytail Rung:** Rung 2 reuses the existing branch, issue, label, and GitHub PR flow.
 
-**Interfaces:** Consumes Task 1–5 reviewed commits. Produces `${ci_routing_pr_url}`, branch `work/v0.6.6-phase0-ci-routing`, and an issue/PR evidence location used by Tasks 7–9.
+**Interfaces:** Produces ci_pr_url and reviewed_sha for Task 3.
 
-- [ ] **Step 1: Prove the complete local boundary and pre-push checks**
+- [ ] **Step 1: Run the pre-push boundary**
 
-Run:
-
-```bash
-git diff --name-only 6b6fde466bc28e5b2e9bca14be8eb43212c39160..HEAD
-python3 scripts/ci_scope.py --selftest
-python3 scripts/check_markdown_links.py --selftest
-python3 scripts/check_knowledge.py --selftest
-python3 -m py_compile scripts/ci_scope.py scripts/check_markdown_links.py scripts/check_knowledge.py
-python3 scripts/ci_scope.py --event-name pull_request --base-ref release/v0.6.6 \
-  --labels-json '[]' --paths-file <(git diff --name-only -z 6b6fde466bc28e5b2e9bca14be8eb43212c39160..HEAD) --assert-known
-ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p) }' \
-  .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml
-git diff --check 6b6fde466bc28e5b2e9bca14be8eb43212c39160..HEAD
-cargo fmt --check
-```
-
-Expected: exact paths are `docs/superpowers/specs/2026-08-08-v0.6.6-change-aware-ci-design.md` at approved commit `e1f67ca`, this already-reviewed plan, the three scripts, three Decision pages, and three workflows only; all named proof passes. The required red paths remain in each script’s self-test transcript. Record skipped expensive local checks explicitly in `progress.md`.
-
-- [ ] **Step 2: Freeze and independently review the full pre-push diff**
-
-Run:
-
-```bash
-git diff --binary 6b6fde466bc28e5b2e9bca14be8eb43212c39160..HEAD | sha256sum
-git log --oneline 6b6fde466bc28e5b2e9bca14be8eb43212c39160..HEAD
-```
-
-A fresh precommit reviewer checks all Task 1–5 contracts together: no unclassified tracked file, no routing policy in YAML, preserved names/ruleset contexts, exact three knowledge pages, every failure self-test, no workflow-level required PR filter, and no excluded scope. Record digest/PASS in the ledger. Any rejection requires a bounded repair package, then repeats Task-specific review and this review; stop after repair round 2.
-
-- [ ] **Step 3: Freeze the reviewed candidate SHA and push it unchanged**
-
-Run:
-
-```bash
-prepush_sha=$(git rev-parse HEAD)
-test -n "$prepush_sha"
-git push -u origin work/v0.6.6-phase0-ci-routing
-test "$(git rev-parse HEAD)" = "$prepush_sha"
-test "$(git ls-remote origin refs/heads/work/v0.6.6-phase0-ci-routing | cut -f1)" = "$prepush_sha"
-```
-
-Expected: no plan mutation occurs; the remote branch equals `prepush_sha`. This SHA is not the final-reviewed SHA because Tasks 7–8 add then remove the probe.
-
-- [ ] **Step 4: Open the implementation PR and immediately apply the label**
-
-Run:
-
-```bash
-ci_routing_issue_number=$(gh issue list --repo miztertea/nim-proxy --state open \
-  --search '"v0.6.6 Phase 0: change-aware CI routing" in:title' --json number,title \
-  --jq '.[] | select(.title == "v0.6.6 Phase 0: change-aware CI routing") | .number')
-test "$ci_routing_issue_number" -gt 0
-ci_routing_pr_url=$(gh pr create --repo miztertea/nim-proxy \
-  --base release/v0.6.6 --head work/v0.6.6-phase0-ci-routing \
-  --title "ci: route v0.6.6 validation from changed surfaces" \
-  --body "## Outcome
-
-Implements the approved fail-closed change-aware CI classifier and documentation proof.
-
-## Proof
-
-- Three standard-library scripts each have observed negative self-tests.
-- CI, CodeQL, and fuzz consume the one classifier and retain existing contexts.
-- Live probe commits will prove selected skips and classifier-failure propagation.
-- Final reviewed head will receive a ci:full twelve-check gate.
-
-## Constraint
-
-No required context name changes; no workflow-level PR path filters; temporary probe never merges.
-
-## Ponytail Rung
-
-Reuse existing workflows/scripts/testing conventions; only the three approved stdlib scripts are new.
-
-Tracks #${ci_routing_issue_number}
-Parent: #131")
-gh pr edit "$ci_routing_pr_url" --repo miztertea/nim-proxy --add-label ci:full
-gh pr view "$ci_routing_pr_url" --repo miztertea/nim-proxy \
-  --json url,baseRefName,headRefName,labels,state
-```
-
-Expected: a non-draft PR targets `release/v0.6.6`, has the exact head branch and `ci:full`, and begins an initial full run. This run may be cancelled by later commits and is not final proof.
-
-- [ ] **Step 5: Conduct the SDD postcommit/post-push review**
-
-A fresh reviewer compares `gh pr diff "$ci_routing_pr_url"` with the frozen digest and local proof, confirms the label event exists, and records PASS or one repair package in the ledger/PR comment. The reviewer must state that Task 7 is the next authorized mutation and that no merge is authorized.
-
-### Task 7: Add and prove the reviewed temporary live-routing probe
-
-**Files:**
-
-- Create temporarily: `.github/workflows/ci-routing-probe.yml`
-- Modify externally: PR and issue evidence only
-
-**Outcome:** The real committed classifier proves both selected/skipped routing and fail-closed dependency behavior in GitHub Actions before its temporary workflow is removed.
-
-**Proof:** Exactly one retained failing probe-run URL shows synthetic docs selection/Rust skip plus malformed classifier failure/`if: always()` guard failure; exactly three concurrent production-run URLs reach terminal success.
-
-**Constraint:** The probe calls the committed `scripts/ci_scope.py`; it must not duplicate classifier logic, mutate production workflows, or remain in the final tree.
-
-**Ponytail Rung:** 2 — one temporary native Actions workflow is the smallest real-environment proof.
-
-**Interfaces:** The temporary workflow triggers only on `pull_request: { types: [synchronize] }`; its single run contains `docs-scope`, `docs-selected`, `rust-skipped`, `malformed-scope`, and `failure-guard`. It invokes the committed classifier twice with synthetic NUL files, never dispatches manually, and need not exist on the default branch.
-
-- [ ] **Step 1: Create the red probe contract**
-
-Before adding the file, run a local assertion that `.github/workflows/ci-routing-probe.yml` is absent and record its nonzero result. Create a `pull_request` `synchronize` workflow with full-history, credential-free checkout. `docs-scope` writes `printf 'docs/synthetic.md\0' > paths.z`, calls the committed classifier with `[]`, and exports outputs; `docs-selected` asserts `docs=true`; `rust-skipped` uses the false `rust` output. Independently, `malformed-scope` writes the same path then calls the real classifier with `{bad json}` and must fail; `failure-guard` has `if: always()` and explicitly fails when `needs.malformed-scope.result != 'success'`.
-
-Use no secrets and write each classifier JSON/result to the workflow summary.
-
-- [ ] **Step 2: Run local syntax plus explicit green/failure evidence**
-
-Run:
-
-```bash
-ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci-routing-probe.yml")'
-python3 scripts/ci_scope.py --event-name pull_request --base-ref release/v0.6.6 \
-  --labels-json '[]' --paths-file <(printf 'docs/synthetic.md\0')
-python3 scripts/ci_scope.py --event-name pull_request --base-ref release/v0.6.6 \
-  --labels-json '{bad json}' --paths-file <(printf 'docs/synthetic.md\0'); test "$?" -ne 0
-git diff --check
-cargo fmt --check
-```
-
-Expected: YAML/docs classification pass, malformed labels exit nonzero, diff/format checks pass; expensive suites remain skipped and recorded.
-
-- [ ] **Step 3: Freeze, independently review, commit, and push the probe**
-
-Run:
-
-```bash
-git diff --binary | sha256sum
-git diff --check
-git add .github/workflows/ci-routing-probe.yml
-git commit -m "test(ci): add temporary routing probe"
-git show --check --stat --oneline HEAD
-```
-
-Before committing, an independent reviewer verifies only the probe changed, real classifier use, both cases’ expected terminal states, no credential persistence, and no production-path change. Record digest/PASS in the separate reviewer report and `progress.md`. A fresh SDD postcommit reviewer confirms the pushed SHA and authorizes probe observation only on PASS.
-
-- [ ] **Step 4: Observe one real PR-event probe run and concurrent production runs**
-
-Run:
-
-```bash
-set -euo pipefail
-probe_started_at=$(date -u +%FT%TZ)
-probe_sha=$(git rev-parse HEAD)
-git push
-for attempt in $(seq 1 20); do
-  probe_runs=$(gh api "/repos/miztertea/nim-proxy/actions/runs?event=pull_request&head_sha=$probe_sha")
-  probe_run=$(jq --arg after "$probe_started_at" '.workflow_runs | map(select(.path == ".github/workflows/ci-routing-probe.yml" and .created_at >= $after)) | sort_by(.created_at) | last' <<<"$probe_runs")
-  probe_run_id=$(jq -r '.id // empty' <<<"$probe_run")
-  test -n "$probe_run_id" && break; sleep 15
-done
-test -n "$probe_run_id"
-test "$(jq -r .head_sha <<<"$probe_run")" = "$probe_sha"
-gh run watch "$probe_run_id" --repo miztertea/nim-proxy || test "$?" -ne 0
-probe_view=$(gh run view "$probe_run_id" --repo miztertea/nim-proxy --json url,conclusion,jobs,headSha,createdAt)
-test "$(jq -r .conclusion <<<"$probe_view")" = failure
-jq -e '.jobs[] | select(.name == "docs-selected" and .conclusion == "success")' <<<"$probe_view"
-jq -e '.jobs[] | select(.name == "rust-skipped" and .conclusion == "skipped")' <<<"$probe_view"
-jq -e '.jobs[] | select(.name == "malformed-scope" and .conclusion == "failure")' <<<"$probe_view"
-jq -e '.jobs[] | select(.name == "failure-guard" and .conclusion == "failure")' <<<"$probe_view"
-declare -A production_ids
-for attempt in $(seq 1 20); do
-  runs=$(gh api "/repos/miztertea/nim-proxy/actions/runs?event=pull_request&head_sha=$probe_sha")
-  for path in .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml; do
-    production_ids[$path]=$(jq -r --arg path "$path" --arg after "$probe_started_at" '.workflow_runs | map(select(.path == $path and .created_at >= $after)) | sort_by(.created_at) | last.id // empty' <<<"$runs")
-  done
-  [ -n "${production_ids[.github/workflows/ci.yml]}" ] && [ -n "${production_ids[.github/workflows/codeql.yml]}" ] && [ -n "${production_ids[.github/workflows/fuzz.yml]}" ] && break; sleep 15
-done
-for path in .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml; do
-  id=${production_ids[$path]}; test -n "$id"; gh run watch "$id" --repo miztertea/nim-proxy
-  view=$(gh run view "$id" --repo miztertea/nim-proxy --json url,conclusion,jobs,headSha,createdAt)
-  test "$(jq -r .headSha <<<"$view")" = "$probe_sha"; test "$(jq -r .conclusion <<<"$view")" = success
-  jq -e '.jobs[] | select(.name == "scope" and .conclusion == "success")' <<<"$view"
-done
-```
-
-Expected: the exact post-push PR-event run has `headSha=$probe_sha`, docs-selected succeeds, rust-skipped is terminal successful skip, malformed-scope fails, and the always-guard fails. Capture production CI/CodeQL/fuzz runs from the same synchronize event separately by `headSha=$probe_sha` and `createdAt >= $probe_started_at`; all their contexts must be terminal. Do not rerun merely for green; classify every unexpected result and increment the one global repair counter before a new synchronize commit.
-
-- [ ] **Step 5: Record probe evidence and postcommit review**
-
-Post the one probe URL and exactly three production URLs, job conclusions, and scope outcomes to the PR and #131. A fresh reviewer checks every production run is terminal, the probe used the committed classifier, and malformed routing could not skip the guard. Record PASS or a bounded repair package; Task 8 is authorized only after PASS.
-
-### Task 8: Remove the temporary probe, independently review, and restore the final tree
-
-**Files:**
-
-- Delete: `.github/workflows/ci-routing-probe.yml`
-- Modify externally: PR evidence only
-
-**Outcome:** The final PR tree excludes the temporary probe while preserving its already-recorded run URLs and outcomes.
-
-**Proof:** The deletion is first observed as a red absence-required test after the probe commit, then committed; `git diff` against the final head has no probe path and all local low-cost checks pass.
-
-**Constraint:** Do not alter the three production workflows or rewrite/delete GitHub run evidence.
-
-**Ponytail Rung:** 2 — a separate small deletion commit preserves probe history without shipping test machinery.
-
-**Interfaces:** Consumes Task 7 PASS/run URLs. Produces final candidate head without `.github/workflows/ci-routing-probe.yml`.
-
-- [ ] **Step 1: Prove the removal target and perform the deliberate deletion**
-
-Run `test -f .github/workflows/ci-routing-probe.yml` and record success as the precondition. Use `apply_patch` to delete exactly that file. Then run:
-
-```bash
-test ! -e .github/workflows/ci-routing-probe.yml
-git diff --name-status
-```
-
-Expected: the first assertion proves the probe exists; after deletion only `D .github/workflows/ci-routing-probe.yml` (plus ledger evidence) appears. If another path changes, stop.
-
-- [ ] **Step 2: Run red/green boundary checks**
-
-Run:
-
-```bash
-ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p) }' \
-  .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml
-python3 scripts/ci_scope.py --selftest
-python3 scripts/check_markdown_links.py --selftest
-python3 scripts/check_knowledge.py --selftest
-git diff --check
-cargo fmt --check
-```
-
-Expected: production YAML and low-cost checks pass; the absent-probe assertion is green. Record intentionally skipped expensive suites.
-
-- [ ] **Step 3: Independently review, commit, push, and postcommit review**
-
-Freeze with `git diff --binary | sha256sum`; an independent precommit reviewer verifies the deletion is exact, probe URLs remain in PR/#131 evidence, and production routing is unchanged. On PASS run:
-
-```bash
-git add -u .github/workflows/ci-routing-probe.yml
-git commit -m "test(ci): remove temporary routing probe"
-git show --check --stat --oneline HEAD
-git push
-```
-
-Expected: no probe file is in HEAD. A fresh SDD postcommit reviewer checks the pushed SHA, removal-only boundary, and evidence links; record PASS or a bounded repair. Stop after global repair round 2.
-
-### Task 9: Run `ci:full`, merge with reviewed-head protection, and close the work item
-
-**Files:**
-
-- Modify externally: implementation PR, tracking issue, and #131
-- Read: final branch and Actions evidence
-
-**Outcome:** The final reviewed probe-free head receives an authoritative `ci:full` full gate, then merges safely into `release/v0.6.6`; the work item and umbrella record durable evidence.
-
-**Proof:** GitHub reports all twelve expected full-gate checks green on the stored final-reviewed SHA, local/remote/PR/run heads equal that SHA, guarded merge succeeds, and it is an ancestor of the integration branch.
-
-**Constraint:** Do not merge #72, target `main`, rerun an unexplained failure, or substitute a stale/local SHA for the reviewed PR head. Natural-path observation is explicitly supplementary.
-
-**Ponytail Rung:** 2 — use existing GitHub checks, PR state, and guarded native merge behavior.
-
-**Interfaces:** Consumes Task 8 PASS, `${ci_routing_pr_url}`, and final probe-free branch head. Produces a merged PR URL, merge commit, closed tracking issue, and #131 evidence comment.
-
-**Commit message:** No new local implementation commit is authorized in this merge-only task; the reviewed candidate history is frozen. The GitHub merge command below is the sole integration mutation and must be guarded by `--match-head-commit`.
-
-- [ ] **Step 1: Freeze final candidate and independently review before the full gate**
-
-Run:
-
-```bash
-git fetch origin --prune
+~~~bash
 git status --short --branch
-test ! -e .github/workflows/ci-routing-probe.yml
-git diff --check origin/release/v0.6.6...HEAD
+python3 scripts/check_agent_guide.py --selftest
+python3 scripts/check_agent_guide.py
 cargo fmt --check
-git diff --binary origin/release/v0.6.6...HEAD | sha256sum
-```
+git diff --check origin/release/v0.6.6...HEAD
+git diff --name-only origin/release/v0.6.6...HEAD
+~~~
 
-After the independent reviewer PASSes this exact head, set `final_reviewed_sha=$(git rev-parse HEAD)`, confirm the remote branch equals it (push once only if it does not), then use `apply_patch` to insert the literal `final_reviewed_sha: <40-character SHA>` in `progress.md` and the reviewer report. Expected: clean final tree with no plan mutation, no probe file, and no whitespace or format error. Any repair invalidates review and re-enters the one global two-round loop.
+Expected: committed design, replacement plan, and ci.yml are the intentional branch diff; no classifier or other workflow exists.
 
-- [ ] **Step 2: Apply `ci:full` to the final reviewed head and observe all twelve checks**
+- [ ] **Step 2: Record the replacement in issue #164**
 
-Run:
+Edit #164 so its current Outcome/Proof/Constraint/Ponytail sections name the pinned action, one ci.yml change, existing checks, full CI, same-head fuzz, and no custom machinery. Preserve all historical comments. Add a comment that the discarded classifier rounds remain evidence and the approved replacement starts repairs_used 0, repairs_remaining 2.
 
-```bash
-set -euo pipefail
-plan=docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md
-sdd_skill=/home/tchawes/.codex/plugins/cache/openai-curated-remote/superpowers/6.2.0/skills/subagent-driven-development
-workspace=$("$sdd_skill/scripts/sdd-workspace" "$plan")
-ci_routing_pr_url=$(gh pr list --repo miztertea/nim-proxy --state open \
-  --base release/v0.6.6 --head work/v0.6.6-phase0-ci-routing --json url --jq '.[0].url')
-test -n "$ci_routing_pr_url"
-reviewed_sha=$(rg '^final_reviewed_sha: ' "$workspace/progress.md" | cut -d' ' -f2)
-run_for_path_after() {
-  local path=$1 after=$2 runs
-  runs=$(gh api "/repos/miztertea/nim-proxy/actions/runs?event=pull_request&head_sha=$reviewed_sha")
-  jq -c --arg path "$path" --arg after "$after" '.workflow_runs | map(select(.path == $path and .created_at >= $after)) | sort_by(.created_at) | last // empty' <<<"$runs"
-}
-paths=(.github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml)
-pre_toggle_checks=$(gh pr checks "$ci_routing_pr_url" --repo miztertea/nim-proxy --json name,state,bucket,link)
-unlabeled_after=$(date -u +%FT%TZ)
-gh pr edit "$ci_routing_pr_url" --repo miztertea/nim-proxy --remove-label ci:full
-declare -A unlabeled_ids labeled_ids
-for attempt in $(seq 1 20); do
-  ready=1; for path in "${paths[@]}"; do
-    run=$(run_for_path_after "$path" "$unlabeled_after"); unlabeled_ids[$path]=$(jq -r '.id // empty' <<<"$run"); test -n "${unlabeled_ids[$path]}" || ready=0
-  done; [ "$ready" = 1 ] && break; sleep 15; done
-test "$ready" = 1
-labeled_after=$(date -u +%FT%TZ)
-gh pr edit "$ci_routing_pr_url" --repo miztertea/nim-proxy --add-label ci:full
-for attempt in $(seq 1 20); do
-  ready=1; for path in "${paths[@]}"; do
-    run=$(run_for_path_after "$path" "$labeled_after"); labeled_ids[$path]=$(jq -r '.id // empty' <<<"$run"); test -n "${labeled_ids[$path]}" || ready=0
-  done; [ "$ready" = 1 ] && break; sleep 15; done
-test "$ready" = 1
-for path in "${paths[@]}"; do
-  test "${labeled_ids[$path]}" != "${unlabeled_ids[$path]}"; gh run watch "${labeled_ids[$path]}" --repo miztertea/nim-proxy
-  view=$(gh run view "${labeled_ids[$path]}" --repo miztertea/nim-proxy --json url,conclusion,jobs,headSha,createdAt)
-  test "$(jq -r .headSha <<<"$view")" = "$reviewed_sha"; test "$(jq -r .conclusion <<<"$view")" = success
-  jq -e '.jobs[] | select(.name == "scope" and .conclusion == "success")' <<<"$view"
-done
-# Use apply_patch to store pre_toggle_checks, unlabeled_ids, labeled_ids, and their URLs in the ignored report.
-```
+- [ ] **Step 3: Push and open the PR**
 
-Expected: use `apply_patch` to retain `pre_toggle_checks`, three distinct unlabeled IDs, three distinct labeled IDs, URLs, head SHAs, and scope conclusions in the ignored report. All labeled IDs differ from their unlabeled counterpart and all twelve historical checks are terminal green: `fmt, clippy, tests`, `coverage`, `msrv`, `cargo-deny`, `gitleaks`, `workflow lint`, `zizmor`, `dependency review`, `docker build`, `CodeQL`, `codeql (rust)`, and `smoke fuzz`. After exact labeled runs complete, record `gh pr checks "$ci_routing_pr_url" --json name,state,bucket,link` for those contexts and compare durations to PR #163’s approximately 28 runner-minute baseline. For any failure, inspect logs, classify introduced/baseline/flaky/infrastructure, and create one repair package; never rerun blindly.
+~~~bash
+reviewed_sha=$(git rev-parse HEAD)
+git push -u origin work/v0.6.6-phase0-ci-routing
+test "$(git ls-remote origin refs/heads/work/v0.6.6-phase0-ci-routing | cut -f1)" = "$reviewed_sha"
+ci_pr_url=$(gh pr create --repo miztertea/nim-proxy \
+  --base release/v0.6.6 \
+  --head work/v0.6.6-phase0-ci-routing \
+  --title "ci: route v0.6.6 validation from changed surfaces" \
+  --body "Implements the approved Lego-brick CI routing design. Reuses existing checks, adds only the pinned paths-filter action, and tracks #164 / #131.")
+test -n "$ci_pr_url"
+gh pr edit "$ci_pr_url" --repo miztertea/nim-proxy --add-label ci:full
+gh pr view "$ci_pr_url" --repo miztertea/nim-proxy \
+  --json url,state,isDraft,baseRefName,headRefName,headRefOid,labels,files
+~~~
 
-- [ ] **Step 3: Fresh-shell guarded merge with reviewed-head equality**
+Expected: one open non-draft PR targets release/v0.6.6, headRefOid equals reviewed_sha, and ci:full is present.
 
-From a fresh shell in the task worktree, run exactly:
+### Task 3: Prove, review, and merge Phase 0
 
-```bash
-plan=docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md
-sdd_skill=/home/tchawes/.codex/plugins/cache/openai-curated-remote/superpowers/6.2.0/skills/subagent-driven-development
-workspace=$("$sdd_skill/scripts/sdd-workspace" "$plan")
+**Files:**
+
+- Read the Phase 0 PR and Actions runs
+- Update issue #164 and #131
+
+**Outcome:** The exact reviewed head passes full required CI, CodeQL, label-triggered CI, and fuzz, then merges into release/v0.6.6 with head protection.
+
+**Proof:** Local, remote, PR, required-check, CI-run, CodeQL-run, and fuzz-run SHAs all equal reviewed_sha; guarded merge succeeds; integration contains the reviewed head.
+
+**Constraint:** Diagnose any failure before retry. Any code repair invalidates the stored head/review and consumes one of two repair rounds.
+
+**Ponytail Rung:** Rung 4 uses native required contexts, label events, workflow_dispatch, and --match-head-commit.
+
+**Interfaces:** Consumes ci_pr_url and reviewed_sha. Produces the merged Phase 0 PR and a mandatory natural-route observation for the first ordinary remediation PR.
+
+- [ ] **Step 1: Freeze the current reviewed head and required checks**
+
+~~~bash
 git fetch origin --prune
-reviewed_sha=$(rg '^final_reviewed_sha: ' "$workspace/progress.md" | cut -d' ' -f2)
-test "${#reviewed_sha}" -eq 40
-ci_routing_pr_url=$(gh pr list --repo miztertea/nim-proxy --state open \
-  --base release/v0.6.6 --head work/v0.6.6-phase0-ci-routing --json url --jq '.[0].url')
-pr_head=$(gh pr view "$ci_routing_pr_url" --repo miztertea/nim-proxy --json headRefOid --jq .headRefOid)
+reviewed_sha=$(git rev-parse HEAD)
+pr_head=$(gh pr view "$ci_pr_url" --repo miztertea/nim-proxy --json headRefOid --jq .headRefOid)
 remote_head=$(git ls-remote origin refs/heads/work/v0.6.6-phase0-ci-routing | cut -f1)
-test "$(git rev-parse HEAD)" = "$reviewed_sha"
-test "$remote_head" = "$reviewed_sha"
 test "$pr_head" = "$reviewed_sha"
-gh pr view "$ci_routing_pr_url" --repo miztertea/nim-proxy --json mergeStateStatus,isDraft,state
-gh pr merge "$ci_routing_pr_url" --repo miztertea/nim-proxy --merge --match-head-commit "$reviewed_sha"
+test "$remote_head" = "$reviewed_sha"
+gh pr checks "$ci_pr_url" --repo miztertea/nim-proxy \
+  --required --watch --fail-fast
+~~~
+
+Expected: all nine required contexts, including unchanged codeql (rust), are green on reviewed_sha. The ci.yml workflow-policy change selects all expensive groups.
+
+- [ ] **Step 2: Prove the label event creates a same-head full CI run**
+
+Record the current newest ci.yml PR run ID for reviewed_sha, remove ci:full, then re-add it. Find the newest pull_request run whose path is .github/workflows/ci.yml, head_sha is reviewed_sha, and created_at is after the add-label timestamp. Watch it and require changes, check, coverage, msrv, deny, gitleaks, lint-workflows, dependency-review, and docker to conclude success. Do not expect CodeQL or fuzz to retrigger from a label event.
+
+- [ ] **Step 3: Prove unchanged fuzz on the reviewed ref**
+
+If no successful native fuzz run already has headSha reviewed_sha:
+
+~~~bash
+fuzz_started=$(date -u +%FT%TZ)
+gh workflow run fuzz.yml --repo miztertea/nim-proxy \
+  --ref work/v0.6.6-phase0-ci-routing
+~~~
+
+Find the newest workflow_dispatch fuzz.yml run created after fuzz_started, require headSha reviewed_sha, watch it, and require conclusion success.
+
+- [ ] **Step 4: Independently review the final head and evidence**
+
+The reviewer reads the PR diff, required checks, label-triggered CI run, CodeQL run, fuzz run, and the four-way SHA equality. Critical or Important findings require a repair and repeat Steps 1–4. A second failed repair stops the goal loop with exact evidence.
+
+- [ ] **Step 5: Merge with reviewed-head protection**
+
+From a fresh shell:
+
+~~~bash
+git fetch origin --prune
+reviewed_sha=$(git rev-parse HEAD)
+pr_head=$(gh pr view "$ci_pr_url" --repo miztertea/nim-proxy --json headRefOid --jq .headRefOid)
+remote_head=$(git ls-remote origin refs/heads/work/v0.6.6-phase0-ci-routing | cut -f1)
+test "$pr_head" = "$reviewed_sha"
+test "$remote_head" = "$reviewed_sha"
+gh pr merge "$ci_pr_url" --repo miztertea/nim-proxy \
+  --merge --match-head-commit "$reviewed_sha"
 git fetch origin --prune
 git merge-base --is-ancestor "$reviewed_sha" origin/release/v0.6.6
-gh pr view "$ci_routing_pr_url" --repo miztertea/nim-proxy --json state,mergedAt,mergeCommit,url
-```
+~~~
 
-Expected: local HEAD, remote branch, PR head, every authoritative CI/CodeQL/Fuzz run head SHA, and `--match-head-commit "$reviewed_sha"` all equal the literal reviewed SHA from the ignored report. The PR is `OPEN`, non-draft, and `CLEAN`; zero approvals are expected under ruleset `18516333`. Final view is `MERGED` and the reviewed head is integrated. If any assertion fails, do not merge—record current state in the ignored report and return to review.
+Expected: the reviewed head merges into release/v0.6.6. Comment on #164 and #131 with PR, merge, required-check, label-run, CodeQL, fuzz, and repair-count evidence. Keep #164 open until Task 4.
 
-- [ ] **Step 4: Conduct the final SDD postmerge review before closure**
+### Task 4: Close Phase 0 on the first natural reduced route
 
-A fresh reviewer reads the merged PR, final Actions JSON, ignored reviewer report, and `git merge-base` result. They verify no probe file merged, protected SHA equality, and fresh results. Record PASS or owner-visible discrepancy in `progress.md`; do not close either issue until PASS.
+**Files:** Read the first ordinary remediation PR and update issues #164/#131.
 
-- [ ] **Step 5: Close/update only after postmerge PASS**
+**Outcome:** Real selected/skipped evidence validates reduced routing before the issue train proceeds.
 
-Run:
+**Proof:** The first ordinary PR shows the jobs expected for its actual changed surface and terminal successful skips for unrelated expensive jobs.
 
-```bash
-ci_routing_issue_number=$(gh issue list --repo miztertea/nim-proxy --state open \
-  --search '"v0.6.6 Phase 0: change-aware CI routing" in:title' --json number,title \
-  --jq '.[] | select(.title == "v0.6.6 Phase 0: change-aware CI routing") | .number')
-test "$ci_routing_issue_number" -gt 0
-gh issue close "$ci_routing_issue_number" --repo miztertea/nim-proxy \
-  --comment "Resolved by ${ci_routing_pr_url}; selected/skipped and malformed-classifier probes passed, final ci:full passed, and the reviewed head merged into release/v0.6.6."
-gh issue comment 131 --repo miztertea/nim-proxy \
-  --body "Phase 0 change-aware CI routing complete: ${ci_routing_pr_url}. Evidence includes probe runs, final twelve-check ci:full run, merge commit, and PR #163’s approximately 28 runner-minute baseline. Natural-path timing is supplementary only."
-```
+**Constraint:** No synthetic file, commit, workflow, or validator. If routing is wrong, pause the train, fix ci.yml under #164, independently review, and repeat Task 3.
 
-Expected: the tracking issue is closed and #131 is updated but never closed. Report fresh check conclusions/durations, global repair count, scope deltas, merge SHA, and the supplementary observation rule.
+**Ponytail Rung:** Rung 2 uses the first real remediation PR and existing Actions UI/API.
 
-## Plan self-review
+- [ ] **Step 1: Inspect the first ordinary remediation PR**
 
-- Coverage: Tasks 1–9 implement the required issue/label, task packages, three scripts, three-workflow wiring, temporary probe add/run/removal, final `ci:full`, guarded merge, tracking-issue closure with #131 update, and supplementary natural-path observation rule.
-- Failure paths: every implementation task starts with an executable negative/self-test case and records the required green proof; GitHub failures are classified before a bounded repair, never blindly retried.
-- Review gates: every mutating repository task names a frozen-diff independent precommit review, commit message, and fresh SDD postcommit review; external-only/merge-only tasks state that no local commit is authorized. All repair sources share the ignored ledger’s two-round cap.
-- Contract consistency: output names, full reasons, check names, event activities, integration base, issue/branch names, stored final-reviewed SHA equality, and guarded merge match the approved design.
-- Placeholder scan: run `! rg -n '^(TBD|TODO|implement later|fill in details|_Task package|_Complete only)' docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md`; expected no matches and exit status 0.
-- Structural proof: run `git diff --check -- docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md`; expected no output.
+Record its reviewed SHA, changed files, changes outputs, selected jobs, skipped jobs, and required-context conclusions.
 
-## Execution handoff
+- [ ] **Step 2: Close or repair**
 
-Execute only through `superpowers:subagent-driven-development`, one sequential task package at a time, preserving the ledger and the two-repair-round cap. The manager must stop with fresh evidence on an ambiguity, scope delta, non-determinable fact, failed proof, or exhausted repair budget.
+If the natural route matches this plan and the approved matrix, close #164 with the evidence URLs and update #131. Otherwise keep #164 open, stop the next remediation issue, and repair Phase 0 within the remaining two-round budget.
+
+## Plan Self-Review
+
+- Spec coverage: Tasks 1–4 cover the sole action, four filters, routing failure, metadata overrides, unchanged security/cheap checks, unchanged CodeQL/fuzz, full gates, guarded merge, and natural reduced evidence.
+- Placeholder scan: the plan contains no deferred implementation, generic test request, or omitted code body.
+- Interface consistency: Task 1 produces the exact branch and changes outputs consumed by Tasks 2–3; Task 3 produces the first-natural observation consumed by Task 4.
+- Execution mode: the owner already chose subagent-driven execution; proceed without another owner-choice gate.

--- a/docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md
+++ b/docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md
@@ -1,0 +1,909 @@
+# v0.6.6 Change-Aware CI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` task-by-task. Maintain the ignored SDD workspace ledger; use one implementer and a fresh independent reviewer per task, sequentially, with no nested delegation. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement fail-closed, change-aware pull-request CI routing while preserving existing required check names and proving both reduced routing and full release validation before merge into `release/v0.6.6`.
+
+**Architecture:** A Python-standard-library classifier is the only source of path/risk policy. `ci.yml`, `codeql.yml`, and `fuzz.yml` add small scope jobs that run classifier self-tests, derive one shared output contract from the live pull-request diff, and use job-level conditions or guarded step groups without workflow-level PR path filters. Two small standard-library documentation checkers provide meaningful docs-only proof; GitHub Actions probes prove selected skips and failure propagation on the real PR.
+
+**Tech Stack:** Python 3 standard library, Git, GitHub CLI, GitHub Actions YAML, existing Rust/Node CI tools.
+
+## Global Constraints
+
+- Integration branch: `release/v0.6.6`; only PR #72 targets `main`.
+- Design commit: `e1f67ca`; integration base: `6b6fde466bc28e5b2e9bca14be8eb43212c39160`.
+- The freshly queried `main` ruleset `18516333` has nine required contexts. Preserve their check names unchanged.
+- PR #72 is `CLEAN`/`MERGEABLE` with twelve green checks and remains unmerged; do not merge it.
+- PR #163 establishes the pre-change baseline at approximately 28 runner-minutes; record it as historical evidence, not a new measurement.
+- Do not use workflow-level path filters for a required PR workflow. Required contexts must reach terminal outcomes.
+- All scope jobs run `ci_scope.py --selftest` before classifying the live event. Unknown, malformed, empty, security-sensitive, workflow-policy, `ci:full`, `main`-targeting, and non-PR changes must fail closed or select full validation.
+- Create no non-stdlib runtime dependencies. Ponytail Rung is 2 for existing workflows/scripts/testing conventions, falling to 3 only for `scripts/ci_scope.py`, `scripts/check_markdown_links.py`, and `scripts/check_knowledge.py`.
+- The plan is immutable once its independent plan review passes: commit this plan once before execution. Execution state never edits or commits the plan; it lives in the ignored SDD workspace and durable GitHub issue/PR comments.
+- Every substantive task gets one independent precommit review and one SDD postcommit review. The SDD skill’s default five rounds is explicitly overridden: one global counter starts at `repairs_used: 0`, `repairs_remaining: 2`; every task, CI, review, or final repair increments that same counter. At exhaustion stop with evidence and request an owner decision.
+- Before every push run the task’s named proof plus `cargo fmt --check`; skipped expensive Rust/render/fuzz checks are explicitly reported, never silently inferred.
+- The temporary live probe is reviewed, committed, run, evidenced, then removed in a separately reviewed commit. It must not be in the merged tree.
+- Natural-path observation on the first ordinary remediation PR after merge is supplementary only; Phase 0 completion cannot wait for it.
+
+## File responsibility map
+
+- `scripts/ci_scope.py` — sole deterministic classifier and self-tests.
+- `scripts/check_markdown_links.py` — local tracked-Markdown link checker and self-tests.
+- `scripts/check_knowledge.py` — OKF schema checker and self-tests, without a legacy allowlist.
+- `knowledge/decisions/dashboard-operator-console-redesign.md` — normalize Decision headings only.
+- `knowledge/decisions/input-sanitizing-and-xss.md` — normalize Decision headings only.
+- `knowledge/decisions/message-catalog-and-escaping.md` — normalize Decision headings only.
+- `.github/workflows/ci.yml` — scope job, guarded required check, and routing conditions.
+- `.github/workflows/codeql.yml` — scope job and guarded CodeQL condition.
+- `.github/workflows/fuzz.yml` — scope job, no top-level PR path filter, and guarded fuzz condition.
+- `.github/workflows/ci-routing-probe.yml` — temporary, real-classifier Actions proof; added then removed before final validation.
+- `docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md` — immutable task contract, reviewed and committed once before execution.
+
+## SDD workspace and task-package protocol
+
+Before execution, independently review this completed plan and commit it once as `docs: add change-aware CI execution plan`. Resolve the plan-scoped ignored workspace, then create the ledger and all task artifacts there:
+
+```bash
+plan=docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md
+sdd_skill=/home/tchawes/.codex/plugins/cache/openai-curated-remote/superpowers/6.2.0/skills/subagent-driven-development
+workspace=$("$sdd_skill/scripts/sdd-workspace" "$plan")
+```
+
+Then use `apply_patch` to create `$workspace/progress.md` with first line `# SDD ledger — plan: docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md`, then `repairs_used: 0` and `repairs_remaining: 2`. Expected: `workspace` is the git-ignored `.superpowers/sdd/2026-08-08-v0.6.6-change-aware-ci/` directory and `progress.md` is its only global recovery record. For each task, use `task-brief`, an implementer report, `review-package`, reviewer report, and (when needed) re-review report in that workspace. The manager uses `apply_patch` to record implementer/reviewer identities, frozen diff digest, named proof, commit SHA, review verdict, scope delta, exact final-reviewed SHA, and repair-counter update in `progress.md`; GitHub issue/PR comments retain durable URLs. Each package authorizes only its listed files/actions; the implementer stops on ambiguity, out-of-scope discovery, non-determinable fact, or failed proof. A reviewer inspects a frozen package before commit; reviewer-report writes are separate ignored files and therefore never change the reviewed digest.
+
+---
+
+### Task 1: Create the tracked Phase 0 CI-routing work item and SDD ledger
+
+**Files:**
+
+- Modify externally: repository label `ci:full`, one new GitHub issue, and umbrella issue #131
+
+**Outcome:** One uniquely titled Phase 0 issue, the `ci:full` label, and an ignored SDD workspace ledger exist before implementation begins.
+
+**Proof:** Fresh GitHub reads show the exact label description, exactly one matching open issue, and #131 linking it; `progress.md` names this plan and records Task 1 evidence.
+
+**Constraint:** Do not create a PR, change workflows, apply `ci:full` to #72, or start implementation. Preserve the known integration base `6b6fde466bc28e5b2e9bca14be8eb43212c39160`.
+
+**Ponytail Rung:** 2 — reuse the existing Phase 0 issue/ledger convention and GitHub CLI; no new mechanism.
+
+**Interfaces:**
+
+- Consumes: design commit `e1f67ca`, integration base `6b6fde466bc28e5b2e9bca14be8eb43212c39160`, and this approved plan.
+- Produces: `ci:full` (description exactly `Run every v0.6.6 release gate`), issue number `${ci_routing_issue_number}`, and branch `work/v0.6.6-phase0-ci-routing` ready for Task 2.
+
+- [ ] **Step 1: Load and constrain the SDD session**
+
+Read `superpowers:using-git-worktrees` and `superpowers:subagent-driven-development`. Run the workspace setup from the preceding section, then run `"$sdd_skill/scripts/task-brief" "$plan" 1` and dispatch only that brief. Record the Task 1 implementer, frozen evidence digest, reviewer, URLs, and result in `"$workspace/progress.md"`; authorize the two external creates only and require stop-on-ambiguity evidence.
+
+- [ ] **Step 2: Prove the pinned starting point and failure path**
+
+Run:
+
+```bash
+git fetch origin --prune
+test "$(git rev-parse origin/release/v0.6.6)" = "6b6fde466bc28e5b2e9bca14be8eb43212c39160"
+git status --short --branch
+gh label list --repo miztertea/nim-proxy --limit 200 --search ci:full
+gh issue list --repo miztertea/nim-proxy --state open \
+  --search '"v0.6.6 Phase 0: change-aware CI routing" in:title' \
+  --json number,title,url
+```
+
+Expected: the SHA assertion passes; the worktree has only the approved plan change; the output either shows no `ci:full` label or a label whose description must be inspected before reuse; and it shows zero matching open issues. If a matching issue or incompatible label already exists, stop and report its URL/description rather than creating a duplicate.
+
+- [ ] **Step 3: Create or verify the exact full-suite override label**
+
+Run:
+
+```bash
+gh label create ci:full --repo miztertea/nim-proxy \
+  --description "Run every v0.6.6 release gate" --color 0E8A16 --force
+gh label list --repo miztertea/nim-proxy --limit 200 --search ci:full \
+  --json name,description,color --jq '.[] | select(.name == "ci:full")'
+```
+
+Expected: exactly one `ci:full` label has the stated description. This is the green path after Step 2’s absent/incorrect-label detection.
+
+- [ ] **Step 4: Create the uniquely titled tracking issue and link #131**
+
+Run:
+
+```bash
+ci_routing_issue_url=$(gh issue create --repo miztertea/nim-proxy \
+  --title "v0.6.6 Phase 0: change-aware CI routing" \
+  --milestone v0.6.6 \
+  --body '## Outcome
+
+Implement fail-closed change-aware CI routing before remediation issue work starts.
+
+## Proof
+
+- A shared standard-library classifier drives CI, CodeQL, and fuzz routing.
+- Real PR probes prove selected skips and classifier-failure propagation.
+- ci:full starts a twelve-check full gate on the final reviewed head.
+
+## Constraint
+
+Preserve existing required check names; do not use workflow-level path filters for required PR workflows; main remains untouched.
+
+## Ponytail Rung
+
+Reuse existing workflows, scripts, and test strategy; add only the three approved standard-library scripts.
+
+Parent: #131')
+ci_routing_issue_number=${ci_routing_issue_url##*/}
+test "$ci_routing_issue_number" -gt 0
+gh issue comment 131 --repo miztertea/nim-proxy \
+  --body "Phase 0 change-aware CI routing started: ${ci_routing_issue_url}. The implementation PR will target release/v0.6.6; PR #163’s approximately 28 runner-minute baseline will be retained as evidence."
+```
+
+Expected: one issue URL is returned and #131 has the linking comment. On API failure, retain command output in the ledger and stop; do not proceed with a local-only substitute.
+
+- [ ] **Step 5: Freeze the ledger update and obtain the independent precommit review**
+
+Run:
+
+```bash
+git status --short
+gh label list --repo miztertea/nim-proxy --limit 200 --search ci:full --json name,description,color
+```
+
+Give a fresh independent reviewer the Task 1 brief, the separate implementer report, label JSON, issue/#131 URLs, and a separate read-only evidence package. The reviewer verifies unique external state, the pinned base, and that no implementation work began. Record `PASS` or the concrete rejection in `progress.md`; each repair increments the same global counter and recomputes `repairs_remaining`.
+
+- [ ] **Step 6: Conduct the SDD task-completion review**
+
+Dispatch a different fresh reviewer with the Task 1 brief, report, and evidence package. The reviewer returns `PASS` or one concrete repair package; record the verdict in `progress.md` and a durable issue comment before Task 2 starts. Task 1 has no repository commit; do not invent one.
+
+### Task 2: Implement and prove the fail-closed classifier
+
+**Files:**
+
+- Create: `scripts/ci_scope.py`
+- Test: committed in-script `--selftest` fixtures; no separate framework or dependency
+
+**Outcome:** The shared classifier deterministically maps normalized changed paths and PR metadata to the exact 18 Boolean outputs plus a closed reason, failing rather than reducing validation on malformed input.
+
+**Proof:** Its self-test first observes each negative fixture exit nonzero and then passes all positive/overlap/full-routing fixtures; `--assert-known` accepts every tracked path; Python compilation passes.
+
+**Constraint:** Implement only Python standard library; no YAML-embedded path policy; keep all result names exactly as the approved design states.
+
+**Ponytail Rung:** 3 — a small stdlib script is required because no existing repository tool supplies this single shared Actions interface.
+
+**Interfaces:**
+
+```python
+@dataclass(frozen=True)
+class Scope:
+    docs: bool; rust: bool; presentation: bool; dependencies: bool
+    workflow: bool; container: bool; security: bool; fuzz: bool
+    full: bool; reason: str
+
+def classify(paths: tuple[str, ...], *, event_name: str,
+             base_ref: str, labels: tuple[str, ...]) -> Scope: ...
+def job_outputs(scope: Scope) -> dict[str, bool]: ...
+```
+
+It writes all nine surface keys, all nine job keys, and `reason`; Booleans are literal lowercase `true`/`false`.
+
+- [ ] **Step 1: Write executable red fixtures before classification code**
+
+Create `scripts/ci_scope.py` with argument parsing, temporary-directory fixtures, and a deliberately raising/stub `classify`. The `--selftest` must invoke the CLI and assert nonzero exits for malformed label JSON, non-array labels, non-string labels, missing/unreadable PR paths file, invalid UTF-8, empty/absolute/trailing-slash/backslash/dot-component paths, an injected internal exception, and a malformed workflow fixture missing `always()`. It must assert expected output dictionaries for docs-only, Rust, static presentation-only, dependency (including `stable=true`), container, fuzz, overlap, target-main, `ci:full`, non-PR, unknown, empty, security, workflow, duplicate-normalization, classifier-policy paths, and a valid three-workflow fixture accepted by `--check-workflows`.
+
+Run:
+
+```bash
+python3 scripts/ci_scope.py --selftest
+```
+
+Expected: FAIL because the classifier is deliberately unimplemented; the self-test output identifies the first missing expected classification rather than treating a failure as a skip.
+
+- [ ] **Step 2: Implement canonical input parsing and classification**
+
+Implement only standard-library `argparse`, `dataclasses`, `json`, `pathlib`, `subprocess`, `sys`, and `tempfile`. The exact interfaces are `classify(paths: tuple[str, ...], *, event_name: str, base_ref: str, labels: tuple[str, ...]) -> Scope` and `job_outputs(scope: Scope) -> dict[str, bool]`; `Scope` has `docs, rust, presentation, dependencies, workflow, container, security, fuzz, full, reason` fields. For a pull request, require a readable NUL file and validate each decoded path; deduplicate and lexically sort paths. For non-PR events, return full scope without consuming label/path inputs. Decode labels only as `list[str]`.
+
+Classify root Markdown/policy text, `docs/**`, `knowledge/**`, `examples/**`, issue/PR templates, `CODEOWNERS`, and the three check scripts as docs; `src/**` except `src/web/**`, Rust integration tests/non-presentation fixtures, `openapi.json`, and `rust-toolchain.toml` as Rust; `src/web/**`, `src/presentation.rs`, render/formatter/i18n/locale/pseudolocale scripts and UI/locale/formatter fixtures as presentation; `Cargo.toml`, `Cargo.lock`, `deny.toml`, `.github/dependabot.yml` as dependencies; `.github/workflows/**`, `.github/codeql/**`, `.github/release.yml`, `scripts/ci_scope.py`, and `scripts/test_release_contract.py` as workflow; `Dockerfile`, `.dockerignore`, and `docker-compose*.yml` as container; `fuzz/**`, `src/proxy.rs`, `src/config.rs`, and `.github/workflows/fuzz.yml` as fuzz; `src/api.rs`, `src/auth.rs`, `src/config.rs`, `src/main.rs`, `src/proxy.rs`, `src/routes.rs`, `src/settings.rs`, and `.github/codeql/**` as security. Other known operational scripts select full; every unknown path selects full.
+
+Use first-match full reasons exactly `non-pr`, `target-main`, `full-label`, `workflow-policy`, `security-path`, `unknown-path`, `empty-diff`, then `routed`. Emit nine surface keys plus nine job keys: `stable=rust|dependencies|full`, `coverage=rust|full`, `msrv=rust|dependencies|full`, `deny=dependencies|full`, `workflow_lint=workflow|full`, `dependency_review=dependencies|workflow|full`, `docker=container|dependencies|full`, `codeql=rust|full`, `smoke_fuzz=fuzz|full`, and closed `reason`. Make `--github-output` append deterministic output lines and stdout print sorted JSON otherwise. Make `--assert-known` enumerate tracked paths with `git ls-files -z` and reject any without a rule. Add `--check-workflows ROOT`: parse the three YAML files as text and fail unless they have the exact five PR activities, `scope` job, required job names, scope output references, no required-workflow path filter, fuzz no top-level PR `paths`, `always()` guards, and the expected job/step conditions; it never invokes a shell or GitHub API.
+
+- [ ] **Step 3: Run the green and explicit failure-path proofs**
+
+Run:
+
+```bash
+python3 scripts/ci_scope.py --selftest
+python3 -m py_compile scripts/ci_scope.py
+python3 scripts/ci_scope.py --event-name pull_request --base-ref release/v0.6.6 \
+  --labels-json '[]' --paths-file <(printf 'docs/readme.md\0')
+python3 scripts/ci_scope.py --event-name pull_request --base-ref release/v0.6.6 \
+  --labels-json '{bad json}' --paths-file <(printf 'docs/readme.md\0'); test "$?" -ne 0
+python3 scripts/ci_scope.py --event-name pull_request --base-ref release/v0.6.6 \
+  --labels-json '[]' --paths-file <(git ls-files -z) --assert-known
+```
+
+Expected: self-test and compilation pass; the docs fixture reports `docs=true`, `full=false`, and all keys; malformed JSON exits nonzero; the tracked inventory passes. If process substitution is unavailable, use a named `mktemp` file and remove it after the command.
+
+- [ ] **Step 4: Freeze, independently review, and commit**
+
+Run:
+
+```bash
+git diff -- scripts/ci_scope.py
+git diff --binary | sha256sum
+git diff --check
+```
+
+An independent precommit reviewer verifies the full reason precedence, every required path family, no unknown/malformed route can reduce scope, exactly 18 Boolean outputs plus `reason`, deterministic normalization, and standard-library-only imports. Record the digest and verdict in the SDD ledger. On PASS:
+
+```bash
+git add scripts/ci_scope.py
+git commit -m "feat(ci): add fail-closed change classifier"
+git show --check --stat --oneline HEAD
+```
+
+Expected: a script-only commit with no whitespace errors.
+
+- [ ] **Step 5: Conduct the SDD postcommit review**
+
+A fresh postcommit reviewer runs the Step 3 proof on the committed SHA and inspects `git show HEAD -- scripts/ci_scope.py`. They record PASS or one bounded repair package in the ledger. A repair must re-run red evidence, green evidence, independent review, and commit; stop after global repair round 2 with the failing output.
+
+### Task 3: Implement and prove repository-local Markdown-link validation
+
+**Files:**
+
+- Create: `scripts/check_markdown_links.py`
+- Test: committed in-script `--selftest` fixtures
+
+**Outcome:** Documentation-only changes receive a deterministic check of tracked repository-local Markdown targets without validating external URLs or anchors.
+
+**Proof:** Negative fixture branches fail before the checker passes its tracked-file scan and compiles.
+
+**Constraint:** Split literal `#` then literal `?` before percent decoding; do not validate anchors, fetch URLs, or traverse outside the repository.
+
+**Ponytail Rung:** 3 — the repository has no Markdown-link checker and the approved design requires one stdlib implementation.
+
+**Interfaces:** `python3 scripts/check_markdown_links.py [--selftest] [--root PATH]` exits 0 only when all tracked Markdown files have valid repository-local targets.
+
+- [ ] **Step 1: Create red fixtures that exercise every branch**
+
+Write a standard-library script using `argparse`, `pathlib`, `re`, `tempfile`, and `urllib.parse`; start its scanner as an intentional failure. Its `--selftest` creates fixtures for a valid local link, encoded space, encoded `%23`, encoded `%3F`, ordinary query, missing target, repository escape, external URL, and fragment-only link.
+
+Run:
+
+```bash
+python3 scripts/check_markdown_links.py --selftest
+```
+
+Expected: FAIL while the scanner is stubbed, proving the test harness detects an invalid checker rather than accepting empty output.
+
+- [ ] **Step 2: Implement the bounded local-link scan**
+
+Enumerate tracked `*.md` paths via `git ls-files -z -- '*.md'`. Extract normal Markdown link destinations while ignoring image-only syntax only if the destination parser already sees it as a local link. For each raw destination: split on the first literal `#`, split the preceding text on the first literal `?`, then percent-decode that remaining path; ignore blank fragment-only paths and parsed URLs with a scheme. Resolve a target relative to the source file, reject it when `relative_to(root)` fails, and reject absent targets. Report source path plus raw destination for every problem and exit nonzero.
+
+- [ ] **Step 3: Prove the red branches and green repository scan**
+
+Run:
+
+```bash
+python3 scripts/check_markdown_links.py --selftest
+python3 -m py_compile scripts/check_markdown_links.py
+python3 scripts/check_markdown_links.py
+tmp=$(mktemp -d)
+git -C "$tmp" init -q
+printf '[bad](../outside.md)\n' > "$tmp/escape.md"
+git -C "$tmp" add escape.md
+python3 scripts/check_markdown_links.py --root "$tmp"; test "$?" -ne 0
+rm -rf "$tmp"
+```
+
+Expected: self-test reports each negative fixture as observed, compilation succeeds, the tracked repository scan exits 0, and the explicit escape fixture exits nonzero.
+
+- [ ] **Step 4: Freeze, independently review, and commit**
+
+Run:
+
+```bash
+git diff -- scripts/check_markdown_links.py
+git diff --binary | sha256sum
+git diff --check
+```
+
+The precommit reviewer independently checks operation order around encoded `#`/`?`, repository escape refusal, no network behavior, and one positive plus all stated negative fixtures. Record the frozen digest and PASS in the ledger, then run:
+
+```bash
+git add scripts/check_markdown_links.py
+git commit -m "test(docs): validate local Markdown links"
+git show --check --stat --oneline HEAD
+```
+
+Expected: script-only commit, no whitespace errors.
+
+- [ ] **Step 5: Conduct the SDD postcommit review**
+
+A fresh reviewer runs Step 3 on the committed SHA, confirms no external URL was fetched, and records PASS or one bounded repair package. Any repair re-enters the red/green/review sequence and stops after the global two-round cap.
+
+### Task 4: Implement knowledge-schema validation and normalize the three Decision exceptions
+
+**Files:**
+
+- Create: `scripts/check_knowledge.py`
+- Modify: `knowledge/decisions/dashboard-operator-console-redesign.md`
+- Modify: `knowledge/decisions/input-sanitizing-and-xss.md`
+- Modify: `knowledge/decisions/message-catalog-and-escaping.md`
+
+**Outcome:** The repository has a dependency-free knowledge schema gate and all Decision pages satisfy the declared Context → Options → Choice → Consequences sequence without an exception list.
+
+**Proof:** One self-test fixture trips each rule; the checker then accepts every tracked knowledge page and a direct malformed Decision fixture fails.
+
+**Constraint:** Normalize exactly the three named legacy Decision pages. Do not revise their durable substance, frontmatter identity, index, or log; do not add a grandfather list.
+
+**Ponytail Rung:** 3 for the required stdlib validator; 2 for repairing existing headings under the established OKF contract.
+
+**Interfaces:** `python3 scripts/check_knowledge.py [--selftest] [--root PATH]` scans tracked `knowledge/**/*.md` and exits nonzero with path-and-rule diagnostics.
+
+- [ ] **Step 1: Write red checker fixtures**
+
+Create `scripts/check_knowledge.py` with `--selftest` before implementing validation. Fixtures must include one valid page and separate invalid cases for missing/unterminated/unparseable frontmatter, empty `type`, wrong `index.md` type, wrong `log.md` type, unsupported concept type, non-kebab concept filename, missing `Context`, missing `Options`, missing `Choice`, missing `Consequences`, and out-of-order Decision headings.
+
+Run:
+
+```bash
+python3 scripts/check_knowledge.py --selftest
+```
+
+Expected: FAIL while validation is unimplemented; each fixture is named so a no-op checker cannot pass.
+
+- [ ] **Step 2: Implement the bounded schema parser and normalize only the exceptions**
+
+Use only Python standard library. Parse the repository’s bounded YAML frontmatter subset sufficiently to require an opening delimiter at byte 0, a closing delimiter, colon key/value lines, and a nonempty `type`. Require `Index` for every file named `index.md`, `Log` for `knowledge/log.md`, and one of `Decision`, `Research Finding`, `Component`, or `Runbook` otherwise. Require kebab-case concept filenames and ordered Decision headings.
+
+Use `apply_patch` for the three documents:
+
+- In `dashboard-operator-console-redesign.md`, rename `## Options & Choice` to `## Options`; insert `## Choice` immediately before `## Consequences` and summarize the four already-selected choices without changing their text.
+- In `input-sanitizing-and-xss.md`, insert `## Options` between Context and Choice with the accurate option statement that the documented alternative was not to rely on one sink-only defense.
+- In `message-catalog-and-escaping.md`, insert `## Options` between Context and Choice with the accurate rejected alternatives already described in Context: global raw `message()` or further partial JavaScript parsing.
+
+Do not alter any other `knowledge/decisions/*.md` path.
+
+- [ ] **Step 3: Run red then green schema proof**
+
+Run:
+
+```bash
+python3 scripts/check_knowledge.py --selftest
+python3 -m py_compile scripts/check_knowledge.py
+python3 scripts/check_knowledge.py
+tmp=$(mktemp -d)
+git -C "$tmp" init -q
+mkdir -p "$tmp/knowledge/decisions"
+printf '%s\n' '---' 'type: Decision' '---' '# Bad' '## Context' '## Choice' '## Consequences' > "$tmp/knowledge/decisions/not-options.md"
+git -C "$tmp" add knowledge/decisions/not-options.md
+python3 scripts/check_knowledge.py --root "$tmp"; test "$?" -ne 0
+rm -rf "$tmp"
+```
+
+Expected: self-test and compilation pass; tracked inventory passes; direct missing-Options fixture exits nonzero; no grandfather exception exists.
+
+- [ ] **Step 4: Freeze, independently review, and commit**
+
+Run:
+
+```bash
+git diff -- scripts/check_knowledge.py knowledge/decisions/dashboard-operator-console-redesign.md \
+  knowledge/decisions/input-sanitizing-and-xss.md knowledge/decisions/message-catalog-and-escaping.md
+git diff --binary | sha256sum
+git diff --check
+```
+
+The independent precommit reviewer checks every self-test rule, frontmatter/type mapping, heading ordering, and that exactly three Decision files changed structurally with no content drift. Record digest/PASS in the ledger, then run:
+
+```bash
+git add scripts/check_knowledge.py knowledge/decisions/dashboard-operator-console-redesign.md \
+  knowledge/decisions/input-sanitizing-and-xss.md knowledge/decisions/message-catalog-and-escaping.md
+git commit -m "test(knowledge): enforce OKF schema"
+git show --check --stat --oneline HEAD
+```
+
+Expected: one bounded script-and-heading commit with no whitespace errors.
+
+- [ ] **Step 5: Conduct the SDD postcommit review**
+
+A new reviewer repeats Step 3 at the committed SHA and uses `git diff HEAD^ HEAD -- knowledge/decisions` to verify exactly three legacy exceptions were normalized. Record PASS or one repair package; repairs repeat red, green, independent review, and commit and stop at the global cap.
+
+### Task 5: Wire all three workflows to the shared classifier and preserve contexts
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml`
+- Modify: `.github/workflows/codeql.yml`
+- Modify: `.github/workflows/fuzz.yml`
+- Consume: `scripts/ci_scope.py`, `scripts/check_markdown_links.py`, `scripts/check_knowledge.py`
+
+**Outcome:** Every PR starts all required workflows; each scope job proves the classifier before classification; the existing check names remain while irrelevant jobs are terminal successful skips and classifier failure cannot authorize a skip.
+
+**Proof:** Workflow syntax parses; static contract assertions verify exact PR activities, no required workflow path filters, all required names, `always()` guards, shared classifier invocations, and all routing conditions.
+
+**Constraint:** Preserve existing actions, permissions, concurrency, job names, security hardening, and full-suite behavior. Do not duplicate classifier path lists in YAML. Remove only fuzz’s top-level PR `paths` filter.
+
+**Ponytail Rung:** 2 — modify the existing three workflows and reuse their job bodies/check names.
+
+**Interfaces:** Each scope job outputs `steps.classify.outputs` from `ci_scope.py`; downstream references use `needs.scope.outputs.<job-key>`. The exact activity list is `opened`, `synchronize`, `reopened`, `labeled`, `unlabeled`.
+
+- [ ] **Step 1: Write the workflow-contract failure script before YAML changes**
+
+Run the committed regression before changing YAML and retain its failure output in the ignored Task 5 report.
+
+```bash
+python3 scripts/ci_scope.py --check-workflows .
+test "$?" -ne 0
+```
+
+Expected: the check fails because scope jobs, the five activities, and required fail-closed guards are absent and fuzz retains its forbidden top-level filter.
+
+- [ ] **Step 2: Add the identical event plumbing and scope-job shape**
+
+Using `apply_patch`, give all three workflows the exact pull-request activity set. Each `scope` job hardens the runner and checks out with `fetch-depth: 0` and `persist-credentials: false`. Its `env:` contains `EVENT_NAME: ${{ github.event_name }}`, `BASE_SHA: ${{ github.event.pull_request.base.sha }}`, `HEAD_SHA: ${{ github.event.pull_request.head.sha }}`, `BASE_REF: ${{ github.event.pull_request.base.ref }}`, and `LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}`. For non-PR variants set `BASE_SHA: ''`, `HEAD_SHA: ${{ github.sha }}`, `BASE_REF: ''`, and `LABELS_JSON: '[]'`; expressions are only environment values, never shell source.
+
+```bash
+python3 scripts/ci_scope.py --selftest
+if [ "$EVENT_NAME" = pull_request ]; then
+  test -n "$BASE_SHA"; test -n "$HEAD_SHA"
+  git diff --name-only -z "$BASE_SHA" "$HEAD_SHA" > changed-paths.z
+  python3 scripts/ci_scope.py --event-name "$EVENT_NAME" --base-ref "$BASE_REF" \
+    --labels-json "$LABELS_JSON" --paths-file changed-paths.z --github-output "$GITHUB_OUTPUT"
+else
+  python3 scripts/ci_scope.py --event-name "$EVENT_NAME" --base-ref '' \
+    --labels-json "$LABELS_JSON" --github-output "$GITHUB_OUTPUT"
+fi
+```
+
+Expose exactly `docs,rust,presentation,dependencies,workflow,container,security,fuzz,full,stable,coverage,msrv,deny,workflow_lint,dependency_review,docker,codeql,smoke_fuzz,reason` via `jobs.scope.outputs`. Do not put a path rule in YAML.
+
+- [ ] **Step 3: Route the existing jobs with fail-closed guards**
+
+In `ci.yml`, retain `fmt, clippy, tests`; set `needs: scope`, `if: always()`, checkout `fetch-depth: 0`/credential-free, and job-local `env: EVENT_NAME: ${{ github.event_name }}, BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}, HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}, BEFORE_SHA: ${{ github.event.before || '' }}`. Its first step is `test "${{ needs.scope.result }}" = success`; exact whitespace shell is `if [ "$EVENT_NAME" = pull_request ]; then git diff --check "$BASE_SHA" "$HEAD_SHA"; elif [ -n "$BEFORE_SHA" ] && git cat-file -e "$BEFORE_SHA^{commit}" 2>/dev/null; then git diff --check "$BEFORE_SHA" "$HEAD_SHA"; else git show --check --format= --no-renames "$HEAD_SHA"; fi`. Keep summary/agent-guide/Markdown checks unconditional; use `if: ${{ needs.scope.outputs.docs == 'true' }}` for knowledge, `stable` for all stable Rust setup/build/test steps, and `presentation` for presentation steps. Set `coverage`, `msrv`, `cargo-deny`, `workflow lint`, and `docker build` to `if: ${{ needs.scope.result == 'success' && needs.scope.outputs.<exact-key> == 'true' }}`; keep gitleaks unconditional.
+
+In `codeql.yml`, keep name `codeql (rust)`, set `needs: scope` and job condition `if: always() && (needs.scope.result != 'success' || needs.scope.outputs.codeql == 'true')`; first guard is `test "${{ needs.scope.result }}" = success`, then analysis steps are `if: ${{ needs.scope.outputs.codeql == 'true' }}`. In `fuzz.yml`, delete top-level PR `paths`; `smoke fuzz` has `needs: scope` and exact job condition `if: always() && (needs.scope.result != 'success' || needs.scope.outputs.smoke_fuzz == 'true')`; its first guard fails on scope failure and every fuzz setup/run step is `if: ${{ needs.scope.outputs.smoke_fuzz == 'true' }}`. Set `dependency review` to `if: ${{ github.event_name == 'pull_request' && needs.scope.result == 'success' && needs.scope.outputs.dependency_review == 'true' }}`. Thus normal false is a terminal job skip, while scope failure is exposed.
+
+- [ ] **Step 4: Run local green, failure-path, and boundary proof**
+
+Run:
+
+```bash
+python3 scripts/ci_scope.py --selftest
+python3 scripts/check_markdown_links.py --selftest
+python3 scripts/check_knowledge.py --selftest
+python3 -m py_compile scripts/ci_scope.py scripts/check_markdown_links.py scripts/check_knowledge.py
+python3 scripts/ci_scope.py --event-name pull_request --base-ref main --labels-json '[]' --paths-file <(printf 'docs/a.md\0')
+git diff --check
+ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "parsed #{p}" }' \
+  .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml
+```
+
+Expected: all script self-tests/compilation/YAML parsing pass; the target-`main` command emits `full=true` and `reason=target-main`; `git diff --check` is silent. Then run `python3 scripts/ci_scope.py --check-workflows .`; it now exits 0 and is added to the always-on CI check job so later workflow drift is protected. Do not run cargo, render, Docker, or fuzz suites locally.
+
+- [ ] **Step 5: Freeze, independently review, and commit**
+
+Run:
+
+```bash
+git diff -- .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml
+git diff --binary | sha256sum
+git diff --check
+```
+
+The precommit reviewer checks exact names against ruleset `18516333`, all `always()` failure guards, all five pull-request activities, absent required-workflow filters, no copied path policy, preserved gitleaks, static-presentation no-Rust setup, dependency stable routing, and fuzz label override. Record digest/PASS, then run:
+
+```bash
+git add .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml
+git commit -m "ci: route validation from changed surfaces"
+git show --check --stat --oneline HEAD
+```
+
+Expected: three-workflow commit, no whitespace errors.
+
+- [ ] **Step 6: Conduct the SDD postcommit review**
+
+A new reviewer re-runs Step 4 and reviews `git show HEAD -- .github/workflows`. They must explicitly verify that a failed scope cannot produce a green required context and that a `ci:full` label will trigger a new PR event. Record PASS or one repair package; repairs follow the global two-round limit.
+
+### Task 6: Integrate, locally validate, independently review, and publish the implementation PR
+
+**Files:**
+
+- Publish: all Task 1–5 committed files
+- Modify externally: one PR into `release/v0.6.6`, its body/comments, and issue #131
+
+**Outcome:** A single implementation PR with the exact intended diff exists, links the tracking issue, carries `ci:full`, and has local proof plus an independent pre-push review recorded before live probes.
+
+**Proof:** The branch diff contains only the task outputs; all three script self-tests, compilation, known-path inventory, YAML parsing, `git diff --check`, and `cargo fmt --check` have fresh output; GitHub reads show the PR targets the integration branch and has the override label.
+
+**Constraint:** Do not run expensive Rust tests, render, Docker, coverage, CodeQL, or fuzz locally. Do not merge or claim a label-triggered run proves the final head yet.
+
+**Ponytail Rung:** 2 — use existing Git/GitHub PR workflow and test strategy.
+
+**Interfaces:** Consumes Task 1–5 reviewed commits. Produces `${ci_routing_pr_url}`, branch `work/v0.6.6-phase0-ci-routing`, and an issue/PR evidence location used by Tasks 7–9.
+
+- [ ] **Step 1: Prove the complete local boundary and pre-push checks**
+
+Run:
+
+```bash
+git diff --name-only 6b6fde466bc28e5b2e9bca14be8eb43212c39160..HEAD
+python3 scripts/ci_scope.py --selftest
+python3 scripts/check_markdown_links.py --selftest
+python3 scripts/check_knowledge.py --selftest
+python3 -m py_compile scripts/ci_scope.py scripts/check_markdown_links.py scripts/check_knowledge.py
+python3 scripts/ci_scope.py --event-name pull_request --base-ref release/v0.6.6 \
+  --labels-json '[]' --paths-file <(git diff --name-only -z 6b6fde466bc28e5b2e9bca14be8eb43212c39160..HEAD) --assert-known
+ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p) }' \
+  .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml
+git diff --check 6b6fde466bc28e5b2e9bca14be8eb43212c39160..HEAD
+cargo fmt --check
+```
+
+Expected: exact paths are `docs/superpowers/specs/2026-08-08-v0.6.6-change-aware-ci-design.md` at approved commit `e1f67ca`, this already-reviewed plan, the three scripts, three Decision pages, and three workflows only; all named proof passes. The required red paths remain in each script’s self-test transcript. Record skipped expensive local checks explicitly in `progress.md`.
+
+- [ ] **Step 2: Freeze and independently review the full pre-push diff**
+
+Run:
+
+```bash
+git diff --binary 6b6fde466bc28e5b2e9bca14be8eb43212c39160..HEAD | sha256sum
+git log --oneline 6b6fde466bc28e5b2e9bca14be8eb43212c39160..HEAD
+```
+
+A fresh precommit reviewer checks all Task 1–5 contracts together: no unclassified tracked file, no routing policy in YAML, preserved names/ruleset contexts, exact three knowledge pages, every failure self-test, no workflow-level required PR filter, and no excluded scope. Record digest/PASS in the ledger. Any rejection requires a bounded repair package, then repeats Task-specific review and this review; stop after repair round 2.
+
+- [ ] **Step 3: Freeze the reviewed candidate SHA and push it unchanged**
+
+Run:
+
+```bash
+prepush_sha=$(git rev-parse HEAD)
+test -n "$prepush_sha"
+git push -u origin work/v0.6.6-phase0-ci-routing
+test "$(git rev-parse HEAD)" = "$prepush_sha"
+test "$(git ls-remote origin refs/heads/work/v0.6.6-phase0-ci-routing | cut -f1)" = "$prepush_sha"
+```
+
+Expected: no plan mutation occurs; the remote branch equals `prepush_sha`. This SHA is not the final-reviewed SHA because Tasks 7–8 add then remove the probe.
+
+- [ ] **Step 4: Open the implementation PR and immediately apply the label**
+
+Run:
+
+```bash
+ci_routing_issue_number=$(gh issue list --repo miztertea/nim-proxy --state open \
+  --search '"v0.6.6 Phase 0: change-aware CI routing" in:title' --json number,title \
+  --jq '.[] | select(.title == "v0.6.6 Phase 0: change-aware CI routing") | .number')
+test "$ci_routing_issue_number" -gt 0
+ci_routing_pr_url=$(gh pr create --repo miztertea/nim-proxy \
+  --base release/v0.6.6 --head work/v0.6.6-phase0-ci-routing \
+  --title "ci: route v0.6.6 validation from changed surfaces" \
+  --body "## Outcome
+
+Implements the approved fail-closed change-aware CI classifier and documentation proof.
+
+## Proof
+
+- Three standard-library scripts each have observed negative self-tests.
+- CI, CodeQL, and fuzz consume the one classifier and retain existing contexts.
+- Live probe commits will prove selected skips and classifier-failure propagation.
+- Final reviewed head will receive a ci:full twelve-check gate.
+
+## Constraint
+
+No required context name changes; no workflow-level PR path filters; temporary probe never merges.
+
+## Ponytail Rung
+
+Reuse existing workflows/scripts/testing conventions; only the three approved stdlib scripts are new.
+
+Tracks #${ci_routing_issue_number}
+Parent: #131")
+gh pr edit "$ci_routing_pr_url" --repo miztertea/nim-proxy --add-label ci:full
+gh pr view "$ci_routing_pr_url" --repo miztertea/nim-proxy \
+  --json url,baseRefName,headRefName,labels,state
+```
+
+Expected: a non-draft PR targets `release/v0.6.6`, has the exact head branch and `ci:full`, and begins an initial full run. This run may be cancelled by later commits and is not final proof.
+
+- [ ] **Step 5: Conduct the SDD postcommit/post-push review**
+
+A fresh reviewer compares `gh pr diff "$ci_routing_pr_url"` with the frozen digest and local proof, confirms the label event exists, and records PASS or one repair package in the ledger/PR comment. The reviewer must state that Task 7 is the next authorized mutation and that no merge is authorized.
+
+### Task 7: Add and prove the reviewed temporary live-routing probe
+
+**Files:**
+
+- Create temporarily: `.github/workflows/ci-routing-probe.yml`
+- Modify externally: PR and issue evidence only
+
+**Outcome:** The real committed classifier proves both selected/skipped routing and fail-closed dependency behavior in GitHub Actions before its temporary workflow is removed.
+
+**Proof:** Exactly one retained failing probe-run URL shows synthetic docs selection/Rust skip plus malformed classifier failure/`if: always()` guard failure; exactly three concurrent production-run URLs reach terminal success.
+
+**Constraint:** The probe calls the committed `scripts/ci_scope.py`; it must not duplicate classifier logic, mutate production workflows, or remain in the final tree.
+
+**Ponytail Rung:** 2 — one temporary native Actions workflow is the smallest real-environment proof.
+
+**Interfaces:** The temporary workflow triggers only on `pull_request: { types: [synchronize] }`; its single run contains `docs-scope`, `docs-selected`, `rust-skipped`, `malformed-scope`, and `failure-guard`. It invokes the committed classifier twice with synthetic NUL files, never dispatches manually, and need not exist on the default branch.
+
+- [ ] **Step 1: Create the red probe contract**
+
+Before adding the file, run a local assertion that `.github/workflows/ci-routing-probe.yml` is absent and record its nonzero result. Create a `pull_request` `synchronize` workflow with full-history, credential-free checkout. `docs-scope` writes `printf 'docs/synthetic.md\0' > paths.z`, calls the committed classifier with `[]`, and exports outputs; `docs-selected` asserts `docs=true`; `rust-skipped` uses the false `rust` output. Independently, `malformed-scope` writes the same path then calls the real classifier with `{bad json}` and must fail; `failure-guard` has `if: always()` and explicitly fails when `needs.malformed-scope.result != 'success'`.
+
+Use no secrets and write each classifier JSON/result to the workflow summary.
+
+- [ ] **Step 2: Run local syntax plus explicit green/failure evidence**
+
+Run:
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci-routing-probe.yml")'
+python3 scripts/ci_scope.py --event-name pull_request --base-ref release/v0.6.6 \
+  --labels-json '[]' --paths-file <(printf 'docs/synthetic.md\0')
+python3 scripts/ci_scope.py --event-name pull_request --base-ref release/v0.6.6 \
+  --labels-json '{bad json}' --paths-file <(printf 'docs/synthetic.md\0'); test "$?" -ne 0
+git diff --check
+cargo fmt --check
+```
+
+Expected: YAML/docs classification pass, malformed labels exit nonzero, diff/format checks pass; expensive suites remain skipped and recorded.
+
+- [ ] **Step 3: Freeze, independently review, commit, and push the probe**
+
+Run:
+
+```bash
+git diff --binary | sha256sum
+git diff --check
+git add .github/workflows/ci-routing-probe.yml
+git commit -m "test(ci): add temporary routing probe"
+git show --check --stat --oneline HEAD
+```
+
+Before committing, an independent reviewer verifies only the probe changed, real classifier use, both cases’ expected terminal states, no credential persistence, and no production-path change. Record digest/PASS in the separate reviewer report and `progress.md`. A fresh SDD postcommit reviewer confirms the pushed SHA and authorizes probe observation only on PASS.
+
+- [ ] **Step 4: Observe one real PR-event probe run and concurrent production runs**
+
+Run:
+
+```bash
+set -euo pipefail
+probe_started_at=$(date -u +%FT%TZ)
+probe_sha=$(git rev-parse HEAD)
+git push
+for attempt in $(seq 1 20); do
+  probe_runs=$(gh api "/repos/miztertea/nim-proxy/actions/runs?event=pull_request&head_sha=$probe_sha")
+  probe_run=$(jq --arg after "$probe_started_at" '.workflow_runs | map(select(.path == ".github/workflows/ci-routing-probe.yml" and .created_at >= $after)) | sort_by(.created_at) | last' <<<"$probe_runs")
+  probe_run_id=$(jq -r '.id // empty' <<<"$probe_run")
+  test -n "$probe_run_id" && break; sleep 15
+done
+test -n "$probe_run_id"
+test "$(jq -r .head_sha <<<"$probe_run")" = "$probe_sha"
+gh run watch "$probe_run_id" --repo miztertea/nim-proxy || test "$?" -ne 0
+probe_view=$(gh run view "$probe_run_id" --repo miztertea/nim-proxy --json url,conclusion,jobs,headSha,createdAt)
+test "$(jq -r .conclusion <<<"$probe_view")" = failure
+jq -e '.jobs[] | select(.name == "docs-selected" and .conclusion == "success")' <<<"$probe_view"
+jq -e '.jobs[] | select(.name == "rust-skipped" and .conclusion == "skipped")' <<<"$probe_view"
+jq -e '.jobs[] | select(.name == "malformed-scope" and .conclusion == "failure")' <<<"$probe_view"
+jq -e '.jobs[] | select(.name == "failure-guard" and .conclusion == "failure")' <<<"$probe_view"
+declare -A production_ids
+for attempt in $(seq 1 20); do
+  runs=$(gh api "/repos/miztertea/nim-proxy/actions/runs?event=pull_request&head_sha=$probe_sha")
+  for path in .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml; do
+    production_ids[$path]=$(jq -r --arg path "$path" --arg after "$probe_started_at" '.workflow_runs | map(select(.path == $path and .created_at >= $after)) | sort_by(.created_at) | last.id // empty' <<<"$runs")
+  done
+  [ -n "${production_ids[.github/workflows/ci.yml]}" ] && [ -n "${production_ids[.github/workflows/codeql.yml]}" ] && [ -n "${production_ids[.github/workflows/fuzz.yml]}" ] && break; sleep 15
+done
+for path in .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml; do
+  id=${production_ids[$path]}; test -n "$id"; gh run watch "$id" --repo miztertea/nim-proxy
+  view=$(gh run view "$id" --repo miztertea/nim-proxy --json url,conclusion,jobs,headSha,createdAt)
+  test "$(jq -r .headSha <<<"$view")" = "$probe_sha"; test "$(jq -r .conclusion <<<"$view")" = success
+  jq -e '.jobs[] | select(.name == "scope" and .conclusion == "success")' <<<"$view"
+done
+```
+
+Expected: the exact post-push PR-event run has `headSha=$probe_sha`, docs-selected succeeds, rust-skipped is terminal successful skip, malformed-scope fails, and the always-guard fails. Capture production CI/CodeQL/fuzz runs from the same synchronize event separately by `headSha=$probe_sha` and `createdAt >= $probe_started_at`; all their contexts must be terminal. Do not rerun merely for green; classify every unexpected result and increment the one global repair counter before a new synchronize commit.
+
+- [ ] **Step 5: Record probe evidence and postcommit review**
+
+Post the one probe URL and exactly three production URLs, job conclusions, and scope outcomes to the PR and #131. A fresh reviewer checks every production run is terminal, the probe used the committed classifier, and malformed routing could not skip the guard. Record PASS or a bounded repair package; Task 8 is authorized only after PASS.
+
+### Task 8: Remove the temporary probe, independently review, and restore the final tree
+
+**Files:**
+
+- Delete: `.github/workflows/ci-routing-probe.yml`
+- Modify externally: PR evidence only
+
+**Outcome:** The final PR tree excludes the temporary probe while preserving its already-recorded run URLs and outcomes.
+
+**Proof:** The deletion is first observed as a red absence-required test after the probe commit, then committed; `git diff` against the final head has no probe path and all local low-cost checks pass.
+
+**Constraint:** Do not alter the three production workflows or rewrite/delete GitHub run evidence.
+
+**Ponytail Rung:** 2 — a separate small deletion commit preserves probe history without shipping test machinery.
+
+**Interfaces:** Consumes Task 7 PASS/run URLs. Produces final candidate head without `.github/workflows/ci-routing-probe.yml`.
+
+- [ ] **Step 1: Prove the removal target and perform the deliberate deletion**
+
+Run `test -f .github/workflows/ci-routing-probe.yml` and record success as the precondition. Use `apply_patch` to delete exactly that file. Then run:
+
+```bash
+test ! -e .github/workflows/ci-routing-probe.yml
+git diff --name-status
+```
+
+Expected: the first assertion proves the probe exists; after deletion only `D .github/workflows/ci-routing-probe.yml` (plus ledger evidence) appears. If another path changes, stop.
+
+- [ ] **Step 2: Run red/green boundary checks**
+
+Run:
+
+```bash
+ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p) }' \
+  .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml
+python3 scripts/ci_scope.py --selftest
+python3 scripts/check_markdown_links.py --selftest
+python3 scripts/check_knowledge.py --selftest
+git diff --check
+cargo fmt --check
+```
+
+Expected: production YAML and low-cost checks pass; the absent-probe assertion is green. Record intentionally skipped expensive suites.
+
+- [ ] **Step 3: Independently review, commit, push, and postcommit review**
+
+Freeze with `git diff --binary | sha256sum`; an independent precommit reviewer verifies the deletion is exact, probe URLs remain in PR/#131 evidence, and production routing is unchanged. On PASS run:
+
+```bash
+git add -u .github/workflows/ci-routing-probe.yml
+git commit -m "test(ci): remove temporary routing probe"
+git show --check --stat --oneline HEAD
+git push
+```
+
+Expected: no probe file is in HEAD. A fresh SDD postcommit reviewer checks the pushed SHA, removal-only boundary, and evidence links; record PASS or a bounded repair. Stop after global repair round 2.
+
+### Task 9: Run `ci:full`, merge with reviewed-head protection, and close the work item
+
+**Files:**
+
+- Modify externally: implementation PR, tracking issue, and #131
+- Read: final branch and Actions evidence
+
+**Outcome:** The final reviewed probe-free head receives an authoritative `ci:full` full gate, then merges safely into `release/v0.6.6`; the work item and umbrella record durable evidence.
+
+**Proof:** GitHub reports all twelve expected full-gate checks green on the stored final-reviewed SHA, local/remote/PR/run heads equal that SHA, guarded merge succeeds, and it is an ancestor of the integration branch.
+
+**Constraint:** Do not merge #72, target `main`, rerun an unexplained failure, or substitute a stale/local SHA for the reviewed PR head. Natural-path observation is explicitly supplementary.
+
+**Ponytail Rung:** 2 — use existing GitHub checks, PR state, and guarded native merge behavior.
+
+**Interfaces:** Consumes Task 8 PASS, `${ci_routing_pr_url}`, and final probe-free branch head. Produces a merged PR URL, merge commit, closed tracking issue, and #131 evidence comment.
+
+**Commit message:** No new local implementation commit is authorized in this merge-only task; the reviewed candidate history is frozen. The GitHub merge command below is the sole integration mutation and must be guarded by `--match-head-commit`.
+
+- [ ] **Step 1: Freeze final candidate and independently review before the full gate**
+
+Run:
+
+```bash
+git fetch origin --prune
+git status --short --branch
+test ! -e .github/workflows/ci-routing-probe.yml
+git diff --check origin/release/v0.6.6...HEAD
+cargo fmt --check
+git diff --binary origin/release/v0.6.6...HEAD | sha256sum
+```
+
+After the independent reviewer PASSes this exact head, set `final_reviewed_sha=$(git rev-parse HEAD)`, confirm the remote branch equals it (push once only if it does not), then use `apply_patch` to insert the literal `final_reviewed_sha: <40-character SHA>` in `progress.md` and the reviewer report. Expected: clean final tree with no plan mutation, no probe file, and no whitespace or format error. Any repair invalidates review and re-enters the one global two-round loop.
+
+- [ ] **Step 2: Apply `ci:full` to the final reviewed head and observe all twelve checks**
+
+Run:
+
+```bash
+set -euo pipefail
+plan=docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md
+sdd_skill=/home/tchawes/.codex/plugins/cache/openai-curated-remote/superpowers/6.2.0/skills/subagent-driven-development
+workspace=$("$sdd_skill/scripts/sdd-workspace" "$plan")
+ci_routing_pr_url=$(gh pr list --repo miztertea/nim-proxy --state open \
+  --base release/v0.6.6 --head work/v0.6.6-phase0-ci-routing --json url --jq '.[0].url')
+test -n "$ci_routing_pr_url"
+reviewed_sha=$(rg '^final_reviewed_sha: ' "$workspace/progress.md" | cut -d' ' -f2)
+run_for_path_after() {
+  local path=$1 after=$2 runs
+  runs=$(gh api "/repos/miztertea/nim-proxy/actions/runs?event=pull_request&head_sha=$reviewed_sha")
+  jq -c --arg path "$path" --arg after "$after" '.workflow_runs | map(select(.path == $path and .created_at >= $after)) | sort_by(.created_at) | last // empty' <<<"$runs"
+}
+paths=(.github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/fuzz.yml)
+pre_toggle_checks=$(gh pr checks "$ci_routing_pr_url" --repo miztertea/nim-proxy --json name,state,bucket,link)
+unlabeled_after=$(date -u +%FT%TZ)
+gh pr edit "$ci_routing_pr_url" --repo miztertea/nim-proxy --remove-label ci:full
+declare -A unlabeled_ids labeled_ids
+for attempt in $(seq 1 20); do
+  ready=1; for path in "${paths[@]}"; do
+    run=$(run_for_path_after "$path" "$unlabeled_after"); unlabeled_ids[$path]=$(jq -r '.id // empty' <<<"$run"); test -n "${unlabeled_ids[$path]}" || ready=0
+  done; [ "$ready" = 1 ] && break; sleep 15; done
+test "$ready" = 1
+labeled_after=$(date -u +%FT%TZ)
+gh pr edit "$ci_routing_pr_url" --repo miztertea/nim-proxy --add-label ci:full
+for attempt in $(seq 1 20); do
+  ready=1; for path in "${paths[@]}"; do
+    run=$(run_for_path_after "$path" "$labeled_after"); labeled_ids[$path]=$(jq -r '.id // empty' <<<"$run"); test -n "${labeled_ids[$path]}" || ready=0
+  done; [ "$ready" = 1 ] && break; sleep 15; done
+test "$ready" = 1
+for path in "${paths[@]}"; do
+  test "${labeled_ids[$path]}" != "${unlabeled_ids[$path]}"; gh run watch "${labeled_ids[$path]}" --repo miztertea/nim-proxy
+  view=$(gh run view "${labeled_ids[$path]}" --repo miztertea/nim-proxy --json url,conclusion,jobs,headSha,createdAt)
+  test "$(jq -r .headSha <<<"$view")" = "$reviewed_sha"; test "$(jq -r .conclusion <<<"$view")" = success
+  jq -e '.jobs[] | select(.name == "scope" and .conclusion == "success")' <<<"$view"
+done
+# Use apply_patch to store pre_toggle_checks, unlabeled_ids, labeled_ids, and their URLs in the ignored report.
+```
+
+Expected: use `apply_patch` to retain `pre_toggle_checks`, three distinct unlabeled IDs, three distinct labeled IDs, URLs, head SHAs, and scope conclusions in the ignored report. All labeled IDs differ from their unlabeled counterpart and all twelve historical checks are terminal green: `fmt, clippy, tests`, `coverage`, `msrv`, `cargo-deny`, `gitleaks`, `workflow lint`, `zizmor`, `dependency review`, `docker build`, `CodeQL`, `codeql (rust)`, and `smoke fuzz`. After exact labeled runs complete, record `gh pr checks "$ci_routing_pr_url" --json name,state,bucket,link` for those contexts and compare durations to PR #163’s approximately 28 runner-minute baseline. For any failure, inspect logs, classify introduced/baseline/flaky/infrastructure, and create one repair package; never rerun blindly.
+
+- [ ] **Step 3: Fresh-shell guarded merge with reviewed-head equality**
+
+From a fresh shell in the task worktree, run exactly:
+
+```bash
+plan=docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md
+sdd_skill=/home/tchawes/.codex/plugins/cache/openai-curated-remote/superpowers/6.2.0/skills/subagent-driven-development
+workspace=$("$sdd_skill/scripts/sdd-workspace" "$plan")
+git fetch origin --prune
+reviewed_sha=$(rg '^final_reviewed_sha: ' "$workspace/progress.md" | cut -d' ' -f2)
+test "${#reviewed_sha}" -eq 40
+ci_routing_pr_url=$(gh pr list --repo miztertea/nim-proxy --state open \
+  --base release/v0.6.6 --head work/v0.6.6-phase0-ci-routing --json url --jq '.[0].url')
+pr_head=$(gh pr view "$ci_routing_pr_url" --repo miztertea/nim-proxy --json headRefOid --jq .headRefOid)
+remote_head=$(git ls-remote origin refs/heads/work/v0.6.6-phase0-ci-routing | cut -f1)
+test "$(git rev-parse HEAD)" = "$reviewed_sha"
+test "$remote_head" = "$reviewed_sha"
+test "$pr_head" = "$reviewed_sha"
+gh pr view "$ci_routing_pr_url" --repo miztertea/nim-proxy --json mergeStateStatus,isDraft,state
+gh pr merge "$ci_routing_pr_url" --repo miztertea/nim-proxy --merge --match-head-commit "$reviewed_sha"
+git fetch origin --prune
+git merge-base --is-ancestor "$reviewed_sha" origin/release/v0.6.6
+gh pr view "$ci_routing_pr_url" --repo miztertea/nim-proxy --json state,mergedAt,mergeCommit,url
+```
+
+Expected: local HEAD, remote branch, PR head, every authoritative CI/CodeQL/Fuzz run head SHA, and `--match-head-commit "$reviewed_sha"` all equal the literal reviewed SHA from the ignored report. The PR is `OPEN`, non-draft, and `CLEAN`; zero approvals are expected under ruleset `18516333`. Final view is `MERGED` and the reviewed head is integrated. If any assertion fails, do not merge—record current state in the ignored report and return to review.
+
+- [ ] **Step 4: Conduct the final SDD postmerge review before closure**
+
+A fresh reviewer reads the merged PR, final Actions JSON, ignored reviewer report, and `git merge-base` result. They verify no probe file merged, protected SHA equality, and fresh results. Record PASS or owner-visible discrepancy in `progress.md`; do not close either issue until PASS.
+
+- [ ] **Step 5: Close/update only after postmerge PASS**
+
+Run:
+
+```bash
+ci_routing_issue_number=$(gh issue list --repo miztertea/nim-proxy --state open \
+  --search '"v0.6.6 Phase 0: change-aware CI routing" in:title' --json number,title \
+  --jq '.[] | select(.title == "v0.6.6 Phase 0: change-aware CI routing") | .number')
+test "$ci_routing_issue_number" -gt 0
+gh issue close "$ci_routing_issue_number" --repo miztertea/nim-proxy \
+  --comment "Resolved by ${ci_routing_pr_url}; selected/skipped and malformed-classifier probes passed, final ci:full passed, and the reviewed head merged into release/v0.6.6."
+gh issue comment 131 --repo miztertea/nim-proxy \
+  --body "Phase 0 change-aware CI routing complete: ${ci_routing_pr_url}. Evidence includes probe runs, final twelve-check ci:full run, merge commit, and PR #163’s approximately 28 runner-minute baseline. Natural-path timing is supplementary only."
+```
+
+Expected: the tracking issue is closed and #131 is updated but never closed. Report fresh check conclusions/durations, global repair count, scope deltas, merge SHA, and the supplementary observation rule.
+
+## Plan self-review
+
+- Coverage: Tasks 1–9 implement the required issue/label, task packages, three scripts, three-workflow wiring, temporary probe add/run/removal, final `ci:full`, guarded merge, tracking-issue closure with #131 update, and supplementary natural-path observation rule.
+- Failure paths: every implementation task starts with an executable negative/self-test case and records the required green proof; GitHub failures are classified before a bounded repair, never blindly retried.
+- Review gates: every mutating repository task names a frozen-diff independent precommit review, commit message, and fresh SDD postcommit review; external-only/merge-only tasks state that no local commit is authorized. All repair sources share the ignored ledger’s two-round cap.
+- Contract consistency: output names, full reasons, check names, event activities, integration base, issue/branch names, stored final-reviewed SHA equality, and guarded merge match the approved design.
+- Placeholder scan: run `! rg -n '^(TBD|TODO|implement later|fill in details|_Task package|_Complete only)' docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md`; expected no matches and exit status 0.
+- Structural proof: run `git diff --check -- docs/superpowers/plans/2026-08-08-v0.6.6-change-aware-ci.md`; expected no output.
+
+## Execution handoff
+
+Execute only through `superpowers:subagent-driven-development`, one sequential task package at a time, preserving the ledger and the two-repair-round cap. The manager must stop with fresh evidence on an ambiguity, scope delta, non-determinable fact, failed proof, or exhausted repair budget.

--- a/docs/superpowers/specs/2026-08-08-v0.6.6-change-aware-ci-design.md
+++ b/docs/superpowers/specs/2026-08-08-v0.6.6-change-aware-ci-design.md
@@ -1,354 +1,320 @@
 # v0.6.6 Change-Aware CI Design
 
-**Status:** Derived from the approved v0.6.6 remediation program design
+**Status:** Approved architecture revision; supersedes the existing change-aware CI implementation plan
 **Date:** 2026-08-08
 **Integration branch:** `release/v0.6.6`
 **Parent issue:** [#131](https://github.com/miztertea/nim-proxy/issues/131)
 
 ## Purpose
 
-Route pull-request validation from the files and risk surfaces that changed so
-ordinary remediation PRs do not pay for unrelated ten-minute rendering,
-fuzzing, container, coverage, and compatibility gates. The complete release
-suite remains mandatory at workstream boundaries, for security-sensitive or
-unknown changes, for PRs targeting `main`, and for non-PR release evidence.
+Reduce pull-request runner time by routing only the existing expensive CI work
+that a changed surface can invalidate. This is a remediation to the current
+workflows, not a new validation subsystem. Required check names, security
+checks, release-gate strength, and the repository's existing proof commands
+remain intact.
 
-The baseline reconciliation PR demonstrated the current cost: its twelve
-checks consumed about 28 runner-minutes, with `fmt, clippy, tests` taking
-10m37s, smoke fuzz 6m02s, Docker 5m12s, CodeQL 2m08s, and coverage 1m55s.
-No check failed or retried. This design removes unnecessary jobs rather than
-weakening their assertions.
+**Ponytail Rung 1:** custom classifiers, parsers, Markdown checkers, knowledge
+checkers, workflow-policy engines, and temporary probe workflows do not need to
+exist. The current implementation plan specifies those artifacts and must not
+be executed; it is superseded and needs replacement after this spec is
+approved.
 
-## Fixed decisions
+## Current evidence
 
-- Every required workflow starts on every pull request. Do not use
-  workflow-level path filters for required checks.
-- A skipped job reports success and may satisfy a required context; a skipped
-  required workflow can remain pending.
-- The existing required check names remain unchanged.
-- One standard-library classifier is the single source of path and risk
-  policy for CI, CodeQL, and fuzz workflows.
-- Every scope job runs the classifier self-test before classifying the live
-  event. A broken classifier or a change to its own policy therefore cannot
-  authorize a reduced run.
-- Unknown paths, classifier errors, security-sensitive changes, workflow
-  changes, `ci:full`, PRs targeting `main`, and non-PR events fail or route to
-  the complete suite.
-- Secret scanning remains always on.
-- Full validation runs on the last PR in every remediation workstream, #153,
-  and PR #72.
-- This subproject receives one issue and one PR into `release/v0.6.6`.
+PR #163 supplies the measured baseline. A fresh read of its completed checks
+shows approximately 28 runner-minutes with no retries: `fmt, clippy, tests`
+took 10m37s, `docker build` 5m12s, `smoke fuzz` 6m02s, `codeql (rust)` 2m08s,
+and `coverage` 1m55s. `msrv` and `cargo-deny` each took 46s; gitleaks,
+dependency review, workflow lint, and the platform summaries were smaller.
 
-GitHub documents that job-level conditional skips report success, while
-workflow-level path skips can leave required contexts pending. It also warns
-that jobs depending on a failed job need `always()` when they are required:
+The active `main` ruleset requires these nine contexts, unchanged:
 
-- <https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-jobs-with-conditions>
-- <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks>
+- `fmt, clippy, tests`
+- `coverage`
+- `msrv`
+- `cargo-deny`
+- `gitleaks`
+- `workflow lint`
+- `dependency review`
+- `docker build`
+- `codeql (rust)`
 
-## Components
+The repository already has the validation bricks this change needs:
 
-### `scripts/ci_scope.py`
+- `check_agent_guide.py` for the agent contract;
+- actionlint, zizmor, the release-contract check, and the Cosign smoke test in
+  `workflow lint`;
+- gitleaks, cargo-deny, dependency review, and CodeQL security gates;
+- the existing stable Rust, coverage, MSRV, presentation, and Docker proofs;
+- fuzz's native pull-request `paths` filter plus schedule and manual dispatch.
 
-This Python-standard-library script owns classification. Workflow YAML owns
-only event plumbing and job conditions; it does not reproduce path lists.
+**Ponytail Rung 2:** retain and route these existing checks. Do not duplicate
+or generalize them.
 
-The script accepts:
+## One routing brick
 
-- `--event-name`: GitHub event name.
-- `--base-ref`: pull-request base branch name, empty for other events.
-- `--labels-json`: JSON array of pull-request label names.
-- `--paths-file`: a required, readable NUL-delimited changed-path file for a
-  pull-request event. Non-PR events ignore this option and always run full.
-- `--github-output`: append deterministic `name=true|false` outputs to the
-  named GitHub output file. Without it, print the result as sorted JSON.
-- `--assert-known`: fail when any supplied path has no explicit classification
-  rule; used against the tracked repository inventory during development.
-- `--selftest`: run the committed positive, negative, overlap, and fail-closed
-  fixtures.
+Only `.github/workflows/ci.yml` receives routing. Add one `changes` job with
+the repository's existing harden-runner convention and a single invocation of:
 
-Its pure interface is:
-
-```python
-@dataclass(frozen=True)
-class Scope:
-    docs: bool
-    rust: bool
-    presentation: bool
-    dependencies: bool
-    workflow: bool
-    container: bool
-    security: bool
-    fuzz: bool
-    full: bool
-    reason: str
-
-
-def classify(
-    paths: tuple[str, ...],
-    *,
-    event_name: str,
-    base_ref: str,
-    labels: tuple[str, ...],
-) -> Scope:
-    ...
-
-
-def job_outputs(scope: Scope) -> dict[str, bool]:
-    ...
+```yaml
+uses: step-security/paths-filter@9098a7821b83402dbe267c0c801e7d580ce74f92 # v4.0.2
 ```
 
-The script emits these exact Boolean outputs, all as lowercase `true` or
-`false`: the nine surface outputs `docs`, `rust`, `presentation`,
-`dependencies`, `workflow`, `container`, `security`, `fuzz`, and `full`; and
-the nine job outputs `stable`, `coverage`, `msrv`, `deny`, `workflow_lint`,
-`dependency_review`, `docker`, `codeql`, and `smoke_fuzz`. It also emits the
-closed string output `reason`.
+The action's filters are inline YAML in `ci.yml`; there is no classifier script
+or second policy file. On pull requests the action uses GitHub's changed-file
+API and therefore the job receives only `pull-requests: read` in addition to
+the repository's read-only default. The action step runs only for pull-request
+events; the current `main` push remains an unconditional full run.
 
-`job_outputs` is a deterministic union:
+The CI pull-request activity list becomes `opened`, `synchronize`, `reopened`,
+`labeled`, and `unlabeled` so the existing `ci:full` override can trigger a new
+CI run. No workflow-level `paths` filter is added to a required workflow.
 
-| Output | True when |
+**Ponytail Rung 7:** Rungs 1–6 do not provide job-level changed-file outputs.
+The maintained, SHA-pinned action is the minimum new machinery. Its v4.0.2
+action contract provides Boolean outputs per declarative filter and runs on
+Node 24; the repository does not recreate either behavior.
+
+## Fail-closed filter shape
+
+Filters answer whether each expensive group must run; they do not try to build
+a general repository taxonomy. Each expensive filter is expressed as `**`
+minus the explicitly known path families that are safe to omit for that group,
+using the action's `predicate-quantifier: every` behavior. Consequently:
+
+- a known low-risk path may exclude an unrelated expensive group;
+- a mixed PR takes the union of every changed path's requirements; and
+- a new or unclassified path matches no safe exclusion and selects every
+  expensive group.
+
+Workflow-policy paths and the security-sensitive Rust paths listed below are
+never in a safe exclusion. They therefore select the complete CI gate without
+custom “unknown” or “security” code.
+
+Security-sensitive paths are `src/api.rs`, `src/auth.rs`, `src/config.rs`,
+`src/main.rs`, `src/proxy.rs`, `src/routes.rs`, and `src/settings.rs`.
+Workflow-policy paths include `.github/workflows/**`, `.github/codeql/**`,
+`.github/release.yml`, and `scripts/test_release_contract.py`. Changes to the
+routing configuration itself are workflow-policy changes and therefore run
+full.
+
+The metadata override is native workflow logic. Every expensive condition is
+true when the event is not a pull request, the PR targets `main`, or the PR has
+the exact `ci:full` label, regardless of path outputs.
+
+**Ponytail Rung 4:** GitHub Actions expressions, job outputs, `needs`, and
+step/job conditions already provide union and override behavior. Unknown paths
+fail closed by exclusion design rather than a parser or policy engine.
+
+## Routing matrix
+
+| Changed surface | Existing work selected |
 | --- | --- |
-| `stable` | Rust behavior, dependency metadata, or full |
-| `coverage` | Rust behavior or full |
-| `msrv` | Rust behavior, dependency metadata, or full |
-| `deny` | Dependency metadata or full |
-| `workflow_lint` | Workflow policy or full |
-| `dependency_review` | Dependency metadata, workflow policy, or full |
-| `docker` | Container/runtime packaging, dependency metadata, or full |
-| `codeql` | Rust behavior or full |
-| `smoke_fuzz` | Fuzz surface or full |
+| Documentation and knowledge (`**/*.md`, `docs/**`, `knowledge/**`, issue/PR templates, `CODEOWNERS`, agent-guide checker) | Required `fmt, clippy, tests` context runs its lightweight always group only |
+| Rust behavior (`src/**` other than static `src/web/**`, Rust tests, OpenAPI, Rust-owned fixtures) | Stable group, coverage, MSRV, Docker |
+| Presentation and i18n (`src/web/**`, `src/presentation.rs`, presentation scripts and fixtures) | Presentation group; `src/presentation.rs` also selects the stable group because it is Rust |
+| Dependency and toolchain metadata (`Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`) | Stable group, MSRV, Docker; always-on cargo-deny remains authoritative |
+| Dependency policy (`deny.toml`, Dependabot configuration) | Always-on cargo-deny and dependency review; workflow/security or unknown overlap still promotes to full |
+| Container/runtime packaging (`Dockerfile`, `.dockerignore`, `docker-compose*.yml`) | Docker |
+| Workflow policy, security-sensitive paths, unknown paths | Complete CI gate |
+| `ci:full`, a PR targeting `main`, or any non-PR CI event | Complete CI gate |
 
-Full-scope reason precedence is exact and first-match wins: `non-pr`,
-`target-main`, `full-label`, `workflow-policy`, `security-path`,
-`unknown-path`, `empty-diff`, then `routed`. Label JSON must decode to an array
-containing only strings; any other shape exits nonzero. Pull-request
-classification requires `--paths-file`; a missing or unreadable file exits
-nonzero. Each NUL-delimited path must be valid UTF-8 and a canonical relative
-POSIX Git path: nonempty, no leading or trailing slash, no backslash, and no
-`.` or `..` component. Malformed paths exit nonzero. Duplicate paths are
-deduplicated and sorted before classification. An empty valid file and
-well-formed unknown paths do not error; they select full scope with
-`empty-diff` or `unknown-path` respectively. Non-PR events select full without
-reading path or label inputs.
+Overlaps are deliberate. A presentation fixture plus Rust handler change runs
+both check groups and all Rust-relevant jobs. A documentation file plus an
+unknown new path runs full.
 
-### `scripts/check_markdown_links.py`
+**Ponytail Rung 2:** these surfaces come directly from the paths consumed by
+the existing checks. The matrix changes when an existing check's real input
+boundary changes, not when a new abstract category seems useful.
 
-This standard-library checker gives documentation-only PRs meaningful proof.
-It scans tracked Markdown files, resolves repository-local Markdown links,
-rejects paths escaping the repository, and fails when a local target is
-absent. For a raw link it first splits the literal fragment marker `#`, then
-the literal query marker `?`, and only then percent-decodes the remaining path.
-Thus encoded `%23` and `%3F` remain filename characters while an ordinary
-query is ignored. It ignores external schemes and does not validate anchors.
+## The required `fmt, clippy, tests` context
 
-The checker supports `--selftest`. Fixtures prove a valid link, an encoded
-space, encoded `#`, encoded `?`, an ordinary query, a missing target,
-repository escape, external URL, and fragment-only link.
+The current `check` job keeps its id and display name. It gains `needs:
+changes` and `if: always()` so it is still created when routing fails. Its
+first executable guard after harden-runner requires
+`needs.changes.result == 'success'`; failure makes `fmt, clippy, tests` red and
+blocks merge. A routing failure can never become a successful skip.
 
-### `scripts/check_knowledge.py`
+The existing steps are grouped only by conditions:
 
-This standard-library checker enforces the committed schema contract on every
-tracked `knowledge/**/*.md` file. It parses the bounded YAML-frontmatter
-subset used by the repository without adding a dependency and verifies:
+- **Always:** harden runner, the routing guard, checkout, and both existing
+  agent-guide contract commands.
+- **Rust setup:** stable toolchain and Rust cache when either the stable or
+  presentation group runs.
+- **Stable:** format, Clippy, unit/integration tests, OpenAPI sync, and
+  Rust-owned UI fixture sync.
+- **Presentation:** embedded source/JavaScript boundaries, formatter fixture,
+  i18n, locale-v1, pseudolocale, and the complete served-browser render gate.
 
-- every file begins with closed, parseable frontmatter and a nonempty `type`;
-- `index.md` pages use `Index`, `knowledge/log.md` uses `Log`, and every other
-  page uses `Decision`, `Research Finding`, `Component`, or `Runbook`;
-- concept filenames are kebab-case; and
-- Decision headings contain `Context`, `Options`, `Choice`, and
-  `Consequences` in that order.
+Presentation retains Rust setup because `render_check.js` builds and starts the
+real binary. Documentation-only work receives a lightweight required routing
+result from the existing agent-guide contract. That contract proves only the
+stable agent instructions and their repository-local links; it does not prove
+general documentation or knowledge correctness.
 
-Its `--selftest` has a positive fixture and one negative fixture for every
-rule. The three existing legacy Decision heading exceptions are normalized in
-this subproject so the tracked inventory passes the declared schema; the
-validator contains no grandfather list.
+**Ponytail Rung 2:** keep the monolithic job and its proven commands; add only
+native conditions around the two existing expensive step groups.
 
-### Workflow scope jobs
+## Other jobs and workflows
 
-`ci.yml`, `codeql.yml`, and `fuzz.yml` each receive a small scope job that:
+In `ci.yml`:
 
-1. Checks out full history without persisted credentials.
-2. Uses the pull-request base and head SHAs to write a NUL-delimited changed
-   path list.
-3. Runs `python3 scripts/ci_scope.py --selftest` as a bootstrap guard.
-4. Invokes `scripts/ci_scope.py` with event, base, labels, and paths.
-5. Exposes the classifier outputs to that workflow's existing jobs.
+- `coverage` runs for Rust behavior or any full trigger.
+- `msrv` runs for Rust behavior, dependency/toolchain metadata, or any full
+  trigger.
+- `docker build` runs for Rust behavior, dependency/toolchain metadata,
+  container/runtime packaging, or any full trigger.
+- `cargo-deny`, gitleaks, workflow lint, and dependency review remain
+  unchanged and always run when their current event permits. Cargo-deny is a
+  cheap supply-chain gate; its 46-second baseline does not justify weakening
+  the always-on security posture.
 
-The repeated YAML is event plumbing only. Classification logic remains in one
-script.
+`codeql.yml` remains unchanged. CodeQL is a required security check, already
+uses `build-mode: none`, and measured 2m08s. Adding a second routing job and
+permission surface would cost complexity while weakening the always-on SAST
+baseline.
 
-## Path classification
+`fuzz.yml` remains byte-for-byte unchanged. Its native path filter already
+routes the three fuzzed surfaces, and `smoke fuzz` is deliberately not a
+required merge check. The 6m02s baseline is therefore not waste on ordinary
+PRs and does not justify replacing its existing solution.
 
-Rules may overlap; the union of their surfaces is intentional.
+**Ponytail Rung 2:** preserve cargo-deny, gitleaks, actionlint, zizmor,
+dependency review, CodeQL, and fuzz exactly where the repository already owns
+them. Only measured build/test/render compatibility work is routed.
 
-| Surface | Paths |
-| --- | --- |
-| Documentation | root Markdown and policy text; `docs/**`; `knowledge/**`; `examples/**`; `.github` issue/PR templates and `CODEOWNERS`; `scripts/check_agent_guide.py`; `scripts/check_markdown_links.py`; `scripts/check_knowledge.py` |
-| Rust behavior | `src/**` except static `src/web/**`; Rust integration tests and non-presentation fixtures; `openapi.json`; `rust-toolchain.toml` |
-| Presentation/i18n | `src/web/**`; `src/presentation.rs`; render, formatter, i18n, locale, and pseudolocale scripts; UI, locale, and formatter fixtures |
-| Dependencies | `Cargo.toml`; `Cargo.lock`; `deny.toml`; `.github/dependabot.yml` |
-| Workflow policy | `.github/workflows/**`; `.github/codeql/**`; `.github/release.yml`; `scripts/ci_scope.py`; `scripts/test_release_contract.py` |
-| Container/runtime packaging | `Dockerfile`; `.dockerignore`; `docker-compose*.yml` |
-| Fuzz | `fuzz/**`; `src/proxy.rs`; `src/config.rs`; `.github/workflows/fuzz.yml` |
-| Security-sensitive | `src/api.rs`; `src/auth.rs`; `src/config.rs`; `src/main.rs`; `src/proxy.rs`; `src/routes.rs`; `src/settings.rs`; `.github/codeql/**` |
+## Full release gates
 
-Other known operational scripts are explicitly classified as full-policy
-tooling. Any future path not matched by the policy routes to full validation.
-`--assert-known` proves every currently tracked path is covered.
+The last PR in every remediation workstream and issue #153 carry `ci:full`.
+PR #72 targets `main`, so its CI is full without depending on a label. At each
+of those boundaries:
 
-Rules overlap deliberately after the Rust exclusion is applied.
-`src/presentation.rs` is both Rust behavior and presentation, so it receives
-stable Rust and render proof. Static `src/web/**` files and presentation
-scripts/fixtures are presentation-only and avoid Rust setup unless another
-changed path selects it.
+1. The current reviewed head completes every required CI and CodeQL context.
+2. The existing fuzz workflow is manually dispatched for that exact reviewed
+   ref unless the unchanged native path trigger already produced a successful
+   run for the same SHA.
+3. The next workstream or final owner review waits for both required and fuzz
+   evidence.
 
-## Job routing matrix
+This preserves the parent remediation design's full-gate promise without
+turning non-required fuzz into a required workflow or changing its trigger.
 
-`fmt, clippy, tests` remains an always-created job because it is required on
-`main`. It depends on the scope job with `if: always()` and begins with a
-fail-closed guard. If classification failed, this required context fails. If
-classification succeeded, its steps are conditional:
+**Ponytail Rung 4:** use the existing `ci:full` label event, target-branch
+metadata, and fuzz `workflow_dispatch` entry point. No temporary workflow or
+synthetic path probe is needed.
 
-- Always: checkout, scope summary, changed-diff whitespace check, agent-guide
-  contract, and tracked Markdown local-link validation.
-- Documentation: knowledge-schema validation in addition to the always-on
-  agent-guide and Markdown-link checks.
-- Stable: stable toolchain, cache, format, Clippy, `cargo test`, OpenAPI sync,
-  and Rust-owned UI fixture sync. Both Rust behavior and dependency metadata
-  select this step group.
-- Presentation: embedded source/JavaScript checks, formatter fixture, i18n,
-  locale-v1, pseudolocale, and the browser render matrix.
+## Approved supersession of parent acceptance details
 
-The other jobs retain their existing names and use job-level conditions:
+The later owner-approved design supersedes exactly two implementation and
+acceptance details in the parent remediation design:
 
-| Job/check | Runs when |
-| --- | --- |
-| `coverage` | Rust behavior or full |
-| `msrv` | Rust behavior, dependencies, or full |
-| `cargo-deny` | Dependencies or full |
-| `gitleaks` | Always |
-| `workflow lint` | Workflow policy or full |
-| `dependency review` | Pull request and dependencies, workflow policy, or full |
-| `docker build` | Container, dependencies, or full |
-| `codeql (rust)` | Rust behavior or full |
-| `smoke fuzz` | Fuzz surface or full |
+1. Phase 0 does not create representative fixtures, synthetic file lists, a
+   probe workflow, or synthetic commits to exercise every reduced route before
+   merge.
+2. Documentation-only routing does not assume generic link, schema, knowledge,
+   or documentation checks that do not already exist in this repository.
 
-A static presentation-only change runs the presentation steps without
-installing the Rust toolchain. A dependency-only change runs the stable build
-and test steps as well as MSRV, deny, dependency review, and Docker proof. A
-documentation-only change runs the fast documentation checks and gitleaks;
-the expensive job contexts conclude as successful skips.
+**Ponytail Rung 1:** those synthetic mechanisms and nonexistent validators do
+not need to exist. This supersession does not authorize another Rung 7 artifact;
+the already approved, SHA-pinned `step-security/paths-filter` action remains the
+only new machinery.
 
-## Full-scope triggers
+The replacement Phase 0 acceptance contract is:
 
-The classifier returns full scope for:
+- verify the pinned action's primary-source matcher contract: pull-request
+  files come from GitHub's changed-file API; picomatch includes dot paths;
+  `predicate-quantifier: every` applies every include/exclusion rule to each
+  path; and a filter is true when at least one changed path matches;
+- manually review the small inline exclusion policy against the current
+  tracked inputs and this design's routing matrix;
+- pass existing YAML parsing, actionlint, and zizmor proof;
+- prove the real workflow-policy implementation PR selects full CI;
+- toggle `ci:full` and prove the label event starts a full rerun on the exact
+  reviewed head;
+- pass all nine required contexts plus unchanged CodeQL on that head; and
+- record selected and skipped reduced-route evidence from the first natural
+  ordinary remediation PR.
 
-- Any PR whose base is `main`.
-- Any PR carrying the exact `ci:full` label.
-- Any non-PR event, preserving current `main` push, scheduled, and manual
-  validation behavior.
-- Any workflow-policy or security-sensitive path.
-- Any unknown path or empty PR diff.
+Phase 0 does **not** claim that every reduced route received a live pre-merge
+exercise. If the first natural evidence exposes a routing mismatch, pause the
+issue train, correct the Phase 0 routing, independently review the correction,
+and repeat this acceptance contract before another remediation issue proceeds.
 
-All three workflows use the exact pull-request activity set `opened`,
-`synchronize`, `reopened`, `labeled`, and `unlabeled`. The fuzz workflow
-removes its top-level `paths` filter; its job-level condition supplies the same
-targeted behavior while allowing `ci:full` to override it.
+Documentation-only PRs run the existing agent-guide contract as their
+lightweight required proof; this design creates no generic Markdown, link,
+schema, knowledge, or documentation validator. Issue #152 remains the single
+owner of knowledge reconciliation and its promotion gate remains full.
 
-Create the repository label `ci:full` with description `Run every v0.6.6
-release gate` before opening the implementation PR. Apply it immediately after
-PR creation. The label event must start the authoritative full run; concurrency
-may cancel the initial opened-event run.
+This supersession does not change fail-closed handling for unknown, security,
+or workflow paths; continuity of all required contexts; the full gate on the
+CI-routing PR, workstream boundaries, #153, and #72; or the requirement that
+release evidence is never weakened.
+
+**Ponytail Rung 2:** reuse the current agent-guide, YAML, actionlint, zizmor,
+required-context, CodeQL, and independent-review proofs. **Ponytail Rung 4:**
+use native workflow, label-event, job-result, and required-context semantics for
+the real acceptance runs.
 
 ## Failure handling
 
-- The classifier job exits nonzero for malformed inputs or internal errors.
-- Required `fmt, clippy, tests` and `codeql (rust)` jobs use `if: always()` and
-  explicit classifier-result guards so a failed dependency cannot become a
-  successful skip.
-- The optional fuzz job also exposes classifier failure rather than silently
-  skipping.
-- Unknown and empty diffs choose full validation.
-- A required context name change is a blocking defect because the `main`
-  ruleset still requires the existing names.
-- A CI failure is classified from logs before any rerun. No failure is retried
-  merely to seek green.
+- A failed or cancelled `changes` job fails `fmt, clippy, tests` through the
+  `always()` guard.
+- Unknown paths run full because only explicitly safe paths are excluded.
+- Workflow and security changes run full.
+- Every required context keeps its current name and reaches a terminal result.
+- A CI failure is diagnosed from its logs before any rerun; green is never
+  sought by repetition.
+
+**Ponytail Rung 4:** native dependency results and required contexts are the
+merge barrier. No custom validator is added to inspect GitHub Actions YAML or
+simulate the platform.
 
 ## Verification
 
-### Classifier self-test
+Before implementation is committed:
 
-Committed cases prove:
+- review the inline path exclusions against the current tracked-file
+  inventory and the matrix above;
+- parse the edited workflow YAML;
+- run `git diff --check`;
+- confirm the nine job display names still match a fresh read of the active
+  `main` ruleset; and
+- obtain independent review of the route-failure guard, metadata overrides,
+  and unknown-path default.
 
-- Documentation-only routing.
-- Ordinary Rust routing.
-- Presentation-only routing without Rust setup.
-- Dependency routing, including `stable=true` for affected builds/tests.
-- Container routing.
-- Fuzz routing.
-- Security path, workflow path, target-main, `ci:full`, non-PR, unknown path,
-  and empty diff full routing.
-- Overlapping paths union their relevant surfaces.
-- Malformed label JSON type, malformed label members, missing PR path file,
-  invalid UTF-8, noncanonical paths, and internal errors fail instead of
-  selecting a smaller scope.
-- Duplicate paths normalize deterministically and every output key is present.
-- The classifier and workflow-policy paths themselves select full, proving the
-  bootstrap self-test cannot authorize reduced validation.
-- Every current tracked repository path is explicitly known.
+On the implementation PR, the workflow-policy change itself must select the
+full gate. Existing actionlint and zizmor validate the workflow, and all nine
+required contexts plus unchanged CodeQL must pass. Toggling `ci:full` proves a
+label event starts a full CI run on the same reviewed head.
 
-### Documentation checker self-tests
+After merge, the first ordinary remediation PR records the natural selected
+and skipped jobs from its real changed surface. This observation may correct a
+filter before further remediation proceeds, but no temporary probe workflow,
+synthetic commit, or custom workflow parser is introduced. Every workstream
+boundary, #153, and #72 then supplies the full-gate evidence described above.
 
-Every Markdown-link and knowledge-schema validation branch has a fixture that
-trips it, followed by clean scans of the tracked repository inventories.
-
-### Workflow proof
-
-Before commit:
-
-- All three Python self-tests pass.
-- All three scripts compile with `python3 -m py_compile`.
-- The current tracked-path inventory passes `--assert-known`.
-- Workflow YAML parses.
-- The full branch diff passes `git diff --check`.
-- Independent review verifies exact check names, `always()` guards, and no
-  workflow-level path filters on required PR workflows.
-
-On the implementation PR, Phase 0 performs live routing proof before merge:
-
-1. A reviewed intermediate commit adds a temporary
-   `.github/workflows/ci-routing-probe.yml`. It invokes the real committed
-   classifier with a synthetic documentation path and proves a selected docs
-   job succeeds while a Rust job is a terminal successful job-level skip.
-2. A second probe invocation supplies malformed label JSON, so the real
-   classifier job fails. A dependent guard with `if: always()` also fails,
-   proving dependency failure cannot authorize a skip. Every context in that
-   probe run, including the ordinary required contexts from the production
-   workflows, must reach a terminal state; the run URL and job conclusions are
-   retained as issue and PR evidence.
-3. A separately reviewed next commit removes the temporary workflow. It never
-   enters the final merged tree; its run remains in the PR history.
-4. Apply `ci:full` to the final reviewed head and prove the label event starts
-   the authoritative run. All twelve existing full-gate checks pass, and the
-   names required by the freshly queried `main` ruleset remain present.
-
-The PR records PR #163's pre-change durations as the baseline. The first
-ordinary remediation PR after merge provides an additional natural-path
-observation, but Phase 0 completion does not depend on deferred evidence.
+**Ponytail Rung 2:** trust the maintained action's tested matching contract
+and the repository's existing workflow lint. Verify this repository's small
+declarative policy through review and real workflow runs.
 
 ## Success criteria
 
-The subproject is complete when:
+1. The final implementation adds no classifier, Markdown checker, knowledge
+   checker, workflow-policy parser, or temporary probe.
+2. Only `ci.yml` receives routing; `codeql.yml` and `fuzz.yml` remain
+   unchanged.
+3. The single `step-security/paths-filter` use is pinned to
+   `9098a7821b83402dbe267c0c801e7d580ce74f92` and all policy is declarative
+   inline YAML.
+4. Unknown, workflow, security, `ci:full`, `main`-targeting, and non-PR changes
+   select full CI.
+5. Routing failure makes `fmt, clippy, tests` fail.
+6. All nine required contexts retain their exact names; cheap and security
+   checks remain always on under their current events.
+7. The implementation PR passes a full gate, the first ordinary remediation
+   PR supplies natural reduced-routing evidence, and workstream/#153/#72
+   boundaries retain full required plus fuzz evidence.
 
-1. The classifier, Markdown checker, and knowledge checker satisfy all local
-   fixtures and current inventory checks.
-2. CI, CodeQL, and fuzz workflows consume the shared classifier and retain
-   their required context names.
-3. Live probe evidence shows selected and skipped jobs, and classifier failure
-   blocks the fail-closed dependent guard; unknown paths select full.
-4. The `ci:full` label exists and demonstrably triggers the full PR run.
-5. The implementation PR passes all twelve checks and merges into
-   `release/v0.6.6`.
-6. Its issue and #131 record the merged evidence and PR #163 baseline cost.
-7. No remediation issue implementation begins before this routing PR merges.
+**Ponytail Rung 1:** completion is the smallest workflow-only remediation that
+achieves the measured savings while preserving release evidence. Anything
+beyond these criteria is a separate, owner-approved need.

--- a/docs/superpowers/specs/2026-08-08-v0.6.6-change-aware-ci-design.md
+++ b/docs/superpowers/specs/2026-08-08-v0.6.6-change-aware-ci-design.md
@@ -1,0 +1,354 @@
+# v0.6.6 Change-Aware CI Design
+
+**Status:** Derived from the approved v0.6.6 remediation program design
+**Date:** 2026-08-08
+**Integration branch:** `release/v0.6.6`
+**Parent issue:** [#131](https://github.com/miztertea/nim-proxy/issues/131)
+
+## Purpose
+
+Route pull-request validation from the files and risk surfaces that changed so
+ordinary remediation PRs do not pay for unrelated ten-minute rendering,
+fuzzing, container, coverage, and compatibility gates. The complete release
+suite remains mandatory at workstream boundaries, for security-sensitive or
+unknown changes, for PRs targeting `main`, and for non-PR release evidence.
+
+The baseline reconciliation PR demonstrated the current cost: its twelve
+checks consumed about 28 runner-minutes, with `fmt, clippy, tests` taking
+10m37s, smoke fuzz 6m02s, Docker 5m12s, CodeQL 2m08s, and coverage 1m55s.
+No check failed or retried. This design removes unnecessary jobs rather than
+weakening their assertions.
+
+## Fixed decisions
+
+- Every required workflow starts on every pull request. Do not use
+  workflow-level path filters for required checks.
+- A skipped job reports success and may satisfy a required context; a skipped
+  required workflow can remain pending.
+- The existing required check names remain unchanged.
+- One standard-library classifier is the single source of path and risk
+  policy for CI, CodeQL, and fuzz workflows.
+- Every scope job runs the classifier self-test before classifying the live
+  event. A broken classifier or a change to its own policy therefore cannot
+  authorize a reduced run.
+- Unknown paths, classifier errors, security-sensitive changes, workflow
+  changes, `ci:full`, PRs targeting `main`, and non-PR events fail or route to
+  the complete suite.
+- Secret scanning remains always on.
+- Full validation runs on the last PR in every remediation workstream, #153,
+  and PR #72.
+- This subproject receives one issue and one PR into `release/v0.6.6`.
+
+GitHub documents that job-level conditional skips report success, while
+workflow-level path skips can leave required contexts pending. It also warns
+that jobs depending on a failed job need `always()` when they are required:
+
+- <https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-jobs-with-conditions>
+- <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks>
+
+## Components
+
+### `scripts/ci_scope.py`
+
+This Python-standard-library script owns classification. Workflow YAML owns
+only event plumbing and job conditions; it does not reproduce path lists.
+
+The script accepts:
+
+- `--event-name`: GitHub event name.
+- `--base-ref`: pull-request base branch name, empty for other events.
+- `--labels-json`: JSON array of pull-request label names.
+- `--paths-file`: a required, readable NUL-delimited changed-path file for a
+  pull-request event. Non-PR events ignore this option and always run full.
+- `--github-output`: append deterministic `name=true|false` outputs to the
+  named GitHub output file. Without it, print the result as sorted JSON.
+- `--assert-known`: fail when any supplied path has no explicit classification
+  rule; used against the tracked repository inventory during development.
+- `--selftest`: run the committed positive, negative, overlap, and fail-closed
+  fixtures.
+
+Its pure interface is:
+
+```python
+@dataclass(frozen=True)
+class Scope:
+    docs: bool
+    rust: bool
+    presentation: bool
+    dependencies: bool
+    workflow: bool
+    container: bool
+    security: bool
+    fuzz: bool
+    full: bool
+    reason: str
+
+
+def classify(
+    paths: tuple[str, ...],
+    *,
+    event_name: str,
+    base_ref: str,
+    labels: tuple[str, ...],
+) -> Scope:
+    ...
+
+
+def job_outputs(scope: Scope) -> dict[str, bool]:
+    ...
+```
+
+The script emits these exact Boolean outputs, all as lowercase `true` or
+`false`: the nine surface outputs `docs`, `rust`, `presentation`,
+`dependencies`, `workflow`, `container`, `security`, `fuzz`, and `full`; and
+the nine job outputs `stable`, `coverage`, `msrv`, `deny`, `workflow_lint`,
+`dependency_review`, `docker`, `codeql`, and `smoke_fuzz`. It also emits the
+closed string output `reason`.
+
+`job_outputs` is a deterministic union:
+
+| Output | True when |
+| --- | --- |
+| `stable` | Rust behavior, dependency metadata, or full |
+| `coverage` | Rust behavior or full |
+| `msrv` | Rust behavior, dependency metadata, or full |
+| `deny` | Dependency metadata or full |
+| `workflow_lint` | Workflow policy or full |
+| `dependency_review` | Dependency metadata, workflow policy, or full |
+| `docker` | Container/runtime packaging, dependency metadata, or full |
+| `codeql` | Rust behavior or full |
+| `smoke_fuzz` | Fuzz surface or full |
+
+Full-scope reason precedence is exact and first-match wins: `non-pr`,
+`target-main`, `full-label`, `workflow-policy`, `security-path`,
+`unknown-path`, `empty-diff`, then `routed`. Label JSON must decode to an array
+containing only strings; any other shape exits nonzero. Pull-request
+classification requires `--paths-file`; a missing or unreadable file exits
+nonzero. Each NUL-delimited path must be valid UTF-8 and a canonical relative
+POSIX Git path: nonempty, no leading or trailing slash, no backslash, and no
+`.` or `..` component. Malformed paths exit nonzero. Duplicate paths are
+deduplicated and sorted before classification. An empty valid file and
+well-formed unknown paths do not error; they select full scope with
+`empty-diff` or `unknown-path` respectively. Non-PR events select full without
+reading path or label inputs.
+
+### `scripts/check_markdown_links.py`
+
+This standard-library checker gives documentation-only PRs meaningful proof.
+It scans tracked Markdown files, resolves repository-local Markdown links,
+rejects paths escaping the repository, and fails when a local target is
+absent. For a raw link it first splits the literal fragment marker `#`, then
+the literal query marker `?`, and only then percent-decodes the remaining path.
+Thus encoded `%23` and `%3F` remain filename characters while an ordinary
+query is ignored. It ignores external schemes and does not validate anchors.
+
+The checker supports `--selftest`. Fixtures prove a valid link, an encoded
+space, encoded `#`, encoded `?`, an ordinary query, a missing target,
+repository escape, external URL, and fragment-only link.
+
+### `scripts/check_knowledge.py`
+
+This standard-library checker enforces the committed schema contract on every
+tracked `knowledge/**/*.md` file. It parses the bounded YAML-frontmatter
+subset used by the repository without adding a dependency and verifies:
+
+- every file begins with closed, parseable frontmatter and a nonempty `type`;
+- `index.md` pages use `Index`, `knowledge/log.md` uses `Log`, and every other
+  page uses `Decision`, `Research Finding`, `Component`, or `Runbook`;
+- concept filenames are kebab-case; and
+- Decision headings contain `Context`, `Options`, `Choice`, and
+  `Consequences` in that order.
+
+Its `--selftest` has a positive fixture and one negative fixture for every
+rule. The three existing legacy Decision heading exceptions are normalized in
+this subproject so the tracked inventory passes the declared schema; the
+validator contains no grandfather list.
+
+### Workflow scope jobs
+
+`ci.yml`, `codeql.yml`, and `fuzz.yml` each receive a small scope job that:
+
+1. Checks out full history without persisted credentials.
+2. Uses the pull-request base and head SHAs to write a NUL-delimited changed
+   path list.
+3. Runs `python3 scripts/ci_scope.py --selftest` as a bootstrap guard.
+4. Invokes `scripts/ci_scope.py` with event, base, labels, and paths.
+5. Exposes the classifier outputs to that workflow's existing jobs.
+
+The repeated YAML is event plumbing only. Classification logic remains in one
+script.
+
+## Path classification
+
+Rules may overlap; the union of their surfaces is intentional.
+
+| Surface | Paths |
+| --- | --- |
+| Documentation | root Markdown and policy text; `docs/**`; `knowledge/**`; `examples/**`; `.github` issue/PR templates and `CODEOWNERS`; `scripts/check_agent_guide.py`; `scripts/check_markdown_links.py`; `scripts/check_knowledge.py` |
+| Rust behavior | `src/**` except static `src/web/**`; Rust integration tests and non-presentation fixtures; `openapi.json`; `rust-toolchain.toml` |
+| Presentation/i18n | `src/web/**`; `src/presentation.rs`; render, formatter, i18n, locale, and pseudolocale scripts; UI, locale, and formatter fixtures |
+| Dependencies | `Cargo.toml`; `Cargo.lock`; `deny.toml`; `.github/dependabot.yml` |
+| Workflow policy | `.github/workflows/**`; `.github/codeql/**`; `.github/release.yml`; `scripts/ci_scope.py`; `scripts/test_release_contract.py` |
+| Container/runtime packaging | `Dockerfile`; `.dockerignore`; `docker-compose*.yml` |
+| Fuzz | `fuzz/**`; `src/proxy.rs`; `src/config.rs`; `.github/workflows/fuzz.yml` |
+| Security-sensitive | `src/api.rs`; `src/auth.rs`; `src/config.rs`; `src/main.rs`; `src/proxy.rs`; `src/routes.rs`; `src/settings.rs`; `.github/codeql/**` |
+
+Other known operational scripts are explicitly classified as full-policy
+tooling. Any future path not matched by the policy routes to full validation.
+`--assert-known` proves every currently tracked path is covered.
+
+Rules overlap deliberately after the Rust exclusion is applied.
+`src/presentation.rs` is both Rust behavior and presentation, so it receives
+stable Rust and render proof. Static `src/web/**` files and presentation
+scripts/fixtures are presentation-only and avoid Rust setup unless another
+changed path selects it.
+
+## Job routing matrix
+
+`fmt, clippy, tests` remains an always-created job because it is required on
+`main`. It depends on the scope job with `if: always()` and begins with a
+fail-closed guard. If classification failed, this required context fails. If
+classification succeeded, its steps are conditional:
+
+- Always: checkout, scope summary, changed-diff whitespace check, agent-guide
+  contract, and tracked Markdown local-link validation.
+- Documentation: knowledge-schema validation in addition to the always-on
+  agent-guide and Markdown-link checks.
+- Stable: stable toolchain, cache, format, Clippy, `cargo test`, OpenAPI sync,
+  and Rust-owned UI fixture sync. Both Rust behavior and dependency metadata
+  select this step group.
+- Presentation: embedded source/JavaScript checks, formatter fixture, i18n,
+  locale-v1, pseudolocale, and the browser render matrix.
+
+The other jobs retain their existing names and use job-level conditions:
+
+| Job/check | Runs when |
+| --- | --- |
+| `coverage` | Rust behavior or full |
+| `msrv` | Rust behavior, dependencies, or full |
+| `cargo-deny` | Dependencies or full |
+| `gitleaks` | Always |
+| `workflow lint` | Workflow policy or full |
+| `dependency review` | Pull request and dependencies, workflow policy, or full |
+| `docker build` | Container, dependencies, or full |
+| `codeql (rust)` | Rust behavior or full |
+| `smoke fuzz` | Fuzz surface or full |
+
+A static presentation-only change runs the presentation steps without
+installing the Rust toolchain. A dependency-only change runs the stable build
+and test steps as well as MSRV, deny, dependency review, and Docker proof. A
+documentation-only change runs the fast documentation checks and gitleaks;
+the expensive job contexts conclude as successful skips.
+
+## Full-scope triggers
+
+The classifier returns full scope for:
+
+- Any PR whose base is `main`.
+- Any PR carrying the exact `ci:full` label.
+- Any non-PR event, preserving current `main` push, scheduled, and manual
+  validation behavior.
+- Any workflow-policy or security-sensitive path.
+- Any unknown path or empty PR diff.
+
+All three workflows use the exact pull-request activity set `opened`,
+`synchronize`, `reopened`, `labeled`, and `unlabeled`. The fuzz workflow
+removes its top-level `paths` filter; its job-level condition supplies the same
+targeted behavior while allowing `ci:full` to override it.
+
+Create the repository label `ci:full` with description `Run every v0.6.6
+release gate` before opening the implementation PR. Apply it immediately after
+PR creation. The label event must start the authoritative full run; concurrency
+may cancel the initial opened-event run.
+
+## Failure handling
+
+- The classifier job exits nonzero for malformed inputs or internal errors.
+- Required `fmt, clippy, tests` and `codeql (rust)` jobs use `if: always()` and
+  explicit classifier-result guards so a failed dependency cannot become a
+  successful skip.
+- The optional fuzz job also exposes classifier failure rather than silently
+  skipping.
+- Unknown and empty diffs choose full validation.
+- A required context name change is a blocking defect because the `main`
+  ruleset still requires the existing names.
+- A CI failure is classified from logs before any rerun. No failure is retried
+  merely to seek green.
+
+## Verification
+
+### Classifier self-test
+
+Committed cases prove:
+
+- Documentation-only routing.
+- Ordinary Rust routing.
+- Presentation-only routing without Rust setup.
+- Dependency routing, including `stable=true` for affected builds/tests.
+- Container routing.
+- Fuzz routing.
+- Security path, workflow path, target-main, `ci:full`, non-PR, unknown path,
+  and empty diff full routing.
+- Overlapping paths union their relevant surfaces.
+- Malformed label JSON type, malformed label members, missing PR path file,
+  invalid UTF-8, noncanonical paths, and internal errors fail instead of
+  selecting a smaller scope.
+- Duplicate paths normalize deterministically and every output key is present.
+- The classifier and workflow-policy paths themselves select full, proving the
+  bootstrap self-test cannot authorize reduced validation.
+- Every current tracked repository path is explicitly known.
+
+### Documentation checker self-tests
+
+Every Markdown-link and knowledge-schema validation branch has a fixture that
+trips it, followed by clean scans of the tracked repository inventories.
+
+### Workflow proof
+
+Before commit:
+
+- All three Python self-tests pass.
+- All three scripts compile with `python3 -m py_compile`.
+- The current tracked-path inventory passes `--assert-known`.
+- Workflow YAML parses.
+- The full branch diff passes `git diff --check`.
+- Independent review verifies exact check names, `always()` guards, and no
+  workflow-level path filters on required PR workflows.
+
+On the implementation PR, Phase 0 performs live routing proof before merge:
+
+1. A reviewed intermediate commit adds a temporary
+   `.github/workflows/ci-routing-probe.yml`. It invokes the real committed
+   classifier with a synthetic documentation path and proves a selected docs
+   job succeeds while a Rust job is a terminal successful job-level skip.
+2. A second probe invocation supplies malformed label JSON, so the real
+   classifier job fails. A dependent guard with `if: always()` also fails,
+   proving dependency failure cannot authorize a skip. Every context in that
+   probe run, including the ordinary required contexts from the production
+   workflows, must reach a terminal state; the run URL and job conclusions are
+   retained as issue and PR evidence.
+3. A separately reviewed next commit removes the temporary workflow. It never
+   enters the final merged tree; its run remains in the PR history.
+4. Apply `ci:full` to the final reviewed head and prove the label event starts
+   the authoritative run. All twelve existing full-gate checks pass, and the
+   names required by the freshly queried `main` ruleset remain present.
+
+The PR records PR #163's pre-change durations as the baseline. The first
+ordinary remediation PR after merge provides an additional natural-path
+observation, but Phase 0 completion does not depend on deferred evidence.
+
+## Success criteria
+
+The subproject is complete when:
+
+1. The classifier, Markdown checker, and knowledge checker satisfy all local
+   fixtures and current inventory checks.
+2. CI, CodeQL, and fuzz workflows consume the shared classifier and retain
+   their required context names.
+3. Live probe evidence shows selected and skipped jobs, and classifier failure
+   blocks the fail-closed dependent guard; unknown paths select full.
+4. The `ci:full` label exists and demonstrably triggers the full PR run.
+5. The implementation PR passes all twelve checks and merges into
+   `release/v0.6.6`.
+6. Its issue and #131 record the merged evidence and PR #163 baseline cost.
+7. No remediation issue implementation begins before this routing PR merges.


### PR DESCRIPTION
Implements the approved Lego-brick CI routing design. Reuses existing checks, adds only the pinned paths-filter action, and tracks #164 / #131.