### PR TITLE
fix(history): clamp samples to canonical ordering

### DIFF
--- a/docs/superpowers/plans/2026-08-08-v0.6.6-issue-140-history-clock-clamp.md
+++ b/docs/superpowers/plans/2026-08-08-v0.6.6-issue-140-history-clock-clamp.md
@@ -1,0 +1,310 @@
+# v0.6.6 Issue #140 History Clock-Clamp Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Clamp runtime history samples to the canonical ordering bound so a clock rollback cannot make canonical persistence reject otherwise valid data.
+
+**Architecture:** Snapshot the existing HistoryStore timestamp under its optional mutex, release that lock, and combine the snapshot with the existing in-memory bound before indexing or writing. Expose no new state: the canonical store's existing last_timestamp is read through one crate-visible accessor.
+
+**Tech Stack:** Rust standard-library Option/mutexes, existing canonical history codec, Tokio-free history unit tests, GitHub Actions and GitHub CLI.
+
+## Global Constraints
+
+- Integration branch is release/v0.6.6; only PR #72 targets main.
+- Issue #140 owns timestamp clamping only; #139 owns persistence-health state, visibility, status, metrics, and poisoned-store behavior.
+- Modify only src/history.rs, src/history/store.rs, the workstream spec, and this plan; the implementation PR contains exactly those four files.
+- Add only HistoryStore::last_timestamp() -> Option<u64> as a crate-visible read-only accessor; add no state, atomic, clock API, or dependency.
+- Snapshot the optional canonical bound before locking inner; release the store guard before parsing, index mutation, or the later append.
+- Clamp to the maximum of input t, inner.available_to, and the snapshot; preserve the single-sampler caller contract and all warning/failure behavior.
+- Replace/rename the memory-only rollback test with a TestDir plus History::open canonical-backed regression; use existing codec/helpers.
+- Do not change API/status/metric/config/format/E2E/knowledge behavior, PR #72, or main; do not implement #139.
+- Task 1 is TDD/review/commit with exact message fix(history): clamp samples to canonical ordering.
+- The natural CI route is stable=true, presentation=false, coverage=true, docker=true: nine CI jobs succeed, all eight presentation steps skip, and CodeQL succeeds. Do not use ci:full unless route booleans mismatch; a mismatch pauses publication for routing repair.
+- The SDD evidence workspace is .superpowers/sdd/2026-08-08-v0.6.6-issue-140-history-clock-clamp/; invoke the external sdd-workspace script after this plan exists, keep its report ignored, and never use a nonexistent repository helper.
+
+## File Responsibility Map
+
+- src/history/store.rs — expose the existing canonical timestamp read-only.
+- src/history.rs — combine canonical and in-memory bounds and carry the canonical-backed red→green regression test.
+- docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md — approved #140 design boundary.
+- This plan — exact implementation, proof, review, publication, and merge contract. The ignored SDD report is authoring evidence only.
+
+---
+
+### Task 1: Clamp runtime samples and prove canonical persistence
+
+**Files:**
+
+- Modify: src/history.rs (append implementation and renamed rollback test)
+- Modify: src/history/store.rs (crate-visible accessor beside append methods)
+- Include: the workstream spec and this plan
+
+**Outcome:** A sample below the boot timestamp is indexed and persisted at the canonical boot timestamp, with sorted points and exact totals unchanged.
+
+**Proof:** The renamed canonical-backed test fails before the fix because the decoded file ends at Boot/no Sample, then passes after the accessor and clamp; focused history tests, formatting, whitespace, path, and status checks pass.
+
+**Constraint:** No public API, new state, lock held across mutation, warning change, poison handling, canonical format, or #139 behavior.
+
+**Ponytail Rung:** Rung 2 reuses History::open, append, the HistoryStore field, TestDir, boot_t, codec decoder, and rollups. Rung 3 uses standard Option maximum composition and existing mutexes.
+
+**Interfaces:** Produces the reviewed four-file commit for Task 2. The report is .superpowers/sdd/2026-08-08-v0.6.6-issue-140-history-clock-clamp/task-1-report.md.
+
+- [ ] **Step 1: Replace the memory-only rollback test with the canonical red test**
+
+Rename append_clamps_clock_rollback_to_preserve_sorted_index to
+append_clamps_clock_rollback_to_canonical_order_and_persists_sample, and
+replace its memory_history(0) setup with this canonical-backed shape. Keep
+the existing capacity helper and TestDir; decode using codec::decode_record.
+
+~~~
+let dir = TestDir::new();
+let history = Arc::new(History::open(dir.0.clone(), 0, capacity(40)).unwrap());
+let boot_t = history.boot_t;
+history.append(
+    boot_t.saturating_sub(60),
+    "# TYPE requests_total counter\nrequests_total 15\n",
+    capacity(40),
+);
+
+let records = fs::read_to_string(dir.0.join("history-v1.jsonl"))
+    .unwrap()
+    .lines()
+    .map(|line| codec::decode_record(line.as_bytes()).unwrap())
+    .collect::<Vec<_>>();
+assert!(matches!(records.last(), Some(codec::Record::Sample(sample))
+    if sample.timestamp == boot_t));
+let timestamps = history
+    .inner
+    .lock()
+    .unwrap()
+    .points
+    .iter()
+    .map(|point| point.t)
+    .collect::<Vec<_>>();
+assert_eq!(timestamps, [boot_t]);
+assert!(timestamps.windows(2).all(|pair| pair[0] <= pair[1]));
+assert_eq!(history.status().available_to, Some(boot_t));
+let rollup = history.rollup(boot_t.saturating_sub(1), boot_t, 20);
+assert_eq!(value(&rollup.data.totals, "requests_total"), 15.0);
+~~~
+The canonical decode assertion comes first so RED truthfully fails at the
+persistence proof: current code leaves the final record Boot with no Sample.
+After the fix, the later in-memory, sorted-index, and totals assertions verify
+the same boot_t bound.
+
+- [ ] **Step 2: Run RED and preserve the failure evidence**
+
+Run:
+
+~~~
+cargo test history::tests::append_clamps_clock_rollback_to_canonical_order_and_persists_sample --lib
+~~~
+
+Expected: FAIL at the final canonical-record assertion while the canonical file still ends at its Boot row; record that output in the ignored SDD report before production changes.
+
+- [ ] **Step 3: Add the accessor and minimal bound composition**
+
+In src/history/store.rs, add this read-only crate-visible method near the
+existing store accessors, returning the existing field without mutation:
+
+~~~
+pub(crate) fn last_timestamp(&self) -> Option<u64> {
+    self.last_timestamp
+}
+~~~
+
+At the first lines of History::append, snapshot the optional canonical bound
+and release that guard before parsing or taking inner:
+
+~~~
+let canonical_last = self
+    .canonical
+    .as_ref()
+    .map(|store| store.lock().unwrap().last_timestamp())
+    .flatten();
+let current = parse_exposition(snapshot);
+let canonical_state = canonical_state(&current);
+let mut inner = self.inner.lock().unwrap();
+let t = [Some(t), inner.available_to, canonical_last]
+    .into_iter()
+    .flatten()
+    .max()
+    .expect("the input timestamp is always present");
+~~~
+
+Replace only the current in-memory clamp with this composition; retain the
+existing normalization, index mutation, later canonical append, warning, and
+compaction paths verbatim. Do not hold the store guard beyond the snapshot.
+
+- [ ] **Step 4: Run GREEN and the complete local proof**
+
+Run exactly:
+
+~~~
+cargo test history::tests::append_clamps_clock_rollback_to_canonical_order_and_persists_sample --lib
+cargo test history::tests --lib
+cargo test history::store::tests --lib
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+git diff --check
+git diff --name-only
+git status --short
+~~~
+
+Expected: both history suites and format/whitespace checks pass; changed paths are exactly the two Rust files plus the spec and plan, with the canonical Sample at boot_t, available_to boot_t, and sorted/totals assertions passing.
+
+- [ ] **Step 5: Review and commit the exact four-file change**
+
+The independent review checks issue #140, the red evidence, lock lifetime,
+Option<u64> accessor, canonical decode assertion, sorted index/totals,
+unchanged warnings/failures, #139 exclusion, and the complete path scope.
+Repair Critical/Important findings and repeat Step 4. Then run:
+
+~~~
+set -euo pipefail
+git diff --check
+git add src/history.rs src/history/store.rs \
+  docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md \
+  docs/superpowers/plans/2026-08-08-v0.6.6-issue-140-history-clock-clamp.md
+git diff --cached --check
+test "$(git diff --cached --name-only | sort)" = "$(printf '%s\n' \
+  docs/superpowers/plans/2026-08-08-v0.6.6-issue-140-history-clock-clamp.md \
+  docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md \
+  src/history.rs src/history/store.rs | sort)"
+git commit -m "fix(history): clamp samples to canonical ordering"
+git show --check --stat --oneline HEAD
+~~~
+
+Do not stage the ignored report or progress ledger. Record the exact SHA for
+Task 2.
+
+---
+
+### Task 2: Publish the ready PR, verify the route, and integrate #140
+
+**Files:** Publish the Task 1 commit and update GitHub issue #140 and parent #131; preserve PR #72 and main.
+
+**Outcome:** A non-draft PR containing exactly the reviewed four files merges
+into release/v0.6.6, closes #140, and records accepted evidence on #131.
+
+**Proof:** Local/remote/PR SHA and file assertions, bounded run discovery, nine CI jobs, eight skipped presentation steps, CodeQL, combined final review, guarded merge, and post-merge ancestry agree.
+
+**Constraint:** Never target main, alter PR #72, merge a different head, or add
+ci:full when the natural route matches. If route booleans mismatch, pause and
+repair routing before any merge.
+
+**Ponytail Rung:** Rung 2 reuses the existing branch, issue, PR, CI, CodeQL, and parent-issue surfaces; native conclusions and --match-head-commit provide the guard.
+
+**Interfaces:** Consumes Task 1's exact SHA and produces the merged PR plus #140/#131 evidence. The ignored report is .superpowers/sdd/2026-08-08-v0.6.6-issue-140-history-clock-clamp/design-plan-report.md.
+
+- [ ] **Step 1: Run the SDD self-ignore preflight, then publish the exact ready PR**
+
+After the plan exists, invoke the external workspace script with the known plan path (not a repository-local helper), then verify its self-ignoring files:
+
+~~~
+set -euo pipefail
+plan=docs/superpowers/plans/2026-08-08-v0.6.6-issue-140-history-clock-clamp.md
+sdd_workspace=$(/home/tchawes/.codex/plugins/cache/openai-curated-remote/superpowers/6.2.0/skills/subagent-driven-development/scripts/sdd-workspace "$plan")
+test "$sdd_workspace" = "$(git rev-parse --show-toplevel)/.superpowers/sdd/2026-08-08-v0.6.6-issue-140-history-clock-clamp"
+test -f .superpowers/sdd/.gitignore
+test "$(cat .superpowers/sdd/.gitignore)" = '*'
+git check-ignore -q "$sdd_workspace/design-plan-report.md"
+git check-ignore -q "$sdd_workspace/progress.md"
+reviewed_head=$(git rev-parse HEAD)
+git push -u origin work/v0.6.6-140-history-clock-clamp
+remote_head=$(git ls-remote origin refs/heads/work/v0.6.6-140-history-clock-clamp | cut -f1)
+test "$remote_head" = "$reviewed_head"
+expected_files=$(printf '%s\n' \
+  docs/superpowers/plans/2026-08-08-v0.6.6-issue-140-history-clock-clamp.md \
+  docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md \
+  src/history.rs src/history/store.rs | sort)
+test "$(git diff-tree --no-commit-id --name-only -r "$reviewed_head" | sort)" = "$expected_files"
+issue_pr_url=$(gh pr create --repo miztertea/nim-proxy \
+  --base release/v0.6.6 --head work/v0.6.6-140-history-clock-clamp \
+  --title "fix(history): clamp samples to canonical ordering" \
+  --body "Resolves #140. Runtime samples are clamped to the canonical ordering bound and proven against a real canonical file. Parent: #131.")
+test -n "$issue_pr_url"
+pr_view=$(gh pr view "$issue_pr_url" --repo miztertea/nim-proxy \
+  --json url,state,isDraft,baseRefName,headRefName,headRefOid,files)
+test "$(jq -r .state <<<"$pr_view")" = OPEN
+test "$(jq -r .isDraft <<<"$pr_view")" = false
+test "$(jq -r .baseRefName <<<"$pr_view")" = release/v0.6.6
+test "$(jq -r .headRefName <<<"$pr_view")" = work/v0.6.6-140-history-clock-clamp
+test "$(jq -r .headRefOid <<<"$pr_view")" = "$reviewed_head"
+test "$(jq -r '.files[].path' <<<"$pr_view" | sort)" = "$expected_files"
+~~~
+
+- [ ] **Step 2: Discover bounded pull-request runs and assert natural evidence**
+
+Use at most 60 five-second attempts, filtering by pull-request event, exact reviewed SHA, and workflow path; never select a push or stale run:
+
+~~~
+ci_run_id=""; codeql_run_id=""
+for attempt in $(seq 1 60); do
+  runs=$(gh api "repos/miztertea/nim-proxy/actions/runs?per_page=100")
+  ci_run_id=$(jq -r --arg h "$reviewed_head" '[.workflow_runs[] | select(.event == "pull_request" and .head_sha == $h and .path == ".github/workflows/ci.yml")] | sort_by(.created_at) | last.id // empty' <<<"$runs")
+  codeql_run_id=$(jq -r --arg h "$reviewed_head" '[.workflow_runs[] | select(.event == "pull_request" and .head_sha == $h and .path == ".github/workflows/codeql.yml")] | sort_by(.created_at) | last.id // empty' <<<"$runs")
+  test -n "$ci_run_id" && test -n "$codeql_run_id" && break
+  sleep 5
+done
+test -n "$ci_run_id" && test -n "$codeql_run_id"
+gh run watch "$ci_run_id" --repo miztertea/nim-proxy --exit-status
+gh run watch "$codeql_run_id" --repo miztertea/nim-proxy --exit-status
+ci_view=$(gh run view "$ci_run_id" --repo miztertea/nim-proxy --json event,headSha,conclusion,jobs)
+codeql_view=$(gh run view "$codeql_run_id" --repo miztertea/nim-proxy --json event,headSha,conclusion,jobs)
+test "$(jq -r .event <<<"$ci_view")" = pull_request
+test "$(jq -r .headSha <<<"$ci_view")" = "$reviewed_head"
+test "$(jq -r .conclusion <<<"$ci_view")" = success
+test "$(jq '[.jobs[]] | length' <<<"$ci_view")" = 9
+for job in 'change routing' 'fmt, clippy, tests' coverage msrv cargo-deny gitleaks 'workflow lint' 'dependency review' 'docker build'; do
+  jq -e --arg job "$job" '.jobs[] | select(.name == $job and .conclusion == "success")' <<<"$ci_view" >/dev/null
+done
+test "$(jq -r .headSha <<<"$codeql_view")" = "$reviewed_head"
+test "$(jq -r .conclusion <<<"$codeql_view")" = success
+jq -e '.jobs[] | select(.name == "codeql (rust)" and .conclusion == "success")' <<<"$codeql_view" >/dev/null
+for route in 'Filter stable = true' 'Filter presentation = false' 'Filter coverage = true' 'Filter docker = true'; do
+  gh run view "$ci_run_id" --repo miztertea/nim-proxy --log | rg -F -q "$route"
+done
+check_steps=$(jq -c '.jobs[] | select(.name == "fmt, clippy, tests") | .steps' <<<"$ci_view")
+presentation_skip_count=0
+for step in 'Embedded presentation source boundaries and JS syntax' 'Formatter output is unchanged' 'i18n lint self-test' 'i18n catalog and untagged-string lint' 'locale-v1 self-test' 'locale-v1 validation' 'Pseudolocale is current' 'Dashboard renders and survives being driven'; do
+  jq -e --arg step "$step" '.[] | select(.name == $step and .conclusion == "skipped")' <<<"$check_steps" >/dev/null
+  presentation_skip_count=$((presentation_skip_count + 1))
+done
+test "$presentation_skip_count" = 8
+~~~
+
+These assertions require the four route booleans, all nine named CI jobs, all eight named presentation skips, and CodeQL on the same SHA. No ci:full is added when they match.
+- [ ] **Step 3: Combine final review and merge with a head guard**
+
+An independent final reviewer combines implementation/evidence review of the exact four-file diff, red/green report, lock scope, PR metadata, route log, nine jobs/eight skips, CodeQL, and no-ci:full decision. From a fresh shell:
+
+~~~
+set -euo pipefail
+reviewed_head=$(git rev-parse HEAD)
+issue_pr_url=$(gh pr list --repo miztertea/nim-proxy --state open --base release/v0.6.6 \
+  --head work/v0.6.6-140-history-clock-clamp --json url --jq '.[0].url')
+pr_head=$(gh pr view "$issue_pr_url" --repo miztertea/nim-proxy --json headRefOid --jq .headRefOid)
+remote_head=$(git ls-remote origin refs/heads/work/v0.6.6-140-history-clock-clamp | cut -f1)
+test "$pr_head" = "$reviewed_head" && test "$remote_head" = "$reviewed_head"
+test "$(gh pr view 72 --repo miztertea/nim-proxy --json baseRefName --jq .baseRefName)" = main
+main_before=$(git ls-remote origin refs/heads/main | cut -f1)
+gh pr merge "$issue_pr_url" --repo miztertea/nim-proxy --merge --match-head-commit "$reviewed_head"
+git fetch origin --prune
+git merge-base --is-ancestor "$reviewed_head" origin/release/v0.6.6
+test "$(git ls-remote origin refs/heads/main | cut -f1)" = "$main_before"
+~~~
+
+- [ ] **Step 4: Close #140 and update parent #131**
+
+~~~
+gh issue close 140 --repo miztertea/nim-proxy --reason completed \
+  --comment "Implemented and merged via $issue_pr_url at $reviewed_head. Canonical-backed red/green proof, exact four-file scope, natural routed CI (stable=true, presentation=false, coverage=true, docker=true), nine jobs/eight skips, CodeQL, and guarded merge passed."
+gh issue comment 131 --repo miztertea/nim-proxy --body \
+  "#140 complete: $issue_pr_url merged at $reviewed_head. Runtime samples now clamp to the canonical ordering bound; local red/green proof, routed CI, CodeQL, and guarded merge passed. PR #72 and main remain untouched."
+~~~
+## Plan Self-Review
+
+- Coverage: accessor, lock lifetime, three-way clamp, canonical RED/GREEN test, unchanged failures, exact four-file scope, route evidence, guarded merge, and issue updates.
+- Scans: no markers/placeholders, #139/API/status/metric/config/format/E2E/knowledge scope, or contradiction; Task 1's SHA is Task 2's published head.
+- Decomposition: exactly two tasks; Task 1 is TDD/review/commit and Task 2 is publication/evidence/final review/integration.

