### PR TITLE
fix(history): create canonical files owner-only

### DIFF
--- a/docs/superpowers/plans/2026-08-08-v0.6.6-issue-135-history-mode.md
+++ b/docs/superpowers/plans/2026-08-08-v0.6.6-issue-135-history-mode.md
@@ -1,0 +1,327 @@
+# v0.6.6 Issue #135 Canonical History Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create canonical history temporaries as owner-only files so first publication and compaction leave `history-v1.jsonl` at mode `0600`.
+
+**Architecture:** Keep `create_temporary` as the single creator and set its existing `OpenOptions` mode with the Unix standard-library extension before opening. Hard-link publication and rename preserve the mode; existing store and real-binary tests assert the invariant at both publication boundaries.
+
+**Tech Stack:** Rust `std::fs::OpenOptions`, Unix filesystem extensions, Tokio real-binary E2E tests, GitHub Actions, GitHub CLI
+
+## Global Constraints
+
+- Integration branch is `release/v0.6.6`; only PR #72 targets `main`.
+- Issue #135 owns canonical temporary/final file mode only; cleanup remains #136, timestamps remain #140, and persistence-health visibility remains #139.
+- Set `.mode(0o600)` under `#[cfg(unix)]` in the existing `create_temporary` builder using `std::os::unix::fs::OpenOptionsExt`.
+- Do not use chmod after publication/rename, umask manipulation, a new helper, a dependency, or any API/config/metric/format change.
+- Add only the three new Unix mode assertions: first publication, post-compaction replacement, and the canonical file in `setup_wizard_claims_the_proxy`; retain the existing `config.json` assertion.
+- Do not change cleanup behavior, timestamps, persistence-health behavior, canonical bytes, PR #72, or `main`.
+- The red phase adds all three assertions before production code; the green phase repeats the two named store tests and exact E2E, then runs the store module, formatting, whitespace, and changed-path checks.
+- Use one reviewed commit with message `fix(history): create canonical files owner-only`; commit only after independent precommit review.
+- Task 2 must report the exact reviewed SHA and exact four-file PR list. The natural route is `stable=true`, `presentation=false`, `coverage=true`, `docker=true`; do not add `ci:full` unless routing is wrong, and on mismatch pause and repair routing rather than merging.
+
+## File Responsibility Map
+
+- `src/history/store.rs` — set mode on the existing temporary creator.
+- `tests/e2e.rs` — assert the wizard-created canonical file is `0600` beside `config.json`.
+- `docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md` — record the approved #135 design boundary.
+- `docs/superpowers/plans/2026-08-08-v0.6.6-issue-135-history-mode.md` — this executable issue contract.
+- `.superpowers/sdd/2026-08-08-v0.6.6-issue-135-history-mode/design-plan-report.md` — local authoring evidence; do not include it in the implementation PR file list.
+
+---
+
+### Task 1: Make canonical history creation owner-only
+
+**Files:**
+
+- Modify: `src/history/store.rs:795-807`
+- Modify: `src/history/store.rs:1715-1740`
+- Modify: `src/history/store.rs:2710-2788`
+- Modify: `tests/e2e.rs:4572-4592`
+- Include in the reviewed commit: `docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md` and this plan
+
+**Outcome:** Both first-publication and compaction-created canonical files are `0600` on Unix, with the real wizard path proving the shipped file and config store agree.
+
+**Proof:** The three new assertions fail before the builder change and pass after it; the focused store tests, exact E2E, full store module, format, whitespace, and changed-path checks pass.
+
+**Constraint:** Do not alter the publication protocol, canonical records, error handling, cleanup, or any issue boundary outside #135.
+
+**Ponytail Rung:** Rung 2 updates the existing creator and existing tests; Rung 3 uses `OpenOptionsExt` and `PermissionsExt` from the standard library.
+
+**Interfaces:** Produces one reviewed commit, `fix(history): create canonical files owner-only`, for Task 2. The local SDD report is evidence only and is not committed.
+
+- [ ] **Step 1: Add all three failing Unix assertions before production code**
+
+In `first_open_publishes_one_synced_canonical_boot_record`, after the existing
+canonical decode/assertions and before cleanup, add:
+
+~~~rust
+#[cfg(unix)]
+{
+    use std::os::unix::fs::PermissionsExt;
+    let mode = fs::metadata(dir.join("history-v1.jsonl"))
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(mode, 0o600, "first publication must create history-v1.jsonl as 0600");
+}
+~~~
+
+In `compaction_restart_rollup_and_subsequent_append_use_the_replacement_inode`,
+immediately after the successful `store.compact(13)` assertion and before the
+existing inode block, add:
+
+~~~rust
+#[cfg(unix)]
+{
+    use std::os::unix::fs::PermissionsExt;
+    let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600, "compaction replacement must preserve history-v1.jsonl mode");
+}
+~~~
+
+In `setup_wizard_claims_the_proxy`, retain the existing `config.json` mode
+assertion and add this canonical assertion immediately after it:
+
+~~~rust
+#[cfg(unix)]
+{
+    use std::os::unix::fs::PermissionsExt;
+    let history_mode = std::fs::metadata(proxy.data_dir.join("history-v1.jsonl"))
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(history_mode, 0o600, "canonical history file must be 0600");
+}
+~~~
+
+These are the three new mode assertions. Do not modify production code before
+running the red commands in the next step.
+
+- [ ] **Step 2: Run RED and record the mode failures**
+
+Run exactly:
+
+~~~bash
+cargo test history::store::tests::first_open_publishes_one_synced_canonical_boot_record --lib
+cargo test history::store::tests::compaction_restart_rollup_and_subsequent_append_use_the_replacement_inode --lib
+cargo test --test e2e setup_wizard_claims_the_proxy -- --exact
+~~~
+
+Expected: the first-open, compaction, and wizard canonical-mode assertions
+fail because the current temporary creator does not request `0600` (normally
+the files are `0644` under `umask 022`). Preserve the failure output in the
+task evidence before editing `src/history/store.rs`.
+
+- [ ] **Step 3: Implement the minimum Unix creation-mode change**
+
+Replace the direct `OpenOptions::new()...open(&path)` expression in
+`create_temporary` with this shape, preserving the collision loop and all
+existing failure injection:
+
+~~~rust
+let mut options = OpenOptions::new();
+options.append(true).create_new(true);
+#[cfg(unix)]
+{
+    use std::os::unix::fs::OpenOptionsExt;
+    options.mode(0o600);
+}
+match options.open(&path) {
+    Ok(file) => return Ok((path, file)),
+    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+    Err(error) => return Err(error),
+}
+~~~
+
+Do not add chmod, change the umask, reopen the file, add a helper/dependency,
+or touch any other creator.
+
+- [ ] **Step 4: Run GREEN and the required local proof**
+
+Run exactly:
+
+~~~bash
+cargo test history::store::tests::first_open_publishes_one_synced_canonical_boot_record --lib
+cargo test history::store::tests::compaction_restart_rollup_and_subsequent_append_use_the_replacement_inode --lib
+cargo test --test e2e setup_wizard_claims_the_proxy -- --exact
+cargo test history::store::tests --lib
+cargo fmt --check
+git diff --check
+git diff --name-only
+~~~
+
+Expected: all tests pass and the format/whitespace checks are clean. The
+changed-path command is diagnostic before staging: the modified tracked spec
+appears in `git diff --name-only`, while this newly created plan and the local
+SDD report remain untracked until the commit step; Task 1 Step 5 freezes the
+exact four-file list.
+
+- [ ] **Step 5: Freeze, independently review, and commit**
+
+Have a fresh-context reviewer inspect the issue, design section, red→green
+evidence, exact three new assertions, Unix gating, hard-link/rename scope,
+rejected alternatives, and complete four-file diff. Repair Critical or
+Important findings before committing. After PASS, verify and commit exactly:
+
+~~~bash
+git diff --check
+git diff --name-only
+git add src/history/store.rs tests/e2e.rs \
+  docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md \
+  docs/superpowers/plans/2026-08-08-v0.6.6-issue-135-history-mode.md
+git diff --cached --check
+git commit -m "fix(history): create canonical files owner-only"
+git show --check --stat --oneline HEAD
+~~~
+
+Record the committed SHA and the red/green commands for Task 2. Do not stage
+or commit the local SDD report.
+
+---
+
+### Task 2: Publish, prove the natural route, and integrate #135
+
+**Files:** Publish the reviewed branch and update GitHub issue #135 and parent #131; preserve PR #72 and `main`.
+
+**Outcome:** One non-draft PR containing exactly the reviewed four files merges into `release/v0.6.6`, closes #135, and records the result on #131.
+
+**Proof:** Local, remote, PR, CI, CodeQL, and post-merge heads agree; the routed jobs and skipped presentation steps are verified on the reviewed SHA; guarded merge and ancestry checks pass.
+
+**Constraint:** Do not target `main`, touch PR #72, merge a different SHA, merge on a route mismatch, or add `ci:full` unless the natural routing itself is wrong. A mismatch pauses the work and repairs the routing issue before any merge.
+
+**Ponytail Rung:** Rung 2 uses the existing issue, branch, PR, CI, CodeQL, and issue-parent surfaces; Rung 4 uses native job conclusions and `--match-head-commit`.
+
+**Interfaces:** Consumes Task 1's reviewed commit and produces the merged issue PR plus issue #135/#131 evidence.
+
+- [ ] **Step 1: Push the reviewed SHA and create the ready PR**
+
+Run from the clean Task 1 worktree:
+
+~~~bash
+set -euo pipefail
+reviewed_head=$(git rev-parse HEAD)
+test "$(git status --porcelain)" = ""
+git push -u origin work/v0.6.6-135-history-mode
+remote_head=$(git ls-remote origin refs/heads/work/v0.6.6-135-history-mode | cut -f1)
+test "$remote_head" = "$reviewed_head"
+expected_files=$(printf '%s\n' \
+  docs/superpowers/plans/2026-08-08-v0.6.6-issue-135-history-mode.md \
+  docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md \
+  src/history/store.rs \
+  tests/e2e.rs | sort)
+actual_files=$(git diff-tree --no-commit-id --name-only -r "$reviewed_head" | sort)
+test "$actual_files" = "$expected_files"
+issue_pr_url=$(gh pr create --repo miztertea/nim-proxy \
+  --base release/v0.6.6 \
+  --head work/v0.6.6-135-history-mode \
+  --title "fix(history): create canonical files owner-only" \
+  --body "Resolves #135. Creates canonical history temporaries as 0600 so first publication and compaction preserve owner-only mode. Parent: #131.")
+test -n "$issue_pr_url"
+pr_view=$(gh pr view "$issue_pr_url" --repo miztertea/nim-proxy \
+  --json url,state,isDraft,baseRefName,headRefName,headRefOid,files)
+test "$(jq -r .state <<<"$pr_view")" = OPEN
+test "$(jq -r .isDraft <<<"$pr_view")" = false
+test "$(jq -r .baseRefName <<<"$pr_view")" = release/v0.6.6
+test "$(jq -r .headRefName <<<"$pr_view")" = work/v0.6.6-135-history-mode
+test "$(jq -r .headRefOid <<<"$pr_view")" = "$reviewed_head"
+pr_files=$(jq -r '.files[].path' <<<"$pr_view" | sort)
+test "$pr_files" = "$expected_files"
+~~~
+
+Require an open, ready (non-draft) PR into `release/v0.6.6`, head SHA exactly
+`$reviewed_head`, and exactly the four paths in `$expected_files`.
+
+- [ ] **Step 2: Verify natural CI routing and CodeQL on the reviewed SHA**
+
+Use only the pull-request runs for the pushed SHA and do not apply `ci:full`:
+
+~~~bash
+set -euo pipefail
+reviewed_head=$(git rev-parse HEAD)
+runs=$(gh api "repos/miztertea/nim-proxy/actions/runs?event=pull_request&head_sha=$reviewed_head&per_page=100")
+ci_run_id=$(jq -r '[.workflow_runs[] | select(.path == ".github/workflows/ci.yml")] | sort_by(.created_at) | last.id // empty' <<<"$runs")
+codeql_run_id=$(jq -r '[.workflow_runs[] | select(.path == ".github/workflows/codeql.yml")] | sort_by(.created_at) | last.id // empty' <<<"$runs")
+test -n "$ci_run_id"
+test -n "$codeql_run_id"
+gh run watch "$ci_run_id" --repo miztertea/nim-proxy --exit-status
+gh run watch "$codeql_run_id" --repo miztertea/nim-proxy --exit-status
+ci_view=$(gh run view "$ci_run_id" --repo miztertea/nim-proxy --json event,headSha,conclusion,jobs)
+codeql_view=$(gh run view "$codeql_run_id" --repo miztertea/nim-proxy --json event,headSha,conclusion,jobs)
+test "$(jq -r .event <<<"$ci_view")" = pull_request
+test "$(jq -r .headSha <<<"$ci_view")" = "$reviewed_head"
+test "$(jq -r .conclusion <<<"$ci_view")" = success
+test "$(jq -r .headSha <<<"$codeql_view")" = "$reviewed_head"
+test "$(jq -r .conclusion <<<"$codeql_view")" = success
+for job in 'change routing' 'fmt, clippy, tests' coverage msrv cargo-deny \
+  gitleaks 'workflow lint' 'dependency review' 'docker build'; do
+  jq -e --arg job "$job" '.jobs[] | select(.name == $job and .conclusion == "success")' \
+    <<<"$ci_view" >/dev/null
+done
+jq -e '.jobs[] | select(.name == "codeql (rust)" and .conclusion == "success")' \
+  <<<"$codeql_view" >/dev/null
+ci_log=$(gh run view "$ci_run_id" --repo miztertea/nim-proxy --log)
+for route in 'Filter stable = true' 'Filter presentation = false' \
+  'Filter coverage = true' 'Filter docker = true'; do
+  rg -F -q "$route" <<<"$ci_log"
+done
+check_steps=$(jq -c '.jobs[] | select(.name == "fmt, clippy, tests") | .steps' <<<"$ci_view")
+for step in 'Embedded presentation source boundaries and JS syntax' \
+  'Formatter output is unchanged' 'i18n lint self-test' \
+  'i18n catalog and untagged-string lint' 'locale-v1 self-test' \
+  'locale-v1 validation' 'Pseudolocale is current' \
+  'Dashboard renders and survives being driven'; do
+  jq -e --arg step "$step" '.[] | select(.name == $step and .conclusion == "skipped")' \
+    <<<"$check_steps" >/dev/null
+done
+~~~
+
+Require `stable=true`, `presentation=false`, `coverage=true`, and `docker=true`,
+successful stable/coverage/MSRV/security/quality/Docker jobs, successful
+`codeql (rust)` on the same SHA, and skipped presentation steps. If any route,
+job, step, event, or SHA differs, pause; repair the routing issue and rerun
+the evidence rather than merging.
+
+- [ ] **Step 3: Independently review evidence and merge with a head guard**
+
+An independent reviewer checks the frozen four-file diff, exact SHA/file list,
+red→green evidence, PR metadata, route log, job/step conclusions, CodeQL, and
+the no-`ci:full` decision. After PASS, run from a fresh shell:
+
+~~~bash
+set -euo pipefail
+reviewed_head=$(git rev-parse HEAD)
+issue_pr_url=$(gh pr list --repo miztertea/nim-proxy --state open \
+  --base release/v0.6.6 --head work/v0.6.6-135-history-mode \
+  --json url --jq '.[0].url')
+test -n "$issue_pr_url"
+pr_head=$(gh pr view "$issue_pr_url" --repo miztertea/nim-proxy --json headRefOid --jq .headRefOid)
+remote_head=$(git ls-remote origin refs/heads/work/v0.6.6-135-history-mode | cut -f1)
+test "$pr_head" = "$reviewed_head"
+test "$remote_head" = "$reviewed_head"
+gh pr merge "$issue_pr_url" --repo miztertea/nim-proxy \
+  --merge --match-head-commit "$reviewed_head"
+git fetch origin --prune
+git merge-base --is-ancestor "$reviewed_head" origin/release/v0.6.6
+~~~
+
+- [ ] **Step 4: Close #135 and record the parent update**
+
+After the guarded merge and ancestry proof, record the exact PR, commit, test,
+route, CodeQL, and merge links:
+
+~~~bash
+gh issue close 135 --repo miztertea/nim-proxy --reason completed \
+  --comment "Implemented and merged via $issue_pr_url at $reviewed_head. Red/green store and E2E mode proofs, natural stable/presentation=false/coverage/docker route, CodeQL, and guarded integration passed."
+gh issue comment 131 --repo miztertea/nim-proxy \
+  --body "#135 complete: $issue_pr_url merged at $reviewed_head. Canonical history first publication and compaction now preserve 0600; focused tests, natural routed CI, and CodeQL passed. PR #72 and main remain untouched."
+~~~
+
+## Plan Self-Review
+
+- Spec coverage: creator mode, both publication paths, three Unix assertions, rejected alternatives, unchanged failure/cleanup boundaries, red→green proof, exact local commands, review/commit, natural route, CodeQL, guarded merge, and issue updates are covered.
+- Placeholder scan: no TBD, TODO, or unspecified implementation/test step remains.
+- Scope scan: only #135 mode work is assigned; #136, #140, and #139 remain explicitly excluded.
+- Interface consistency: Task 1 produces the exact four-file reviewed commit and SHA that Task 2 verifies, publishes, and merges.

