### PR TITLE
fix(history): clean failed compaction temporaries

### DIFF
--- a/docs/superpowers/plans/2026-08-08-v0.6.6-issue-136-compaction-temp-cleanup.md
+++ b/docs/superpowers/plans/2026-08-08-v0.6.6-issue-136-compaction-temp-cleanup.md
@@ -1,0 +1,331 @@
+# v0.6.6 Issue #136 Failed-Compaction Temporary Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the unique temporary created by a failed pre-rename canonical compaction while preserving the old canonical bytes and all existing outcomes.
+
+**Architecture:** Keep the existing compact_inner_if_authorized protocol and unique same-directory temporary. Wrap its fallible pre-rename work in standard Result/closure control flow; on an error, drop the output handle and best-effort remove that attempt's path before returning the original error. Keep startup stale-temporary evidence opaque and untouched.
+
+**Tech Stack:** Rust std::result::Result, std::fs, existing HistoryStore unit-test failure injection, GitHub Actions, GitHub CLI
+
+## Global Constraints
+
+- Integration branch is release/v0.6.6; only PR #72 targets main.
+- Issue #136 owns cleanup only for the unique temporary created by the current compaction attempt before rename commits; #139 owns visibility/status and #140 owns timestamps.
+- On every pre-rename error, the closure exits, the open output handle is dropped, fs::remove_file(&temporary) is best-effort, and the original error is returned.
+- Preserve canonical old bytes, the existing Superseded cleanup/outcome, successful rename behavior, and CommittedSyncPending after directory-sync failure.
+- Keep startup stale_temporary_count warning/opaque evidence policy unchanged; do not sweep unknown or pre-existing stale temporaries.
+- Do not add a guard type, fixed-name reuse, forensic retention, failure switch, helper, dependency, startup sweep, E2E/API/status/metric change, or canonical-format/byte change.
+- Production and test code changes are confined to src/history/store.rs.
+- The red check is the existing compaction_crash_points_leave_only_old_or_complete_new_canonical_bytes; assert stale_temporary_count(&dir) == 0 after every pre-commit failure.
+- Use one reviewed commit with exact message fix(history): clean failed compaction temporaries.
+- The SDD controller creates this plan's workspace before task dispatch at .superpowers/sdd/2026-08-08-v0.6.6-issue-136-compaction-temp-cleanup; preserve its report and progress ledger with the self-ignoring .superpowers/sdd/.gitignore without modifying tracked ignore files.
+- Before either status gate, test -f .superpowers/sdd/.gitignore, assert its exact content is *, and prove the named SDD report and ledger paths are ignored with git check-ignore -q; Task 1 status therefore contains only the three product/doc paths, and Task 2's clean git status is satisfiable after the reviewed commit.
+- The PR contains exactly the spec, this plan, and src/history/store.rs; the local SDD report and progress ledger are ignored evidence only and are not committed or included.
+- The natural CI route must report stable=true, presentation=false, coverage=true, and docker=true; do not add ci:full unless routing is wrong.
+
+## File Responsibility Map
+
+- src/history/store.rs — clean the current compaction temporary on every pre-rename error and extend the existing crash-point assertion.
+- docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md — record the approved #136 outcome, flow, boundaries, proof, and Ponytail rungs.
+- docs/superpowers/plans/2026-08-08-v0.6.6-issue-136-compaction-temp-cleanup.md — this executable issue contract.
+- .superpowers/sdd/2026-08-08-v0.6.6-issue-136-compaction-temp-cleanup/design-plan-report.md and progress.md — authoring report and SDD progress ledger, created/kept by the SDD controller, ignored evidence only; never stage either.
+
+---
+
+### Task 1: Clean failed compaction temporaries with TDD
+
+**Files:**
+
+- Modify: src/history/store.rs:332-410 (compact_inner_if_authorized)
+- Modify: src/history/store.rs:1078-1085 (test imports) and src/history/store.rs:2644-2700 (existing crash-point test)
+- Include in the reviewed commit: docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md and this plan
+
+**Outcome:** Every injected pre-rename compaction failure leaves zero temporary files from the current attempt, while the canonical path remains byte-for-byte old evidence and directory-sync failure remains post-rename CommittedSyncPending.
+
+**Proof:** The named crash-point test fails RED at the first leaking point with a stale count of one, then passes GREEN for all existing pre-commit points; the store module, format, whitespace, and changed-path checks pass.
+
+**Constraint:** Do not change the retention selection, validation rules, authorization semantics, rename protocol, directory-sync outcome, startup stale-file policy, or any file outside src/history/store.rs plus the two committed docs.
+
+**Ponytail Rung:** Rung 2 reuses the existing compaction flow, failure test, and stale_temporary_count; Rung 3 uses standard Rust Result/closure control flow and existing filesystem calls.
+
+**Interfaces:** Produces the exact reviewed commit fix(history): clean failed compaction temporaries for Task 2. The SDD report remains untracked evidence.
+
+- [ ] **Step 1: Add the RED assertion before changing production flow**
+
+Import stale_temporary_count in the existing tests module. In the existing
+pre-commit for point in [...] loop, immediately after validate_canonical(&path)
+.unwrap() and before directory cleanup, add:
+
+~~~
+assert_eq!(
+    stale_temporary_count(&dir).unwrap(),
+    0,
+    "{point:?}: failed compaction must remove its attempt temporary"
+);
+~~~
+
+Do not add a failure point, helper, or new test. Keep the separate
+CompactionDirectorySync case unchanged because rename already committed.
+
+- [ ] **Step 2: Run the named crash-point test and capture RED**
+
+Run:
+
+~~~
+cargo test history::store::tests::compaction_crash_points_leave_only_old_or_complete_new_canonical_bytes --lib
+~~~
+
+Expected: FAIL at the first leaking pre-rename point (normally
+CompactionTempWrite) because the count is 1; the assertion must identify the
+failure point. Preserve this output as Task 1 evidence before editing the
+production function.
+
+- [ ] **Step 3: Implement minimal closure-scoped cleanup**
+
+In compact_inner_if_authorized, retain the existing temporary creation and
+all retained-record writes. Keep the outer ownership exact:
+
+~~~rust
+let (temporary, mut output) = create_temporary(
+    &directory,
+    &mut failure,
+    FailurePoint::CompactionTempCreate,
+)?;
+let prepared = (|| -> io::Result<Option<(T, Replay)>> {
+    for record in &retained {
+        write_record(
+            &mut output,
+            record,
+            failure.as_deref_mut(),
+            Some(FailurePoint::CompactionTempWrite),
+        )
+        .map_err(write_error_to_io)?;
+    }
+    output.flush()?;
+    fail(&mut failure, FailurePoint::CompactionTempSync)?;
+    output.sync_all()?;
+    let replacement_replay = validate_canonical(&temporary).map_err(open_error_to_io)?;
+    if replacement_replay.records != retained
+        || !replacement_replay.gaps.is_empty()
+        || replacement_replay.needs_separator
+        || replacement_replay.diagnostics.excluded_epochs != 0
+        || replacement_replay.diagnostics.excluded_records != 0
+    {
+        return Err(io::Error::other(
+            "compaction replacement does not exactly validate as retained canonical history",
+        ));
+    }
+    let Some(authorization) = authorize() else { return Ok(None) };
+    fail(&mut failure, FailurePoint::CompactionRename)?;
+    fs::rename(&temporary, &self.path)?;
+    Ok(Some((authorization, replacement_replay)))
+})();
+let (authorization, replacement_replay) = match prepared {
+    Err(error) => {
+        drop(output);
+        let _ = fs::remove_file(&temporary);
+        return Err(error);
+    }
+    Ok(None) => {
+        drop(output);
+        let _ = fs::remove_file(&temporary);
+        return Ok(CompactionOutcome::Superseded);
+    }
+    Ok(Some((authorization, replacement_replay))) => (authorization, replacement_replay),
+};
+drop(authorization);
+self.file = output;
+// Existing replay/state updates and unchanged directory-sync match follow.
+~~~
+
+The snippet fixes ownership and control flow; retain the existing validation
+condition and write_error_to_io mapping in the closure. The closure returns
+io::Result<Option<(T, Replay)>>: every pre-rename Err is handled outside by
+dropping output, best-effort unlinking temporary, and returning the original
+error; Ok(None) uses the same outer cleanup then returns Superseded; only
+Ok(Some((authorization, replacement_replay))) follows successful rename. Drop
+authorization, install the still-open outer output, update state, and enter the
+unchanged directory-sync match. Do not move output into the closure, and do not
+remove the temporary after successful rename; that path no longer exists.
+
+- [ ] **Step 4: Run GREEN and all required local proof**
+
+Run exactly:
+
+~~~
+cargo test history::store::tests::compaction_crash_points_leave_only_old_or_complete_new_canonical_bytes --lib
+cargo test history::store::tests --lib
+cargo fmt --check
+git diff --check
+sdd_workspace=".superpowers/sdd/2026-08-08-v0.6.6-issue-136-compaction-temp-cleanup"
+test -f .superpowers/sdd/.gitignore
+test "$(cat .superpowers/sdd/.gitignore)" = '*'
+git check-ignore -q "$sdd_workspace/design-plan-report.md"
+git check-ignore -q "$sdd_workspace/progress.md"
+git diff --name-only
+git status --short
+~~~
+
+Expected: the named test and complete store module pass, formatting and
+whitespace checks are clean, both SDD evidence paths are ignored by the
+self-ignoring workspace, and changed-path/status output contains only the
+spec, plan, and src/history/store.rs. The report and progress ledger are
+ignored evidence, not implementation paths.
+
+- [ ] **Step 5: Obtain independent precommit review and commit exactly once**
+
+Have an independent reviewer inspect the issue, appended spec section, red and
+green output, closure error paths (write/flush/sync/validation/authorization/
+rename), original-error preservation, Superseded and directory-sync behavior,
+stale-count assertion, and exact three-file implementation scope. Repair every
+Critical or Important finding and rerun Step 4. After review PASS, run:
+
+~~~
+set -euo pipefail
+git diff --check
+git add src/history/store.rs \
+  docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md \
+  docs/superpowers/plans/2026-08-08-v0.6.6-issue-136-compaction-temp-cleanup.md
+git diff --cached --check
+git diff --cached --name-only
+test "$(git diff --cached --name-only | sort)" = "$(printf '%s\n' \
+  docs/superpowers/plans/2026-08-08-v0.6.6-issue-136-compaction-temp-cleanup.md \
+  docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md \
+  src/history/store.rs | sort)"
+git commit -m "fix(history): clean failed compaction temporaries"
+git show --check --stat --oneline HEAD
+~~~
+
+Record the exact commit SHA and the red/green evidence for Task 2. Do not
+stage the SDD report.
+
+---
+
+### Task 2: Publish, prove routed CI, and integrate #136
+
+**Files:** Publish the reviewed branch and update GitHub issue #136 and parent #131; preserve PR #72 and main.
+
+**Outcome:** One ready PR containing exactly the reviewed three files merges into release/v0.6.6, closes #136, and records the exact evidence on #131.
+
+**Proof:** Local commit, remote branch, PR metadata/file list, natural route log, required CI jobs, CodeQL, independent review, guarded merge, and post-merge ancestry all agree on one SHA.
+
+**Constraint:** Use --match-head-commit; never target main, alter PR #72, merge a different head, sweep stale files, or add ci:full when the natural route matches. If routing is wrong, pause and repair routing before merge.
+
+**Ponytail Rung:** Rung 2 reuses the existing issue, PR, CI, CodeQL, and parent-issue surfaces; native GitHub checks and --match-head-commit supply the required integration guard.
+
+**Interfaces:** Consumes Task 1's exact reviewed SHA and produces the merged PR plus #136/#131 evidence.
+
+- [ ] **Step 1: Push the reviewed SHA and create a ready PR with an exact file guard**
+
+From the clean worktree, run:
+
+~~~
+set -euo pipefail
+reviewed_head=$(git rev-parse HEAD)
+sdd_workspace=".superpowers/sdd/2026-08-08-v0.6.6-issue-136-compaction-temp-cleanup"
+test -f .superpowers/sdd/.gitignore
+test "$(cat .superpowers/sdd/.gitignore)" = '*'
+git check-ignore -q "$sdd_workspace/design-plan-report.md"
+git check-ignore -q "$sdd_workspace/progress.md"
+test "$(git status --porcelain)" = ""
+git push -u origin work/v0.6.6-136-compaction-temp-cleanup
+remote_head=$(git ls-remote origin refs/heads/work/v0.6.6-136-compaction-temp-cleanup | cut -f1)
+test "$remote_head" = "$reviewed_head"
+expected_files=$(printf '%s\n' \
+  docs/superpowers/plans/2026-08-08-v0.6.6-issue-136-compaction-temp-cleanup.md \
+  docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md \
+  src/history/store.rs | sort)
+actual_files=$(git diff-tree --no-commit-id --name-only -r "$reviewed_head" | sort)
+test "$actual_files" = "$expected_files"
+issue_pr_url=$(gh pr create --repo miztertea/nim-proxy \
+  --base release/v0.6.6 --head work/v0.6.6-136-compaction-temp-cleanup \
+  --title "fix(history): clean failed compaction temporaries" \
+  --body "Resolves #136. Failed compactions clean their own pre-rename temporary while preserving old canonical bytes. Parent: #131.")
+test -n "$issue_pr_url"
+pr_view=$(gh pr view "$issue_pr_url" --repo miztertea/nim-proxy \
+  --json url,state,isDraft,baseRefName,headRefName,headRefOid,files)
+test "$(jq -r .state <<<"$pr_view")" = OPEN
+test "$(jq -r .isDraft <<<"$pr_view")" = false
+test "$(jq -r .baseRefName <<<"$pr_view")" = release/v0.6.6
+test "$(jq -r .headRefName <<<"$pr_view")" = work/v0.6.6-136-compaction-temp-cleanup
+test "$(jq -r .headRefOid <<<"$pr_view")" = "$reviewed_head"
+test "$(jq -r '.files[].path' <<<"$pr_view" | sort)" = "$expected_files"
+~~~
+
+- [ ] **Step 2: Verify natural CI and CodeQL on the reviewed SHA**
+
+Run exactly:
+
+~~~
+set -euo pipefail
+reviewed_head=$(git rev-parse HEAD)
+ci_run_id=""
+codeql_run_id=""
+for attempt in $(seq 1 60); do
+  runs=$(gh api "repos/miztertea/nim-proxy/actions/runs?per_page=100")
+  ci_run_id=$(jq -r --arg head "$reviewed_head" '[.workflow_runs[] | select(.event == "pull_request" and .head_sha == $head and .path == ".github/workflows/ci.yml")] | sort_by(.created_at) | last.id // empty' <<<"$runs")
+  codeql_run_id=$(jq -r --arg head "$reviewed_head" '[.workflow_runs[] | select(.event == "pull_request" and .head_sha == $head and .path == ".github/workflows/codeql.yml")] | sort_by(.created_at) | last.id // empty' <<<"$runs")
+  test -n "$ci_run_id" && test -n "$codeql_run_id" && break
+  sleep 5
+done
+test -n "$ci_run_id" && test -n "$codeql_run_id"
+gh run watch "$ci_run_id" --repo miztertea/nim-proxy --exit-status
+gh run watch "$codeql_run_id" --repo miztertea/nim-proxy --exit-status
+ci_view=$(gh run view "$ci_run_id" --repo miztertea/nim-proxy --json event,headSha,conclusion,jobs)
+codeql_view=$(gh run view "$codeql_run_id" --repo miztertea/nim-proxy --json event,headSha,conclusion,jobs)
+test "$(jq -r .event <<<"$ci_view")" = pull_request && test "$(jq -r .headSha <<<"$ci_view")" = "$reviewed_head" && test "$(jq -r .conclusion <<<"$ci_view")" = success
+test "$(jq -r .event <<<"$codeql_view")" = pull_request && test "$(jq -r .headSha <<<"$codeql_view")" = "$reviewed_head" && test "$(jq -r .conclusion <<<"$codeql_view")" = success
+for job in 'change routing' 'fmt, clippy, tests' coverage msrv cargo-deny gitleaks 'workflow lint' 'dependency review' 'docker build'; do jq -e --arg job "$job" '.jobs[] | select(.name == $job and .conclusion == "success")' <<<"$ci_view" >/dev/null; done
+jq -e '.jobs[] | select(.name == "codeql (rust)" and .conclusion == "success")' <<<"$codeql_view" >/dev/null
+ci_log=$(gh run view "$ci_run_id" --repo miztertea/nim-proxy --log)
+for route in 'Filter stable = true' 'Filter presentation = false' 'Filter coverage = true' 'Filter docker = true'; do rg -F -q "$route" <<<"$ci_log"; done
+check_steps=$(jq -c '.jobs[] | select(.name == "fmt, clippy, tests") | .steps' <<<"$ci_view")
+for step in 'Embedded presentation source boundaries and JS syntax' 'Formatter output is unchanged' 'i18n lint self-test' 'i18n catalog and untagged-string lint' 'locale-v1 self-test' 'locale-v1 validation' 'Pseudolocale is current' 'Dashboard renders and survives being driven'; do jq -e --arg step "$step" '.[] | select(.name == $step and .conclusion == "skipped")' <<<"$check_steps" >/dev/null; done
+~~~
+
+Verify presentation steps are skipped in the fmt/clippy/tests job. Do not
+apply ci:full; a route mismatch pauses this task for routing repair and a fresh
+evidence run.
+
+- [ ] **Step 3: Combine independent evidence/final review and guarded-merge**
+
+An independent reviewer may combine the final implementation review with the
+evidence review after checking the exact three-file diff, red/green output,
+issue/PR metadata, reviewed SHA, route booleans, CI conclusions, CodeQL, and
+no-ci:full decision. Then run:
+
+~~~
+set -euo pipefail
+reviewed_head=$(git rev-parse HEAD)
+issue_pr_url=$(gh pr list --repo miztertea/nim-proxy --state open \
+  --base release/v0.6.6 --head work/v0.6.6-136-compaction-temp-cleanup \
+  --json url --jq '.[0].url')
+pr_head=$(gh pr view "$issue_pr_url" --repo miztertea/nim-proxy --json headRefOid --jq .headRefOid)
+remote_head=$(git ls-remote origin refs/heads/work/v0.6.6-136-compaction-temp-cleanup | cut -f1)
+test "$pr_head" = "$reviewed_head"
+test "$remote_head" = "$reviewed_head"
+test "$(gh pr view 72 --repo miztertea/nim-proxy --json baseRefName --jq .baseRefName)" = main
+gh pr merge "$issue_pr_url" --repo miztertea/nim-proxy --merge --match-head-commit "$reviewed_head"
+git fetch origin --prune
+git merge-base --is-ancestor "$reviewed_head" origin/release/v0.6.6
+~~~
+
+- [ ] **Step 4: Close #136 and update parent #131**
+
+After the guarded merge, record the exact PR URL, SHA, local red/green proof,
+routed CI, CodeQL, and merge/ancestry links:
+
+~~~
+gh issue close 136 --repo miztertea/nim-proxy --reason completed \
+  --comment "Implemented and merged via $issue_pr_url at $reviewed_head. Red/green compaction crash-point proof, exact three-file scope, natural stable/presentation=false/coverage/docker route, CodeQL, and guarded integration passed."
+gh issue comment 131 --repo miztertea/nim-proxy \
+  --body "#136 complete: $issue_pr_url merged at $reviewed_head. Failed compactions clean their own pre-rename temporary while preserving old canonical bytes; store proof, natural routed CI, CodeQL, and guarded merge passed. PR #72 and main remain untouched."
+~~~
+
+## Plan Self-Review
+
+- Spec coverage: outcome, closure flow, rejected guard/sweep/fixed-name alternatives, failure outcomes, RED/GREEN proof, unchanged boundaries, and all required rungs are covered.
+- Marker scan: no unresolved or unspecified implementation/test step remains.
+- Scope scan: only #136 cleanup is assigned; #134, #135, #139, and #140 behavior remains excluded.
+- Interface consistency: Task 1 produces one exact SHA and three-file commit; Task 2 verifies, publishes, reviews, merges, and reports that same SHA.

