### PR TITLE
fix(history): keep proxy available when canonical history cannot open

### DIFF
--- a/docs/superpowers/plans/2026-08-08-v0.6.6-issue-134-history-availability.md
+++ b/docs/superpowers/plans/2026-08-08-v0.6.6-issue-134-history-availability.md
@@ -1,0 +1,302 @@
+# v0.6.6 Issue #134 History Availability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the proxy start with in-memory history when canonical history cannot open, without changing rejected bytes or config/auth refusal.
+
+**Architecture:** Keep `HistoryStore::open` strict. The existing startup caller catches its error, logs once, and falls back to `History::load(None, ...)`. A real-binary E2E test captures the prior fatal behavior red, then proves availability and byte preservation green.
+
+**Tech Stack:** Rust, Tokio E2E harness, GitHub Actions
+
+## Global Constraints
+
+- Integration branch is `release/v0.6.6`; only PR #72 targets `main`.
+- Issue #134 owns startup availability only. Persistence-health API/UI/metric work remains #139.
+- Modify production behavior only in `src/lib.rs`; modify regression proof only in `tests/e2e.rs`.
+- Add no setting, status field, metric, parser, validator, recovery path, or dependency.
+- Do not change `HistoryStore`, canonical bytes, config bytes, OpenAPI, knowledge, or release artifacts.
+- Preserve config/auth fail-closed startup behavior.
+- One initial review plus at most two repair/review rounds; stop on exhaustion or scope expansion.
+- Commit only after independent review passes.
+
+## File Responsibility Map
+
+- `src/lib.rs` — decide startup availability and reuse the in-memory history fallback.
+- `tests/e2e.rs` — real-binary red→green reproduction and byte-preservation proof.
+- `docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md` — reviewed workstream boundary.
+- This plan — exact issue execution contract.
+
+---
+
+### Task 1: Capture and fix canonical-open availability
+
+**Files:**
+
+- Modify: `tests/e2e.rs`
+- Modify: `src/lib.rs`
+
+**Outcome:** Rejected canonical history degrades to in-memory history and the configured proxy becomes healthy.
+
+**Proof:** The named E2E test fails before the implementation, passes after it, preserves canonical/config bytes, and is paired with the unchanged config-store refusal test.
+
+**Constraint:** No public API or canonical-store behavior changes.
+
+**Ponytail Rung:** Rung 2 reuses `History::load(None, ...)`, the existing startup match, and the real-binary E2E harness.
+
+**Interfaces:** Produces reviewed commit `fix(history): degrade canonical open failure` for Task 2.
+
+- [ ] **Step 1: Write the failing real-binary regression**
+
+Replace `history_startup_is_fail_closed` with
+`history_startup_degrades_to_memory_without_mutating_canonical`. Keep its
+configured-store fixture and table of empty plus future-version canonical
+bytes. For each row:
+
+1. Snapshot `config.json` and `history-v1.jsonl` bytes.
+2. Call `start_proxy_in(data_dir, &[("HISTORY_SAMPLE_SECS", "3600")])`.
+3. POST a normal open-mode `/v1/chat/completions` request using the existing
+   `chat_body` helper and require a successful response.
+4. Assert both files still equal their snapshots.
+5. Terminate through the returned `Proxy` guard.
+
+Do not add a helper unless the two-row loop cannot use existing imports.
+
+- [ ] **Step 2: Run RED and capture the fatal-startup failure**
+
+Run:
+
+~~~bash
+cargo test --test e2e history_startup_degrades_to_memory_without_mutating_canonical -- --exact --nocapture
+~~~
+
+Expected: FAIL because `start_proxy_in` times out waiting for health after the
+current process exits on `History::open` error. Record the command and relevant
+failure in the task report before editing `src/lib.rs`.
+
+- [ ] **Step 3: Implement the minimum caller fallback**
+
+In `src/lib.rs`, replace the current history construction with this shape,
+using the existing names and formatting:
+
+~~~rust
+let history_capacity = capacity_snapshot(&pool.read().unwrap());
+let hist = match history::History::open(
+    data_dir.clone(),
+    stored.history.days,
+    history_capacity.clone(),
+) {
+    Ok(history) => Arc::new(history),
+    Err(error) => {
+        tracing::error!(
+            "canonical history unavailable: {error}; continuing with in-memory history"
+        );
+        Arc::new(history::History::load(
+            None,
+            stored.history.days,
+            history_capacity,
+        ))
+    }
+};
+~~~
+
+Do not change `History::open`, `History::load`, the store, or error types.
+
+- [ ] **Step 4: Run GREEN and focused non-regression proof**
+
+Run:
+
+~~~bash
+cargo test --test e2e history_startup_degrades_to_memory_without_mutating_canonical -- --exact --nocapture
+cargo test --test e2e corrupt_or_future_store_refuses_to_start -- --exact
+cargo test history::store::tests --lib
+cargo fmt --check
+git diff --check
+git diff --name-only
+~~~
+
+Expected: all tests pass; the diff contains only `src/lib.rs`, `tests/e2e.rs`,
+this plan, and its design spec.
+
+- [ ] **Step 5: Freeze, independently review, and commit**
+
+The reviewer checks issue #134, red→green evidence, byte preservation, the
+config/history boundary, no #139 scope, and the complete diff. Critical or
+Important findings enter the two-round repair loop. After PASS, verify the
+committed tree equals the reviewed tree and run:
+
+~~~bash
+git add src/lib.rs tests/e2e.rs \
+  docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md \
+  docs/superpowers/plans/2026-08-08-v0.6.6-issue-134-history-availability.md
+git commit -m "fix(history): degrade canonical open failure"
+git show --check --stat --oneline HEAD
+~~~
+
+---
+
+### Task 2: Publish, prove the natural route, and integrate #134
+
+**Files:** Publish the reviewed branch and update issues #134, #164, and #131.
+
+**Outcome:** One reviewed PR resolves #134 in `release/v0.6.6`, and its real
+selected/skipped steps close Phase 0 routing issue #164.
+
+**Proof:** Local/remote/PR/reviewed heads match; PR file list is exact; routed
+CI and CodeQL pass; presentation steps skip while stable work runs; guarded
+merge and integration ancestry pass.
+
+**Constraint:** Do not add `ci:full`; #134 is the natural reduced-route proof.
+Do not target `main`, touch PR #72, or merge on any failed/ambiguous route.
+
+**Ponytail Rung:** Rung 2 uses the existing issue, branch, PR, CI jobs, and
+Phase 0 evidence issue. Rung 4 uses native job/step conclusions and
+`--match-head-commit`.
+
+**Interfaces:** Produces merged #134 PR and closes #164 after accepted route evidence.
+
+- [ ] **Step 1: Verify and publish the exact reviewed head**
+
+Run the Task 1 focused proof plus `cargo fmt --check`, then:
+
+~~~bash
+set -euo pipefail
+reviewed_head=$(git rev-parse HEAD)
+git push -u origin work/v0.6.6-134-history-availability
+remote_head=$(git ls-remote origin refs/heads/work/v0.6.6-134-history-availability | cut -f1)
+test "$remote_head" = "$reviewed_head"
+issue_pr_url=$(gh pr create --repo miztertea/nim-proxy \
+  --base release/v0.6.6 \
+  --head work/v0.6.6-134-history-availability \
+  --title "fix(history): keep proxy available when canonical history cannot open" \
+  --body "Resolves #134 by degrading canonical-history open failure to the existing in-memory history path. Includes real-binary red-to-green and byte-preservation proof. Parent: #131.")
+test -n "$issue_pr_url"
+gh pr view "$issue_pr_url" --repo miztertea/nim-proxy \
+  --json url,state,isDraft,baseRefName,headRefName,headRefOid,files
+~~~
+
+Require an open non-draft PR into `release/v0.6.6`, exact reviewed head, and
+the four planned files. Do not apply `ci:full`.
+
+- [ ] **Step 2: Verify the natural route before merge**
+
+Select only pull-request runs for the reviewed SHA and inspect their real job
+and step conclusions:
+
+~~~bash
+set -euo pipefail
+reviewed_head=$(git rev-parse HEAD)
+issue_pr_url=$(gh pr list --repo miztertea/nim-proxy --state open \
+  --base release/v0.6.6 --head work/v0.6.6-134-history-availability \
+  --json url --jq '.[0].url')
+test -n "$issue_pr_url"
+pr_head=$(gh pr view "$issue_pr_url" --repo miztertea/nim-proxy \
+  --json headRefOid --jq .headRefOid)
+remote_head=$(git ls-remote origin refs/heads/work/v0.6.6-134-history-availability | cut -f1)
+test "$pr_head" = "$reviewed_head"
+test "$remote_head" = "$reviewed_head"
+
+runs=$(gh api "repos/miztertea/nim-proxy/actions/runs?event=pull_request&head_sha=$reviewed_head&per_page=100")
+ci_run_id=$(jq -r '[.workflow_runs[] | select(.path == ".github/workflows/ci.yml")] | sort_by(.created_at) | last.id // empty' <<<"$runs")
+codeql_run_id=$(jq -r '[.workflow_runs[] | select(.path == ".github/workflows/codeql.yml")] | sort_by(.created_at) | last.id // empty' <<<"$runs")
+test -n "$ci_run_id"
+test -n "$codeql_run_id"
+gh run watch "$ci_run_id" --repo miztertea/nim-proxy --exit-status
+gh run watch "$codeql_run_id" --repo miztertea/nim-proxy --exit-status
+
+ci_view=$(gh run view "$ci_run_id" --repo miztertea/nim-proxy \
+  --json url,event,headSha,conclusion,jobs)
+codeql_view=$(gh run view "$codeql_run_id" --repo miztertea/nim-proxy \
+  --json url,event,headSha,conclusion,jobs)
+test "$(jq -r .event <<<"$ci_view")" = pull_request
+test "$(jq -r .headSha <<<"$ci_view")" = "$reviewed_head"
+test "$(jq -r .conclusion <<<"$ci_view")" = success
+test "$(jq -r .headSha <<<"$codeql_view")" = "$reviewed_head"
+test "$(jq -r .conclusion <<<"$codeql_view")" = success
+
+for job in 'change routing' 'fmt, clippy, tests' coverage msrv cargo-deny \
+  gitleaks 'workflow lint' 'dependency review' 'docker build'; do
+  jq -e --arg job "$job" '.jobs[] | select(.name == $job and .conclusion == "success")' \
+    <<<"$ci_view" >/dev/null
+done
+jq -e '.jobs[] | select(.name == "codeql (rust)" and .conclusion == "success")' \
+  <<<"$codeql_view" >/dev/null
+
+ci_log=$(gh run view "$ci_run_id" --repo miztertea/nim-proxy --log)
+for route in 'Filter stable = true' 'Filter presentation = false' \
+  'Filter coverage = true' 'Filter docker = true'; do
+  rg -F -q "$route" <<<"$ci_log"
+done
+
+check_steps=$(jq -c '.jobs[] | select(.name == "fmt, clippy, tests") | .steps' <<<"$ci_view")
+for step in 'Format' 'Clippy' 'Tests (unit + integration)' \
+  'OpenAPI spec is in sync' 'Rust-owned UI fixtures are in sync'; do
+  jq -e --arg step "$step" '.[] | select(.name == $step and .conclusion == "success")' \
+    <<<"$check_steps" >/dev/null
+done
+jq -e '.[] | select((.name | startswith("Run dtolnay/rust-toolchain@")) and .conclusion == "success")' \
+  <<<"$check_steps" >/dev/null
+jq -e '.[] | select((.name | startswith("Run Swatinem/rust-cache@")) and .conclusion == "success")' \
+  <<<"$check_steps" >/dev/null
+for step in 'Embedded presentation source boundaries and JS syntax' \
+  'Formatter output is unchanged' 'i18n lint self-test' \
+  'i18n catalog and untagged-string lint' 'locale-v1 self-test' \
+  'locale-v1 validation' 'Pseudolocale is current' \
+  'Dashboard renders and survives being driven'; do
+  jq -e --arg step "$step" '.[] | select(.name == $step and .conclusion == "skipped")' \
+    <<<"$check_steps" >/dev/null
+done
+~~~
+
+The assertions require:
+
+- `change routing` succeeds with `stable=true`, `presentation=false`,
+  `coverage=true`, and `docker=true`;
+- `fmt, clippy, tests`, coverage, MSRV, Docker, cargo-deny, gitleaks,
+  workflow lint, and dependency review conclude success;
+- stable toolchain/cache and stable Rust steps execute successfully;
+- every presentation/render/i18n/locale step in `fmt, clippy, tests` concludes
+  skipped; and
+- `codeql (rust)` concludes success on the same head.
+
+If any route differs, keep #134 open, pause the train, and repair #164 within
+its remaining two-round budget.
+
+- [ ] **Step 3: Independently review PR evidence and merge guarded**
+
+An independent reviewer checks the frozen diff, red→green report, PR metadata,
+route outputs/step conclusions, CodeQL, and SHA equality. After PASS, run from
+a fresh shell:
+
+~~~bash
+set -euo pipefail
+reviewed_head=$(git rev-parse HEAD)
+issue_pr_url=$(gh pr list --repo miztertea/nim-proxy --state open \
+  --base release/v0.6.6 --head work/v0.6.6-134-history-availability \
+  --json url --jq '.[0].url')
+test -n "$issue_pr_url"
+pr_head=$(gh pr view "$issue_pr_url" --repo miztertea/nim-proxy --json headRefOid --jq .headRefOid)
+remote_head=$(git ls-remote origin refs/heads/work/v0.6.6-134-history-availability | cut -f1)
+test "$pr_head" = "$reviewed_head"
+test "$remote_head" = "$reviewed_head"
+gh pr merge "$issue_pr_url" --repo miztertea/nim-proxy \
+  --merge --match-head-commit "$reviewed_head"
+git fetch origin --prune
+git merge-base --is-ancestor "$reviewed_head" origin/release/v0.6.6
+~~~
+
+- [ ] **Step 4: Close and index accepted evidence**
+
+Close #134 with its PR, commit, red→green proof, routed CI, CodeQL, and merge
+links. Close #164 with the natural route outputs and selected/skipped step
+evidence. Comment on #131 with both results and name #135 as next. Keep #72
+open for final owner review.
+
+## Plan Self-Review
+
+- Spec coverage: startup fallback, byte preservation, config refusal, bounded
+  scope, review, natural route, guarded merge, and issue indexing are covered.
+- Placeholder scan: no TBD/TODO/deferred implementation remains.
+- Interface consistency: Task 1's reviewed commit and report are the exact head
+  Task 2 publishes and merges.
+- Execution mode: the owner already selected continuous subagent-driven
+  execution; no intermediate approval gate is added.