--- a/docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md
+++ b/docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md
@@ -134,3 +134,63 @@ branch, one reviewed commit, and one PR target `release/v0.6.6`. PR #72 and
 4. No new machinery or wire field is added.
 5. The reviewed #134 PR merges into `release/v0.6.6` after its natural routed
    CI evidence is accepted, allowing #164 to close.
+
+## #135 canonical file mode
+
+### Outcome
+
+The canonical `data/history-v1.jsonl` file is owner-only (`0600`) immediately
+when it is created, both on first boot publication and on compaction
+replacement, matching the existing `config.json` protection.
+
+### Selected approach
+
+`create_temporary` is the sole creator for both first-publication and
+compaction temporaries. Build its existing `OpenOptions` with
+`OpenOptionsExt::mode(0o600)` under `#[cfg(unix)]`, before `create_new(true)`
+opens the path. Hard-link publication and atomic rename preserve that mode, so
+the canonical path stays owner-only through both creation routes and later
+appends without a post-publication permission window.
+
+### Rejected alternatives
+
+- `chmod` after hard-link or rename leaves a race window and duplicates the
+  invariant across publication paths.
+- Umask manipulation changes process-wide behavior and is not a file-level
+  guarantee.
+- A new helper, dependency, API/config/format field, or cleanup behavior adds
+  machinery outside this one creator and its existing tests. Cleanup remains
+  #136; timestamps remain #140; persistence-health visibility remains #139.
+
+### Failure handling
+
+Mode selection is part of temporary creation; an open failure follows the
+existing error path and no best-effort chmod is attempted. Existing write,
+flush, sync, hard-link, rename, directory-sync, stale-temporary, and recovery
+semantics remain unchanged. A failed temporary may remain opaque evidence under
+the existing #136 boundary; this issue neither removes nor repairs it.
+
+### Proof
+
+The red phase adds Unix `PermissionsExt` assertions to the existing first-open
+and compaction-replacement store tests and adds the canonical-file assertion to
+the real-binary `setup_wizard_claims_the_proxy` check beside its `config.json`
+assertion. Those three new assertions fail against the current `0644` creator
+under the normal `umask 022`; the same tests pass after the builder change.
+The store test module, formatting, whitespace, and changed-path checks provide
+focused local proof, while the natural stable/presentation/coverage/docker
+route and CodeQL provide PR proof.
+
+### Constraints
+
+Change only `src/history/store.rs`, its existing store tests, and the named E2E
+permission assertion plus this workstream spec and its issue plan. Do not alter
+canonical bytes, config/API/metrics, dependencies, cleanup, timestamps,
+persistence-health state, branch/PR #72, or `main`. Use one reviewed commit
+targeting `release/v0.6.6`.
+
+### Ponytail rungs
+
+**Rung 2:** update the existing temporary creator and the existing publication,
+compaction, and wizard tests. **Rung 3:** use the standard-library Unix
+`OpenOptionsExt` and `PermissionsExt` extensions; no new machinery is needed.

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -800,7 +800,14 @@ fn create_temporary(
     for _ in 0..32 {
         let path = directory.join(format!("{TEMP_PREFIX}{}", new_boot_id()));
         fail(failure, failure_point)?;
-        match OpenOptions::new().append(true).create_new(true).open(&path) {
+        let mut options = OpenOptions::new();
+        options.append(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        match options.open(&path) {
             Ok(file) => return Ok((path, file)),
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
             Err(error) => return Err(error),
@@ -1736,6 +1743,19 @@ mod tests {
         assert_eq!(boot.capacity, capacity());
         assert!(!boot.boot_id.is_empty(), "store owns a fresh boot id");
         assert!(!dir.join("history.jsonl").exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(dir.join("history-v1.jsonl"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(
+                mode, 0o600,
+                "first publication must create history-v1.jsonl as 0600"
+            );
+        }
         let _ = fs::remove_dir_all(dir);
     }
 
@@ -2734,6 +2754,15 @@ mod tests {
             store.compact(13).unwrap(),
             CompactionOutcome::Durable
         ));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(
+                mode, 0o600,
+                "compaction replacement must preserve history-v1.jsonl mode"
+            );
+        }
         #[cfg(unix)]
         let replacement_inode = {
             use std::os::unix::fs::MetadataExt;

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -4590,6 +4590,17 @@ async fn setup_wizard_claims_the_proxy() {
         & 0o777;
     assert_eq!(mode, 0o600, "config store must be 0600");
 
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let history_mode = std::fs::metadata(proxy.data_dir.join("history-v1.jsonl"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(history_mode, 0o600, "canonical history file must be 0600");
+    }
+
     // The wizard is gone once the proxy is claimed.
     assert_eq!(
         client()


### PR DESCRIPTION
Resolves #135. Creates canonical history temporaries as 0600 so first publication and compaction preserve owner-only mode. Parent: #131.