--- a/docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md
+++ b/docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md
@@ -194,3 +194,48 @@ targeting `release/v0.6.6`.
 **Rung 2:** update the existing temporary creator and the existing publication,
 compaction, and wizard tests. **Rung 3:** use the standard-library Unix
 `OpenOptionsExt` and `PermissionsExt` extensions; no new machinery is needed.
+
+## #136 failed-compaction temporary cleanup
+
+### Outcome
+
+Each failed compaction removes the unique temporary created by that attempt
+before rename commits. The canonical old bytes and every existing compaction
+outcome remain unchanged.
+
+### Selected flow
+
+Keep cleanup local to `compact_inner_if_authorized`. Use standard `Result` and
+closure control flow around the existing write, flush, sync, replacement
+validation, authorization, and rename preparation. On every error before a
+successful rename, leave the closure, drop its open output handle, best-effort
+`fs::remove_file(&temporary)`, and return the original error. Preserve the
+existing `authorize() == None` `Superseded` result and cleanup. After rename the
+temporary path is gone; directory-sync failure remains `CommittedSyncPending`
+and needs no cleanup.
+
+### Rejected alternatives
+
+A new temporary guard type is unnecessary machinery and is rejected. Startup
+must keep warning with the opaque `stale_temporary_count`; unknown or
+pre-existing stale files are not swept. Fixed-name reuse or retaining one
+forensic file is rejected because this issue owns cleanup of the current
+attempt, not evidence policy. #139 owns visibility/status and #140 owns
+timestamps.
+
+### Proof and constraints
+
+Extend only the existing injected pre-commit crash-point loop in
+`compaction_crash_points_leave_only_old_or_complete_new_canonical_bytes` to
+assert `stale_temporary_count(&dir) == 0` after each failure. RED is the first
+leaking failure reporting one temporary; GREEN covers all existing points.
+Production and test changes stay in `src/history/store.rs` only: no new
+failure switches, helpers, dependencies, startup sweep, E2E/API/status/metric
+change, canonical-byte change, or directory-sync cleanup. The store module,
+format, whitespace, and changed-path checks provide local proof.
+
+### Ponytail rungs
+
+**Rung 1:** no guard or sweep needs to exist. **Rung 2:** reuse the current
+compaction flow, crash-point test, and stale-count helper. **Rung 3:** use
+standard Rust `Result`/closure control flow and filesystem operations.

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -353,37 +353,50 @@ impl HistoryStore {
             .to_path_buf();
         let (temporary, mut output) =
             create_temporary(&directory, &mut failure, FailurePoint::CompactionTempCreate)?;
-        for record in &retained {
-            write_record(
-                &mut output,
-                record,
-                failure.as_deref_mut(),
-                Some(FailurePoint::CompactionTempWrite),
-            )
-            .map_err(write_error_to_io)?;
-        }
-        output.flush()?;
-        fail(&mut failure, FailurePoint::CompactionTempSync)?;
-        output.sync_all()?;
-
-        let replacement_replay = validate_canonical(&temporary).map_err(open_error_to_io)?;
-        if replacement_replay.records != retained
-            || !replacement_replay.gaps.is_empty()
-            || replacement_replay.needs_separator
-            || replacement_replay.diagnostics.excluded_epochs != 0
-            || replacement_replay.diagnostics.excluded_records != 0
-        {
-            return Err(io::Error::other(
-                "compaction replacement does not exactly validate as retained canonical history",
-            ));
-        }
-        let Some(authorization) = authorize() else {
-            drop(output);
-            let _ = fs::remove_file(&temporary);
-            return Ok(CompactionOutcome::Superseded);
+        let prepared = (|| -> io::Result<Option<(T, Replay)>> {
+            for record in &retained {
+                write_record(
+                    &mut output,
+                    record,
+                    failure.as_deref_mut(),
+                    Some(FailurePoint::CompactionTempWrite),
+                )
+                .map_err(write_error_to_io)?;
+            }
+            output.flush()?;
+            fail(&mut failure, FailurePoint::CompactionTempSync)?;
+            output.sync_all()?;
+            let replacement_replay = validate_canonical(&temporary).map_err(open_error_to_io)?;
+            if replacement_replay.records != retained
+                || !replacement_replay.gaps.is_empty()
+                || replacement_replay.needs_separator
+                || replacement_replay.diagnostics.excluded_epochs != 0
+                || replacement_replay.diagnostics.excluded_records != 0
+            {
+                return Err(io::Error::other(
+                    "compaction replacement does not exactly validate as retained canonical history",
+                ));
+            }
+            let Some(authorization) = authorize() else {
+                return Ok(None);
+            };
+            fail(&mut failure, FailurePoint::CompactionRename)?;
+            fs::rename(&temporary, &self.path)?;
+            Ok(Some((authorization, replacement_replay)))
+        })();
+        let (authorization, replacement_replay) = match prepared {
+            Err(error) => {
+                drop(output);
+                let _ = fs::remove_file(&temporary);
+                return Err(error);
+            }
+            Ok(None) => {
+                drop(output);
+                let _ = fs::remove_file(&temporary);
+                return Ok(CompactionOutcome::Superseded);
+            }
+            Ok(Some((authorization, replacement_replay))) => (authorization, replacement_replay),
         };
-        fail(&mut failure, FailurePoint::CompactionRename)?;
-        fs::rename(&temporary, &self.path)?;
         drop(authorization);
 
         self.file = output;
@@ -1077,8 +1090,8 @@ mod tests {
 
     use super::{
         add_sample, append_with_test_failure, compact_with_test_failure, open_with_test_failure,
-        validate_canonical, CompactionOutcome, Epoch, FailurePoint, HistoryStore, OpenError,
-        ScannerState,
+        stale_temporary_count, validate_canonical, CompactionOutcome, Epoch, FailurePoint,
+        HistoryStore, OpenError, ScannerState,
     };
     use crate::history::{
         codec::{
@@ -2685,6 +2698,11 @@ mod tests {
                 "{point:?}: canonical path remains the complete old bytes"
             );
             validate_canonical(&path).unwrap();
+            assert_eq!(
+                stale_temporary_count(&dir).unwrap(),
+                0,
+                "{point:?}: failed compaction must remove its attempt temporary"
+            );
             let _ = fs::remove_dir_all(dir);
         }
 


### PR DESCRIPTION
Resolves #136. Failed compactions clean their own pre-rename temporary while preserving old canonical bytes. Parent: #131.