--- a/docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md
+++ b/docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md
@@ -9,9 +9,10 @@
 
 History failures stop threatening proxy availability or silently discarding
 durability while the canonical format, append-only recovery evidence, and
-one-PR-per-issue boundary remain intact. This first executable slice resolves
-#134 only: a canonical-history open failure degrades startup to the existing
-in-memory history path instead of terminating the process.
+one-PR-per-issue boundary remain intact. Each issue owns one reviewed executable
+slice: #134 availability, #135 file mode, #136 cleanup, #140 timestamp clamping,
+and #139 persistence-health visibility; this design records their shared
+boundaries and proof contracts without expanding any issue's behavior.
 
 ## Existing boundaries
 
@@ -239,3 +240,50 @@ format, whitespace, and changed-path checks provide local proof.
 **Rung 1:** no guard or sweep needs to exist. **Rung 2:** reuse the current
 compaction flow, crash-point test, and stale-count helper. **Rung 3:** use
 standard Rust `Result`/closure control flow and filesystem operations.
+
+## #140 canonical runtime timestamp clamping
+
+### Outcome
+
+Samples accepted after a wall-clock rollback remain ordered against both the
+in-memory index and canonical boot record, so the point persists instead of
+becoming silently discarded dashboard-only data.
+
+### Selected approach
+
+Add the crate-visible read-only accessor `HistoryStore::last_timestamp() -> Option<u64>`
+for the existing field. At the start of `History::append`, briefly lock the
+optional canonical store, snapshot its bound, release the guard, then lock
+`inner`. Clamp `t` to max(input, `inner.available_to`, and the snapshot). Do not
+hold the store lock across parsing, index mutation, or the later append; retain
+the existing single-sampler caller contract.
+
+### Rejected alternatives
+
+- No new timestamp field, atomic, or clock API: the existing store and index
+  already own the required bounds.
+- No lock-held append or sampler-concurrency redesign: that expands the lock
+  protocol beyond this issue.
+- No persistence-health or poison transition here: #139 owns those surfaces.
+
+### Failure handling and proof
+
+Rename the memory-only rollback test to use `TestDir` plus `History::open`, set
+`boot_t`, append below it, and decode the canonical file with existing codec
+helpers. RED shows the final record remains Boot with no Sample under current
+code; GREEN proves a Sample persists at `boot_t`, in-memory available_to and
+point timestamp are `boot_t`, and sorted index/totals remain correct. Preserve
+existing warning and failure behavior.
+
+### Constraints
+
+Only `src/history.rs`, `src/history/store.rs`, this spec, and the issue plan
+change. Do not alter API/status/metrics/config/codec/format/E2E/knowledge or
+#139 work. Use one reviewed commit targeting `release/v0.6.6`; PR #72 and
+`main` remain untouched.
+
+### Ponytail rungs
+
+`Rung 2` reuses `History::open`, `History::append`, `last_timestamp`, `TestDir`,
+`boot_t`, codec decoding, and existing rollup/index assertions. `Rung 3` uses
+standard `Option`/maximum composition and existing mutexes.