--- a/docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md
+++ b/docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md
@@ -1,0 +1,136 @@
+# v0.6.6 History Durability Workstream Design
+
+**Status:** Just-in-time execution design derived from the approved remediation program and live issue contracts
+**Date:** 2026-08-08
+**Integration branch:** `release/v0.6.6`
+**Workstream issues:** #134, #135, #136, #140, #139
+
+## Outcome
+
+History failures stop threatening proxy availability or silently discarding
+durability while the canonical format, append-only recovery evidence, and
+one-PR-per-issue boundary remain intact. This first executable slice resolves
+#134 only: a canonical-history open failure degrades startup to the existing
+in-memory history path instead of terminating the process.
+
+## Existing boundaries
+
+The config/auth store remains fail-closed. Canonical history is telemetry and
+uses its own recovery policy. `HistoryStore::open` remains the strict validator
+and does not mutate rejected canonical bytes. `History::load(None, ...)`
+already supplies the in-memory-only history implementation used when durable
+history is unavailable.
+
+The five issue boundaries are fixed:
+
+- #134 owns startup availability and one bounded startup error.
+- #135 owns canonical temporary/final file mode.
+- #136 owns failed-compaction temporary cleanup.
+- #140 owns canonical runtime timestamp clamping.
+- #139 owns durable persistence-health state, API/UI visibility, metrics, and
+  poisoned-store transition behavior for both startup and runtime failures.
+
+This allocation prevents #134 from pre-implementing #139's wire and operator
+contract. Issue #152 remains the single knowledge-reconciliation owner.
+
+## Considered approaches
+
+### Selected: caller fallback to the existing in-memory implementation
+
+Keep `History::open` strict and returning `Result`. In `lib.rs`, capture the
+capacity snapshot once. On `OpenError`, emit one `tracing::error!` and construct
+`History::load(None, days, capacity)`. The listener then binds and the data
+plane operates normally while rejected canonical bytes remain untouched.
+
+This is the smallest change, preserves the store's validation interface for
+tests and later issues, and gives #139 a clear place to add health state later.
+
+**Ponytail Rung 2:** the repository already has a strict opener, an
+in-memory-only `History`, and the startup call site where availability is
+decided.
+
+### Rejected: make `History::open` infallible
+
+Catching every error inside `History::open` would hide the reason and require
+changing its many strict store tests or inventing a second result channel.
+That weakens a useful boundary without improving availability.
+
+**Ponytail Rung 1:** this interface rewrite does not need to exist.
+
+### Rejected: add `HISTORY_STRICT` or another mode
+
+An opt-in strictness setting adds configuration, documentation, tests, and a
+new support matrix. No current consumer needs two startup policies.
+
+**Ponytail Rung 1:** the new knob does not need to exist.
+
+## #134 behavior
+
+`lib.rs` remains the only production file changed. It computes one
+`CapacitySnapshot`, attempts canonical open, and on failure logs once at error
+level with the existing bounded `OpenError` display. It then constructs the
+same in-memory history object already returned by `History::load(None, ...)`.
+
+The fallback does not:
+
+- truncate, rename, delete, repair, or append to the rejected canonical file;
+- change config/auth startup refusal;
+- add a strict-mode setting;
+- add a status/API/metric field owned by #139;
+- change the canonical codec, scanner, or store;
+- claim durable history is healthy.
+
+The in-memory sampler continues to accept points. Persistence remains disabled
+for that process, and a restart retries the canonical opener against the same
+untouched evidence.
+
+## Failure handling
+
+Every `HistoryStore::open` error takes the same availability path. This
+includes ordinary I/O errors, empty canonical input, unsupported format or
+version, and timestamp regression. The error is not swallowed: it is emitted
+once before the listener binds. Repeated sampler warnings are avoided because
+the degraded `History` has no canonical store.
+
+Config/auth corruption and future config versions remain hard startup errors;
+the fallback is scoped only around history construction.
+
+## Proof
+
+The existing E2E startup-refusal table becomes a red→green availability table
+for representative rejected canonical inputs. Before the production change,
+the renamed test must fail because the proxy exits instead of becoming
+healthy. After the change it proves:
+
+- the real binary becomes healthy;
+- `/v1` remains available under the configured open API mode;
+- rejected canonical bytes are unchanged;
+- config bytes are unchanged; and
+- both empty canonical input and a future canonical version take the fallback.
+
+The existing `corrupt_or_future_store_refuses_to_start` E2E test independently
+proves config/auth fail-closed behavior remains intact. Focused history tests,
+`cargo fmt --check`, and `git diff --check` complete local proof.
+
+The ordinary #134 PR supplies Phase 0's natural route evidence. Its expected
+route is stable/presentation=false/coverage/docker: stable Rust checks,
+coverage, MSRV, Docker, and always-on security/cheap checks run; presentation
+steps in the successful `fmt, clippy, tests` job skip. Any mismatch pauses the
+issue train and reopens #164's repair loop.
+
+## Constraint
+
+No wire format, metric name, configuration field, canonical byte, knowledge
+page, or unrelated history behavior changes in #134. One issue, one task
+branch, one reviewed commit, and one PR target `release/v0.6.6`. PR #72 and
+`main` remain untouched.
+
+## Success criteria
+
+1. Representative canonical-open failures no longer prevent the real proxy
+   from becoming healthy or serving `/v1`.
+2. Rejected canonical and config bytes remain unchanged.
+3. Config/auth startup corruption remains fatal.
+4. No new machinery or wire field is added.
+5. The reviewed #134 PR merges into `release/v0.6.6` after its natural routed
+   CI evidence is accepted, allowing #164 to close.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -545,15 +545,22 @@ pub async fn run() {
 
     // Metrics history: finish indexing before the listener can report ready,
     // then sample the registry with contemporaneous pool capacity.