--- a/src/history.rs
+++ b/src/history.rs
@@ -907,13 +907,21 @@ impl History {
     }
 
     pub fn append(self: &Arc<Self>, t: u64, snapshot: &str, capacity: CapacitySnapshot) {
+        let canonical_last = self
+            .canonical
+            .as_ref()
+            .and_then(|store| store.lock().unwrap().last_timestamp());
         let current = parse_exposition(snapshot);
         let canonical_state = canonical_state(&current);
         let mut inner = self.inner.lock().unwrap();
         // Wall clocks can move backward, and a retained file can contain a
         // future-dated point. Keep ingestion order without fabricating time:
         // equal timestamps preserve binary-search ordering and exact deltas.
-        let t = inner.available_to.map_or(t, |latest| latest.max(t));
+        let t = [Some(t), inner.available_to, canonical_last]
+            .into_iter()
+            .flatten()
+            .max()
+            .expect("the input timestamp is always present");
         let explicit_reset = inner.last_parsed.is_some()
             && inner.last_sample_boot.as_deref() != Some(self.boot_id.as_str());
         let normalized = normalize(inner.last_parsed.as_ref(), &current, explicit_reset);
@@ -1818,19 +1826,23 @@ nimproxy_ttft_seconds_count{model="z-ai/glm-5.2"} 4
     }
 
     #[test]
-    fn append_clamps_clock_rollback_to_preserve_sorted_index() {
-        let history = memory_history(0);
+    fn append_clamps_clock_rollback_to_canonical_order_and_persists_sample() {
+        let dir = TestDir::new();
+        let history = Arc::new(History::open(dir.0.clone(), 0, capacity(40)).unwrap());
+        let boot_t = history.boot_t;
         history.append(
-            300,
-            "# TYPE requests_total counter\nrequests_total 10\n",
-            capacity(40),
-        );
-        history.append(
-            200,
+            boot_t.saturating_sub(60),
             "# TYPE requests_total counter\nrequests_total 15\n",
             capacity(40),
         );
 
+        let records = fs::read_to_string(dir.0.join("history-v1.jsonl"))
+            .unwrap()
+            .lines()
+            .map(|line| codec::decode_record(line.as_bytes()).unwrap())
+            .collect::<Vec<_>>();
+        assert!(matches!(records.last(), Some(codec::Record::Sample(sample))
+            if sample.timestamp == boot_t));
         let timestamps = history
             .inner
             .lock()
@@ -1839,10 +1851,10 @@ nimproxy_ttft_seconds_count{model="z-ai/glm-5.2"} 4
             .iter()
             .map(|point| point.t)
             .collect::<Vec<_>>();
-        assert_eq!(timestamps, [300, 300]);
+        assert_eq!(timestamps, [boot_t]);
         assert!(timestamps.windows(2).all(|pair| pair[0] <= pair[1]));
-        assert_eq!(history.status().available_to, Some(300));
-        let rollup = history.rollup(299, 300, 20);
+        assert_eq!(history.status().available_to, Some(boot_t));
+        let rollup = history.rollup(boot_t.saturating_sub(1), boot_t, 20);
         assert_eq!(value(&rollup.data.totals, "requests_total"), 15.0);
     }
 

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -448,6 +448,10 @@ impl HistoryStore {
         &self.boot_id
     }
 
+    pub(crate) fn last_timestamp(&self) -> Option<u64> {
+        self.last_timestamp
+    }
+
     pub(crate) fn take_replay(&mut self) -> Replay {
         std::mem::take(&mut self.replay)
     }


### PR DESCRIPTION
Resolves #140. Runtime samples are clamped to the canonical ordering bound and proven against a real canonical file. Parent: #131.