+    let history_capacity = capacity_snapshot(&pool.read().unwrap());
     let hist = match history::History::open(
         data_dir.clone(),
         stored.history.days,
-        capacity_snapshot(&pool.read().unwrap()),
+        history_capacity.clone(),
     ) {
         Ok(history) => Arc::new(history),
         Err(error) => {
-            eprintln!("\nnim-proxy cannot start: canonical history is unusable: {error}\n");
-            std::process::exit(1);
+            tracing::error!(
+                "canonical history unavailable: {error}; continuing with in-memory history"
+            );
+            Arc::new(history::History::load(
+                None,
+                stored.history.days,
+                history_capacity,
+            ))
         }
     };
     {

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -4352,10 +4352,10 @@ async fn corrupt_or_future_store_refuses_to_start() {
     expect_refuses_to_start(future).await;
 }
 
-/// Fatal canonical history classes stay fail-closed. Recoverable corruption
-/// is covered separately by `dashboard_history_reports_completeness`.
+/// Rejected canonical history degrades to in-memory history without changing
+/// the configured store or canonical bytes.
 #[tokio::test]
-async fn history_startup_is_fail_closed() {
+async fn history_startup_degrades_to_memory_without_mutating_canonical() {
     let mock = start_mock().await;
     for (name, contents) in [
         ("empty", b"".as_slice()),
@@ -4372,8 +4372,27 @@ async fn history_startup_is_fail_closed() {
         .unwrap();
         std::fs::write(data_dir.join("history-v1.jsonl"), contents).unwrap();
 
-        expect_refuses_to_start(data_dir).await;
-        eprintln!("history-startup:{name}: refused fatal canonical input");
+        let config_before = std::fs::read(data_dir.join("config.json")).unwrap();
+        let history_before = std::fs::read(data_dir.join("history-v1.jsonl")).unwrap();
+        let proxy = start_proxy_in(data_dir, &[("HISTORY_SAMPLE_SECS", "3600")]).await;
+        let response = client()
+            .post(proxy.url("/v1/chat/completions"))
+            .json(&chat_body(&format!("history startup {name}"), false))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200, "history-startup:{name}: /v1 remains available");
+        assert_eq!(
+            std::fs::read(proxy.data_dir.join("config.json")).unwrap(),
+            config_before,
+            "history-startup:{name}: config bytes remain unchanged"
+        );
+        assert_eq!(
+            std::fs::read(proxy.data_dir.join("history-v1.jsonl")).unwrap(),
+            history_before,
+            "history-startup:{name}: canonical bytes remain unchanged"
+        );
+        proxy.terminate();
     }
 }
 


### PR DESCRIPTION
Resolves #134 by degrading canonical-history open failure to the existing in-memory history path. Includes real-binary red-to-green and byte-preservation proof. Parent: #131.