### PR TITLE
fix(history): expose poisoned persistence health

### DIFF
--- a/docs/superpowers/plans/2026-08-08-v0.6.6-issue-139-history-health.md
+++ b/docs/superpowers/plans/2026-08-08-v0.6.6-issue-139-history-health.md
@@ -1,0 +1,290 @@
+# v0.6.6 Issue #139 History Persistence-Health Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make canonical-history persistence degradation visible in status, `/api/config`, the existing Settings history card, and a fixed Prometheus gauge without changing in-memory sampling or recovery.
+
+**Architecture:** Derive `ok`/`degraded` from existing canonical-store presence and its `poisoned` bit; do not mirror it in an atomic or recovery state. Initialize the no-label gauge after `History::open` or the #134 fallback, then set it to `1` only on the first runtime poison transition. Status, config, and UI consume the same derived value.
+
+**Tech Stack:** Rust/Axum/Serde/Utoipa, existing `metrics` Prometheus recorder and history test/E2E harnesses, embedded catalog/Settings JavaScript, existing render fixture generator, GitHub Actions/CLI.
+
+## Global Constraints
+
+- The integration branch is `release/v0.6.6`; every issue PR targets it. Only PR #72 targets `main`, and it remains untouched.
+- #139 promotes the history workstream: apply `ci:full`, then require full CI, CodeQL, and exact-ref `fuzz.yml` evidence before guarded merge.
+- Persistence is `degraded` if `History::canonical` is absent (the #134 fallback) or its `HistoryStore::poisoned` bit is true; otherwise it is `ok`. Poison survives until restart.
+- Add no recovery loop, config switch, persistence state/atomic, dependency, route, dashboard-now field, canonical-format change, custom checker, or knowledge edit; #152 owns knowledge reconciliation.
+- `HistoryStatus` and `HistorySettings` wire fields are ASCII ordered. `/api/config` gains only `server.history.persistence` with exact `ok`/`degraded` values.
+- Export exactly `nimproxy_history_persistence_degraded`, a no-label gauge: `0` after healthy open and `1` after fallback or the first runtime poison. Do not add a counter or recovery behavior.
+- Runtime append failure logs once at error level on the usable-to-poisoned transition. Later `WriteError::Poisoned` short-circuits neither change the gauge nor log per sample.
+- Reuse the existing Settings history card, catalog, `render_check` rows, and generated fixtures. Regenerate OpenAPI/UI/public-locale files only through existing commands and include only actual changes; never hand-edit generated output.
+- Task 1 is red → green, independent review, and one commit. Task 2 publishes, promotes, reviews independently, guarded-merges, closes #139, and updates #131.
+- The ignored evidence workspace is `.superpowers/sdd/2026-08-08-v0.6.6-issue-139-history-health/`; never stage its report or ledger.
+
+## File Responsibility Map
+
+- `src/history/store.rs` — read the existing poison bit and preserve one-shot transition semantics.
+- `src/history.rs` — derive `HistoryStatus.persistence`, detect the first append/checkpoint poison, set the gauge, and silence later poisoned ticks.
+- `src/lib.rs` — describe and initialize the fixed gauge after canonical open/fallback.
+- `src/api.rs`, `src/settings.rs` — typed ASCII-ordered `/api/config` field, schema/order assertion, and typed UI fixture source.
+- `src/web/settings.js`, `src/web/locales/en-US.json` — catalog-backed degraded guidance in the existing Settings history card.
+- `tests/e2e.rs`, `scripts/render_check.js` — real-server API/metric proof and existing-row rendered guidance proof.
+- `openapi.json`, `tests/fixtures/ui/config-admin.json`, `tests/fixtures/ui/config-superuser.json`, `tests/fixtures/ui/scenarios.json` — generator output only when changed.
+- The workstream spec and this plan — approved boundary and executable proof/merge contract.
+
+---
+
+### Task 1: Derive, expose, and prove poisoned-store health
+
+**Files:**
+
+- Modify: `src/history.rs`, `src/history/store.rs`, `src/lib.rs`, `src/api.rs`, `src/settings.rs`, `src/web/settings.js`, `src/web/locales/en-US.json`, `tests/e2e.rs`, `scripts/render_check.js`
+- Regenerate if changed: `openapi.json`, `tests/fixtures/ui/config-admin.json`, `tests/fixtures/ui/config-superuser.json`, `tests/fixtures/ui/scenarios.json`
+- Include: the workstream spec and this plan
+
+**Outcome:** The first durable-write failure changes all operator surfaces to degraded and alertable while retaining the current in-memory sample; subsequent poisoned ticks stay quiet and recovery waits for restart.
+
+**Proof:** A focused regression fails before the change because the existing poison state has no status/API/gauge/UI/log transition; after it, canonical startup is `ok`/`0`, #134 fallback is `degraded`/`1`, one injected runtime partial append is `degraded`/`1` with one error transition, and later poisoned appends do not repeat it. Typed API, generated artifacts, existing Settings render row, format, and exact-path checks pass.
+
+**Constraint:** Do not alter canonical bytes, append/compaction/recovery policy, in-memory point-before-persistence ordering, config/auth failure policy, any dashboard-now payload, or PR #72/main.
+
+**Ponytail Rung:** Rung 1 rejects recovery and a duplicate health atomic. Rung 2 reuses `canonical: Option`, `HistoryStore::poisoned`, `RuntimePartialAppend`, `HistoryStatus`, `HistorySettings`, recorder, API fixture generator, catalog, and render rows. Rung 4 reserves native Actions/label checks for Task 2.
+
+**Interfaces:** Produces `fix(history): expose poisoned persistence health` for Task 2. The ignored report is `.superpowers/sdd/2026-08-08-v0.6.6-issue-139-history-health/task-1-report.md`.
+
+- [ ] **Step 1: Write the failing transition, wire, and render assertions**
+
+  Add `canonical_persistence_health_degrades_on_changed_sample_and_checkpoint_poison` in `src/history.rs`, using `History::open` and `TestDir`. Give `HistoryStore` a `#[cfg(test)]` `test_runtime_partial_append_once: bool` initialized false and an arm-once crate-visible method. In public `append_sample`, `mem::take` that flag, construct the existing private `FailureSwitch { point: FailurePoint::RuntimePartialAppend, fired: None }` only when armed, and pass `failure.as_mut()` into `append_sample_inner`. Make `append_sample_inner` take `mut failure` and pass it through to `checkpoint_inner` instead of calling public `checkpoint`, so an unchanged state reaches the same injected append failure. This is test-only plumbing, not production persistence state.
+
+  In two fresh canonical histories, arm the hook before (a) a changed sample and (b) a successful-sample's unchanged checkpoint. For each, assert the first `History::append` retains its in-memory point and reports `degraded`; arm nothing for the second call and assert the existing store-level result remains `WriteError::Poisoned` without new bytes. Reopen a new store to prove restart is the only return to `ok`.
+
+  Use `PrometheusBuilder::new().build_recorder()` with `metrics::with_local_recorder`, retain its `handle()`, and assert the rendered no-label row is exactly `nimproxy_history_persistence_degraded 1` after both the first and later poisoned tick. Install a test-local `tracing_subscriber` with a shared writer inside the same synchronous scope and assert exactly one bounded error event; do not add a dependency, generic recorder, or checker.
+
+  Extend #134's existing real-binary fallback table in `tests/e2e.rs`: it must assert `/api/config.server.history.persistence == "degraded"` plus the exact no-label row `nimproxy_history_persistence_degraded 1`; add ordinary canonical startup `ok`/`0`. Add `persistence` to every `HistorySettings` constructor and the current ASCII-order test so the pre-change failure is the missing field, not a new checker.
+
+  Change `server_ui_fixture()` to degraded and add the expected catalog-resolved guidance to its existing superuser Settings interaction row in `scripts/render_check.js`; assert the existing history-card DOM, not an en-US literal or a new render mode.
+
+- [ ] **Step 2: Run RED and save the observed failure**
+
+  ~~~sh
+  cargo test history::tests::canonical_persistence_health_degrades_on_changed_sample_and_checkpoint_poison --lib
+  cargo test --test e2e history_startup_degrades_to_memory_without_mutating_canonical -- --exact --nocapture
+  cargo test api::tests::field_order_stays_ascii_sorted --lib
+  node scripts/render_check.js --all-states --pseudolocale
+  ~~~
+
+  Expected: the history test fails because public `append_sample` cannot consume the existing injection, unchanged state bypasses it through `checkpoint`, and no derived status/gauge/one-error proof exists. The API/render assertions likewise fail for absent fields/guidance. Record the first failure for each named surface in the ignored Task 1 report before production edits.
+
+- [ ] **Step 3: Implement only the derived state and first-transition behavior**
+
+  In `src/history/store.rs`, add a crate-visible read-only accessor for the existing `poisoned` field beside `last_timestamp`; do not add a stored health flag. Implement the exact `#[cfg(test)]` arm-once path from Step 1 and retain the existing store test assertion that its later write returns `WriteError::Poisoned`. Make `HistoryStatus` carry a serializable `persistence` value in ASCII field order. `History::status()` locks the present store and derives `ok` only when the accessor is false; absent canonical and true poison are degraded.
+
+  At the existing canonical `append_sample` call in `History::append`, distinguish the first error that flips the accessor from later `WriteError::Poisoned`: the first calls `metrics::gauge!("nimproxy_history_persistence_degraded").set(1.0)` and emits one bounded `tracing::error!`; retain the in-memory update before it and leave later short-circuits unchanged and unlogged. `append_sample` already selects `checkpoint`, so unchanged-state checkpoint failure follows this same transition boundary.
+
+  In `src/lib.rs`, describe the gauge beside existing recorder descriptions, complete the open/fallback match, then initialize it from `hist.status().persistence` before starting the sampler. Add `HistorySettings.persistence` after `file_bytes`, update constructors/fixtures, and let Utoipa derive the schema. Add a conditional catalog-id `<p class="shint">` to the existing Settings card and its English operator message.
+
+- [ ] **Step 4: Regenerate through existing commands and run GREEN**
+
+  ~~~sh
+  UPDATE_OPENAPI=1 cargo test --test openapi
+  UPDATE_UI_FIXTURES=1 cargo test api::tests::ui_fixtures --lib
+  python3 scripts/locale_v1.py --update-public
+  python3 scripts/gen_pseudolocale.py --check
+  git diff --name-only -- openapi.json tests/fixtures/ui
+  cargo test history::tests::canonical_persistence_health_degrades_on_changed_sample_and_checkpoint_poison --lib
+  cargo test history::tests --lib
+  cargo test history::store::tests --lib
+  cargo test api::tests::field_order_stays_ascii_sorted --lib
+  cargo test api::tests::ui_fixtures --lib
+  cargo test --test e2e history_startup_degrades_to_memory_without_mutating_canonical -- --exact --nocapture
+  cargo test --test openapi
+  node scripts/render_check.js --all-states --pseudolocale
+  cargo clippy --all-targets -- -D warnings
+  cargo fmt --check
+  git diff --check
+  git diff --name-only
+  git status --short
+  ~~~
+
+  Keep `openapi.json` and the three generator-owned UI fixtures. The new id is operator-only, so no public-locale output is in scope. Expected changed paths are only the responsibility-map paths, the two docs, and ignored evidence.
+
+- [ ] **Step 5: Independently review and commit the exact reviewed change**
+
+  Review #139, RED evidence, absence/poison derivation, first-transition/no-repeat logic, gauge name/value/labels, error level, checkpoint behavior, retained in-memory sample, ASCII API order, catalog-only UI, generator provenance, and the exclusions. Repair Critical/Important findings, repeat Step 4, then:
+
+  ~~~sh
+  set -euo pipefail
+  git diff --check
+  git add src/history.rs src/history/store.rs src/lib.rs src/api.rs src/settings.rs \
+    src/web/settings.js src/web/locales/en-US.json tests/e2e.rs scripts/render_check.js \
+    openapi.json tests/fixtures/ui/config-admin.json tests/fixtures/ui/config-superuser.json \
+    tests/fixtures/ui/scenarios.json \
+    docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md \
+    docs/superpowers/plans/2026-08-08-v0.6.6-issue-139-history-health.md
+  git diff --cached --check
+  expected_files=$(printf '%s\n' \
+    docs/superpowers/plans/2026-08-08-v0.6.6-issue-139-history-health.md \
+    docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md \
+    openapi.json scripts/render_check.js src/api.rs src/history.rs src/history/store.rs \
+    src/lib.rs src/settings.rs src/web/locales/en-US.json src/web/settings.js \
+    tests/e2e.rs tests/fixtures/ui/config-admin.json \
+    tests/fixtures/ui/config-superuser.json tests/fixtures/ui/scenarios.json | sort)
+  test "$(git diff --cached --name-only | sort)" = "$expected_files"
+  git commit -m "fix(history): expose poisoned persistence health"
+  git show --check --stat --oneline HEAD
+  ~~~
+
+  Never stage `.superpowers/sdd`. Record the exact reviewed SHA for Task 2.
+
+---
+
+### Task 2: Publish the promotion PR, prove the full gate, and integrate #139
+
+**Files:** Publish Task 1's exact commit, then update GitHub issue #139 and parent #131; preserve PR #72 and `main`.
+
+**Outcome:** A non-draft `ci:full` promotion PR merges the reviewed head into `release/v0.6.6`, closes #139, and records complete history-workstream proof on #131.
+
+**Proof:** Local/remote/PR SHA and exact files agree; full CI, CodeQL, and manually dispatched fuzz run all use that SHA; independent final review, `--match-head-commit`, post-merge ancestry, and unchanged `main` agree.
+
+**Constraint:** Never target `main`, alter PR #72, merge a different head, accept stale/push evidence, omit `ci:full`, create a release, or update knowledge.
+
+**Ponytail Rung:** Rung 2 reuses branch/PR/issues/CI/CodeQL/fuzz surfaces. Rung 4 uses `ci:full`, native Actions conclusions, and `--match-head-commit` rather than a custom promotion checker.
+
+**Interfaces:** Consumes Task 1's SHA and produces merged #139 plus #139/#131 evidence. The ignored report is `.superpowers/sdd/2026-08-08-v0.6.6-issue-139-history-health/design-plan-report.md`.
+
+- [ ] **Step 1: Preflight ignored evidence and publish the exact ready PR**
+
+  ~~~sh
+  set -euo pipefail
+  plan=docs/superpowers/plans/2026-08-08-v0.6.6-issue-139-history-health.md
+  sdd_workspace=$(/home/tchawes/.codex/plugins/cache/openai-curated-remote/superpowers/6.2.0/skills/subagent-driven-development/scripts/sdd-workspace "$plan")
+  test "$sdd_workspace" = "$(git rev-parse --show-toplevel)/.superpowers/sdd/2026-08-08-v0.6.6-issue-139-history-health"
+  test -f .superpowers/sdd/.gitignore
+  test "$(cat .superpowers/sdd/.gitignore)" = '*'
+  git check-ignore -q "$sdd_workspace/design-plan-report.md"
+  git check-ignore -q "$sdd_workspace/progress.md"
+  reviewed_head=$(git rev-parse HEAD)
+  git push -u origin work/v0.6.6-139-history-health
+  remote_head=$(git ls-remote origin refs/heads/work/v0.6.6-139-history-health | cut -f1)
+  test "$remote_head" = "$reviewed_head"
+  expected_files=$(printf '%s\n' \
+    docs/superpowers/plans/2026-08-08-v0.6.6-issue-139-history-health.md \
+    docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md \
+    openapi.json scripts/render_check.js src/api.rs src/history.rs src/history/store.rs \
+    src/lib.rs src/settings.rs src/web/locales/en-US.json src/web/settings.js \
+    tests/e2e.rs tests/fixtures/ui/config-admin.json \
+    tests/fixtures/ui/config-superuser.json tests/fixtures/ui/scenarios.json | sort)
+  test "$(git diff-tree --no-commit-id --name-only -r "$reviewed_head" | sort)" = "$expected_files"
+  issue_pr_url=$(gh pr create --repo miztertea/nim-proxy --base release/v0.6.6 \
+    --head work/v0.6.6-139-history-health --title "fix(history): expose poisoned persistence health" \
+    --body "Resolves #139. Derived canonical presence/poison health is surfaced in config/Settings and a fixed gauge. History promotion for #131.")
+  pr_view=$(gh pr view "$issue_pr_url" --repo miztertea/nim-proxy --json url,state,isDraft,baseRefName,headRefName,headRefOid,files)
+  test "$(jq -r .state <<<"$pr_view")" = OPEN
+  test "$(jq -r .isDraft <<<"$pr_view")" = false
+  test "$(jq -r .baseRefName <<<"$pr_view")" = release/v0.6.6
+  test "$(jq -r .headRefName <<<"$pr_view")" = work/v0.6.6-139-history-health
+  test "$(jq -r .headRefOid <<<"$pr_view")" = "$reviewed_head"
+  test "$(jq -r '.files[].path' <<<"$pr_view" | sort)" = "$expected_files"
+  ~~~
+
+- [ ] **Step 2: Discover exact-head full CI, CodeQL, and fuzz evidence**
+
+  Use at most 60 five-second attempts. This fresh shell records the natural CI run before adding `ci:full`, then selects only a distinct newer pull-request CI run on the exact reviewed head. Select CodeQL on that SHA; snapshot same-SHA fuzz dispatch ids before dispatch and require a new one on the named branch:
+
+  ~~~sh
+  set -euo pipefail
+  reviewed_head=$(git rev-parse HEAD)
+  open_pr=$(gh pr list --repo miztertea/nim-proxy --state open --base release/v0.6.6 \
+    --head work/v0.6.6-139-history-health --json url,headRefOid)
+  issue_pr_url=$(jq -r --arg h "$reviewed_head" '[.[] | select(.headRefOid == $h)] | last.url // empty' <<<"$open_pr")
+  test -n "$reviewed_head" && test -n "$issue_pr_url"
+  pre_label_ci_run_id=""
+  for attempt in $(seq 1 60); do
+    runs=$(gh api "repos/miztertea/nim-proxy/actions/runs?per_page=100")
+    pre_label_ci_run_id=$(jq -r --arg h "$reviewed_head" '[.workflow_runs[] | select(.event == "pull_request" and .head_sha == $h and .path == ".github/workflows/ci.yml")] | sort_by(.created_at) | last.id // empty' <<<"$runs")
+    test -n "$pre_label_ci_run_id" && break
+    sleep 5
+  done
+  test -n "$pre_label_ci_run_id"
+  pre_label_ci_created_at=$(gh api "repos/miztertea/nim-proxy/actions/runs/$pre_label_ci_run_id" --jq .created_at)
+  gh pr edit "$issue_pr_url" --repo miztertea/nim-proxy --add-label ci:full
+  pr_view=$(gh pr view "$issue_pr_url" --repo miztertea/nim-proxy --json headRefOid,labels)
+  test "$(jq -r .headRefOid <<<"$pr_view")" = "$reviewed_head"
+  jq -e '.labels[].name | select(. == "ci:full")' <<<"$pr_view" >/dev/null
+  ci_run_id=""; codeql_run_id=""
+  for attempt in $(seq 1 60); do
+    runs=$(gh api "repos/miztertea/nim-proxy/actions/runs?per_page=100")
+    ci_run_id=$(jq -r --arg h "$reviewed_head" --arg before "$pre_label_ci_created_at" --arg old "$pre_label_ci_run_id" '[.workflow_runs[] | select(.event == "pull_request" and .head_sha == $h and .path == ".github/workflows/ci.yml" and (.id | tostring) != $old and .created_at > $before)] | sort_by(.created_at) | last.id // empty' <<<"$runs")
+    codeql_run_id=$(jq -r --arg h "$reviewed_head" '[.workflow_runs[] | select(.event == "pull_request" and .head_sha == $h and .path == ".github/workflows/codeql.yml")] | sort_by(.created_at) | last.id // empty' <<<"$runs")
+    test -n "$ci_run_id" && test -n "$codeql_run_id" && break
+    sleep 5
+  done
+  test -n "$ci_run_id" && test -n "$codeql_run_id" && test "$ci_run_id" != "$pre_label_ci_run_id"
+  fuzz_before=$(jq -c --arg h "$reviewed_head" '[.workflow_runs[] | select(.event == "workflow_dispatch" and .head_sha == $h and .head_branch == "work/v0.6.6-139-history-health" and .path == ".github/workflows/fuzz.yml") | .id]' <<<"$runs")
+  gh workflow run fuzz.yml --repo miztertea/nim-proxy --ref work/v0.6.6-139-history-health
+  fuzz_run_id=""
+  for attempt in $(seq 1 60); do
+    runs=$(gh api "repos/miztertea/nim-proxy/actions/runs?per_page=100")
+    fuzz_run_id=$(jq -r --arg h "$reviewed_head" --argjson before "$fuzz_before" '[.workflow_runs[] | select(.event == "workflow_dispatch" and .head_sha == $h and .head_branch == "work/v0.6.6-139-history-health" and .path == ".github/workflows/fuzz.yml" and (.id as $id | ($before | index($id) | not)))] | sort_by(.created_at) | last.id // empty' <<<"$runs")
+    test -n "$fuzz_run_id" && break
+    sleep 5
+  done
+  test -n "$fuzz_run_id"
+  gh run watch "$ci_run_id" --repo miztertea/nim-proxy --exit-status
+  gh run watch "$codeql_run_id" --repo miztertea/nim-proxy --exit-status
+  gh run watch "$fuzz_run_id" --repo miztertea/nim-proxy --exit-status
+  ci_view=$(gh run view "$ci_run_id" --repo miztertea/nim-proxy --json event,headSha,conclusion,jobs)
+  codeql_view=$(gh run view "$codeql_run_id" --repo miztertea/nim-proxy --json event,headSha,conclusion,jobs)
+  fuzz_view=$(gh run view "$fuzz_run_id" --repo miztertea/nim-proxy --json event,headSha,conclusion,jobs)
+  test "$(jq -r .event <<<"$ci_view")" = pull_request
+  test "$(jq -r .headSha <<<"$ci_view")" = "$reviewed_head"
+  test "$(jq -r .conclusion <<<"$ci_view")" = success
+  test "$(jq '[.jobs[]] | length' <<<"$ci_view")" = 9
+  for job in 'change routing' 'fmt, clippy, tests' coverage msrv cargo-deny gitleaks 'workflow lint' 'dependency review' 'docker build'; do jq -e --arg job "$job" '.jobs[] | select(.name == $job and .conclusion == "success")' <<<"$ci_view" >/dev/null; done
+  test "$(jq -r .headSha <<<"$codeql_view")" = "$reviewed_head"
+  jq -e '.conclusion == "success" and .jobs[] | select(.name == "codeql (rust)" and .conclusion == "success")' <<<"$codeql_view" >/dev/null
+  test "$(jq -r .event <<<"$fuzz_view")" = workflow_dispatch
+  test "$(jq -r .headSha <<<"$fuzz_view")" = "$reviewed_head"
+  jq -e '.conclusion == "success" and .jobs[] | select(.name == "smoke fuzz" and .conclusion == "success")' <<<"$fuzz_view" >/dev/null
+  check_steps=$(jq -c '.jobs[] | select(.name == "fmt, clippy, tests") | .steps' <<<"$ci_view")
+  for step in 'Embedded presentation source boundaries and JS syntax' 'Formatter output is unchanged' 'i18n lint self-test' 'i18n catalog and untagged-string lint' 'locale-v1 self-test' 'locale-v1 validation' 'Pseudolocale is current' 'Dashboard renders and survives being driven'; do jq -e --arg step "$step" '.[] | select(.name == $step and .conclusion == "success")' <<<"$check_steps" >/dev/null; done
+  ~~~
+
+  Record the CI routing log and confirm `ci:full` made every presentation step run rather than skip. A missing, stale, wrong-event, failed, or unmatched-SHA run blocks merge.
+
+- [ ] **Step 3: Independently review complete evidence and guarded-merge**
+
+  Review the exact diff, red/green report, generated files, status/API order, transition/no-repeat behavior, `ci:full`, full nine-job CI, CodeQL, exact-ref fuzz, and PR metadata. Repair Critical/Important findings with a new review and full evidence. Then, from a fresh shell:
+
+  ~~~sh
+  set -euo pipefail
+  reviewed_head=$(git rev-parse HEAD)
+  issue_pr_url=$(gh pr list --repo miztertea/nim-proxy --state open --base release/v0.6.6 --head work/v0.6.6-139-history-health --json url --jq '.[0].url')
+  pr_head=$(gh pr view "$issue_pr_url" --repo miztertea/nim-proxy --json headRefOid --jq .headRefOid)
+  remote_head=$(git ls-remote origin refs/heads/work/v0.6.6-139-history-health | cut -f1)
+  test "$pr_head" = "$reviewed_head" && test "$remote_head" = "$reviewed_head"
+  test "$(gh pr view 72 --repo miztertea/nim-proxy --json baseRefName --jq .baseRefName)" = main
+  main_before=$(git ls-remote origin refs/heads/main | cut -f1)
+  gh pr merge "$issue_pr_url" --repo miztertea/nim-proxy --merge --match-head-commit "$reviewed_head"
+  git fetch origin --prune
+  git merge-base --is-ancestor "$reviewed_head" origin/release/v0.6.6
+  test "$(git ls-remote origin refs/heads/main | cut -f1)" = "$main_before"
+  ~~~
+
+- [ ] **Step 4: Close #139 and update #131**
+
+  ~~~sh
+  set -euo pipefail
+  reviewed_head=$(git rev-parse HEAD)
+  merged_pr=$(gh pr list --repo miztertea/nim-proxy --state merged --base release/v0.6.6 --head work/v0.6.6-139-history-health --json url,headRefOid)
+  issue_pr_url=$(jq -r --arg h "$reviewed_head" '[.[] | select(.headRefOid == $h)] | last.url // empty' <<<"$merged_pr")
+  test -n "$reviewed_head" && test -n "$issue_pr_url"
+  gh issue close 139 --repo miztertea/nim-proxy --reason completed --comment "Implemented and merged via $issue_pr_url at $reviewed_head. Derived canonical-presence/poison persistence health, exact 0/1 no-label gauge, catalog-backed Settings guidance, red/green proof, ci:full nine-job CI, CodeQL, exact-ref fuzz, and guarded merge passed."
+  gh issue comment 131 --repo miztertea/nim-proxy --body "#139 complete: $issue_pr_url merged at $reviewed_head. The history workstream promotion passed derived persistence-health visibility, full CI, CodeQL, exact-ref fuzz, and guarded merge. PR #72 and main remain untouched."
+  ~~~
+
+## Plan Self-Review
+
+- Coverage: canonical absence, poisoned runtime transition, no-repeat logging/gauge, status/API/UI/metric surfaces, generated contracts, existing render proof, promotion CI, CodeQL, exact-ref fuzz, guarded merge, and issue updates are assigned.
+- Scans: no recovery loop, duplicate state, config/route/dashboard-now/format/knowledge change, custom checker, PR #72/main work, or generated-file hand edit is authorized.
+- Decomposition: exactly two tasks; Task 1 is TDD/review/commit and Task 2 is publication/full-gate/final-review/merge.

--- a/docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md
+++ b/docs/superpowers/specs/2026-08-08-v0.6.6-history-durability-workstream-design.md
@@ -287,3 +287,53 @@ change. Do not alter API/status/metrics/config/codec/format/E2E/knowledge or
 `Rung 2` reuses `History::open`, `History::append`, `last_timestamp`, `TestDir`,
 `boot_t`, codec decoding, and existing rollup/index assertions. `Rung 3` uses
 standard `Option`/maximum composition and existing mutexes.
+
+## #139 poisoned-store persistence health
+
+### Outcome
+
+Operators can see and alert on unavailable canonical persistence even while the
+in-memory history index continues to advance: `HistoryStatus` and
+`/api/config` `HistorySettings` expose `persistence: "ok" | "degraded"`, the
+existing Settings history card explains degradation through the operator
+catalog, and the fixed no-label
+`nimproxy_history_persistence_degraded` gauge is `0` or `1`.
+
+### Selected approach
+
+Derive health, rather than store it again: canonical-store absence from the
+existing #134 fallback is degraded, as is a present `HistoryStore` whose
+existing `poisoned` bit is true; only a present, unpoisoned canonical store is
+ok. Add a read-only store accessor and derive the status under the existing
+store mutex. Set the gauge after startup open/fallback, then set it to `1`
+only when `append_sample`/`checkpoint` first changes the store from usable to
+poisoned. Emit that transition once at error level; later `Poisoned`
+short-circuits remain silent. Poison is process-lifetime state and restart is
+the retry boundary.
+
+### Rejected alternatives
+
+- A duplicate `AtomicBool` can drift from the canonical store's authoritative
+  bit and adds lifecycle state without a consumer need.
+- A failure counter alone cannot show that persistence remains unavailable
+  after the first error, nor cover #134's startup fallback.
+- Recovery, a setting, a new route/dashboard-now field, a canonical-format
+  change, or a checker expands this visibility issue beyond its contract.
+
+### Proof and constraints
+
+Use the existing `RuntimePartialAppend` injection to demonstrate RED then
+GREEN for the first transition, the unchanged in-memory point, status/API
+`degraded`, gauge `1`, and quiet later short-circuits; prove fresh canonical
+startup is `ok`/`0` and #134 fallback is `degraded`/`1`. Keep API declarations
+ASCII ordered, regenerate OpenAPI and Rust-owned UI fixtures only through their
+existing commands, and extend an existing `render_check` Settings row/fixture
+for the catalog-backed guidance. Do not hand-edit generated files. #152 alone
+reconciles knowledge.
+
+### Ponytail rungs
+
+**Rung 1:** reject recovery and duplicate state. **Rung 2:** reuse the poison
+bit, canonical presence, status/config/Settings/recorder paths, existing
+injection, fixtures, and render rows. **Rung 4:** use the `ci:full` GitHub
+label and native Actions conclusions for the workstream promotion gate.

--- a/openapi.json
+++ b/openapi.json
@@ -1594,7 +1594,8 @@
         "required": [
           "compaction_pending",
           "days",
-          "file_bytes"
+          "file_bytes",
+          "persistence"
         ],
         "properties": {
           "available_from": {
@@ -1618,6 +1619,9 @@
             "type": "integer",
             "format": "int64",
             "minimum": 0
+          },
+          "persistence": {
+            "type": "string"
           }
         }
       },

--- a/scripts/render_check.js
+++ b/scripts/render_check.js
@@ -436,7 +436,6 @@ const INTERACTION_ROWS = [
     state: 'mutation-success',
     action: 'change the history fields and activate Save',
     visible: 'Saved is visible beside History and dashboard',
-    dom: [{ selector: '#history-err', property: 'textContent', equals: 'Saved.' }],
     request: {
       method: 'POST',
       path: '/api/settings/history',
@@ -1433,6 +1432,7 @@ const DOM_CONTRACTS = {
       ]`,
       ['30', '7', '99.9']),
     domContract('history-saved', `document.querySelector('#history-err')?.textContent.trim() ?? null`, 'Saved.'),
+    domContract('history-persistence-degraded', `document.querySelector('[data-i18n="settings.server.history.persistence_degraded"]')?.textContent.trim() ?? null`, 'History persistence is degraded. Restart the proxy to retry canonical storage.'),
   ],
   'mutation-governor-toggle': [
     domContract('governor-disabled', `document.querySelector('#gov-tog')?.getAttribute('aria-pressed') ?? null`, 'false'),

--- a/src/api.rs
+++ b/src/api.rs
@@ -305,6 +305,7 @@ pub struct HistorySettings {
     /// Retention in days; 0 = keep forever.
     pub days: u64,
     pub file_bytes: u64,
+    pub persistence: String,
 }
 
 /// A user row with how much of the pool they own.
@@ -1207,6 +1208,7 @@ mod tests {
                 compaction_pending: true,
                 days: 30,
                 file_bytes: 12_345,
+                persistence: "degraded".into(),
             },
             limits: Limits::default(),
         }
@@ -2381,6 +2383,7 @@ mod tests {
                 compaction_pending: false,
                 days: 30,
                 file_bytes: 0,
+                persistence: "ok".into(),
             },
         );
         sorted(
@@ -2402,6 +2405,7 @@ mod tests {
                 compaction_pending: false,
                 days: 30,
                 file_bytes: 0,
+                persistence: "ok".into(),
             },
             limits: Limits::default(),
         };

--- a/src/history.rs
+++ b/src/history.rs
@@ -443,8 +443,9 @@ fn diagnostics_at(inner: &HistoryInner, to: u64) -> HistoryDiagnostics {
 pub struct HistoryStatus {
     pub available_from: Option<u64>,
     pub available_to: Option<u64>,
-    pub file_bytes: u64,
     pub compaction_pending: bool,
+    pub file_bytes: u64,
+    pub persistence: String,
 }
 
 /// ASCII-ordered: served inside `/api/dashboard` (see `src/api.rs`).
@@ -883,26 +884,34 @@ impl History {
             (inner.available_from, inner.available_to)
         };
         let compaction_pending = self.compaction_pending.load(Ordering::SeqCst);
-        let file_bytes = self.canonical.as_ref().map_or_else(
+        let (file_bytes, persistence) = self.canonical.as_ref().map_or_else(
             || {
-                self.file
-                    .as_ref()
-                    .and_then(|path| fs::metadata(path).ok())
-                    .map_or(0, |metadata| metadata.len())
+                (
+                    self.file
+                        .as_ref()
+                        .and_then(|path| fs::metadata(path).ok())
+                        .map_or(0, |metadata| metadata.len()),
+                    "degraded".to_owned(),
+                )
             },
             |store| {
-                store
-                    .lock()
-                    .ok()
-                    .and_then(|store| store.file_bytes().ok())
-                    .unwrap_or(0)
+                let store = store.lock().unwrap();
+                (
+                    store.file_bytes().unwrap_or(0),
+                    if store.poisoned() {
+                        "degraded".to_owned()
+                    } else {
+                        "ok".to_owned()
+                    },
+                )
             },
         );
         HistoryStatus {
             available_from,
             available_to,
-            file_bytes,
             compaction_pending,
+            file_bytes,
+            persistence,
         }
     }
 
@@ -973,12 +982,17 @@ impl History {
         }
 
         if let Some(store) = &self.canonical {
-            if let Err(error) = store.lock().unwrap().append_sample(
-                t,
-                canonical_capacity(&capacity),
-                canonical_state,
-            ) {
-                tracing::warn!("canonical history append failed: {error}");
+            let mut store = store.lock().unwrap();
+            let was_poisoned = store.poisoned();
+            if let Err(error) =
+                store.append_sample(t, canonical_capacity(&capacity), canonical_state)
+            {
+                if !was_poisoned && store.poisoned() {
+                    metrics::gauge!("nimproxy_history_persistence_degraded").set(1.0);
+                    tracing::error!("canonical history persistence degraded: {error}");
+                } else if !matches!(error, store::WriteError::Poisoned) {
+                    tracing::warn!("canonical history append failed: {error}");
+                }
             }
         }
 
@@ -1566,8 +1580,23 @@ fn sync_parent_directory(_path: &Path) -> std::io::Result<()> {
 mod tests {
     use super::*;
     use std::fmt::Write as _;
+    use std::io;
     use std::sync::Arc;
     use std::time::Duration;
+
+    #[derive(Clone)]
+    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for SharedWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
 
     fn capacity(rpm: usize) -> CapacitySnapshot {
         CapacitySnapshot {
@@ -1856,6 +1885,100 @@ nimproxy_ttft_seconds_count{model="z-ai/glm-5.2"} 4
         assert_eq!(history.status().available_to, Some(boot_t));
         let rollup = history.rollup(boot_t.saturating_sub(1), boot_t, 20);
         assert_eq!(value(&rollup.data.totals, "requests_total"), 15.0);
+    }
+
+    #[test]
+    fn canonical_persistence_health_degrades_on_changed_sample_and_checkpoint_poison() {
+        for (label, prime_first) in [("changed", false), ("checkpoint", true)] {
+            let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+            let handle = recorder.handle();
+            metrics::with_local_recorder(&recorder, || {
+                let dir = TestDir::new();
+                let history = Arc::new(History::open(dir.0.clone(), 0, capacity(40)).unwrap());
+                let timestamp = history.boot_t;
+                let path = dir.0.join("history-v1.jsonl");
+
+                assert_eq!(history.status().persistence, "ok", "{label}: fresh store");
+                if prime_first {
+                    history.append(timestamp, SNAPSHOT, capacity(40));
+                }
+                let before_failure = fs::read(&path).unwrap();
+                history
+                    .canonical
+                    .as_ref()
+                    .unwrap()
+                    .lock()
+                    .unwrap()
+                    .arm_test_runtime_partial_append_once();
+
+                let logs = Arc::new(Mutex::new(Vec::new()));
+                let writer = logs.clone();
+                let subscriber = tracing_subscriber::fmt()
+                    .with_ansi(false)
+                    .without_time()
+                    .with_target(false)
+                    .with_max_level(tracing::Level::ERROR)
+                    .with_writer(move || SharedWriter(writer.clone()))
+                    .finish();
+                tracing::subscriber::with_default(subscriber, || {
+                    history.append(timestamp, SNAPSHOT, capacity(40));
+                    assert_eq!(
+                        history.status().persistence,
+                        "degraded",
+                        "{label}: first failed durable append degrades persistence"
+                    );
+                    assert_eq!(
+                        history.inner.lock().unwrap().points.len(),
+                        if prime_first { 2 } else { 1 }
+                    );
+                    let after_failed_tick = fs::read(&path).unwrap();
+                    assert!(
+                        after_failed_tick.starts_with(&before_failure),
+                        "{label}: partial append preserves existing canonical bytes"
+                    );
+
+                    history.append(timestamp, SNAPSHOT, capacity(40));
+                    assert_eq!(
+                        fs::read(&path).unwrap(),
+                        after_failed_tick,
+                        "{label}: later poisoned tick adds no bytes"
+                    );
+                });
+
+                let log = String::from_utf8(logs.lock().unwrap().clone()).unwrap();
+                assert_eq!(
+                    log.matches("canonical history persistence degraded")
+                        .count(),
+                    1,
+                    "{label}: only the first poison transition is an error"
+                );
+                assert!(matches!(
+                    history
+                        .canonical
+                        .as_ref()
+                        .unwrap()
+                        .lock()
+                        .unwrap()
+                        .append_sample(timestamp, canonical_capacity(&[40]), Vec::new()),
+                    Err(store::WriteError::Poisoned)
+                ));
+                assert_eq!(
+                    handle
+                        .render()
+                        .lines()
+                        .find(|line| line.starts_with("nimproxy_history_persistence_degraded ")),
+                    Some("nimproxy_history_persistence_degraded 1"),
+                    "{label}: the no-label gauge remains degraded"
+                );
+
+                let restarted = History::open(dir.0.clone(), 0, capacity(40)).unwrap();
+                assert_eq!(
+                    restarted.status().persistence,
+                    "ok",
+                    "{label}: only a fresh store after restart can return to ok"
+                );
+            });
+        }
     }
 
     async fn wait_for_canonical_compaction_idle(history: &Arc<History>, label: &str) {

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -24,6 +24,8 @@ pub struct HistoryStore {
     poisoned: bool,
     #[cfg(test)]
     test_compaction_directory_sync_failure: bool,
+    #[cfg(test)]
+    test_runtime_partial_append_once: bool,
 }
 
 #[derive(Debug, Default)]
@@ -175,6 +177,8 @@ impl HistoryStore {
                     poisoned: false,
                     #[cfg(test)]
                     test_compaction_directory_sync_failure: false,
+                    #[cfg(test)]
+                    test_runtime_partial_append_once: false,
                 })
             }
             Err(error) if error.kind() == io::ErrorKind::NotFound => {
@@ -196,6 +200,8 @@ impl HistoryStore {
                             poisoned: false,
                             #[cfg(test)]
                             test_compaction_directory_sync_failure: false,
+                            #[cfg(test)]
+                            test_runtime_partial_append_once: false,
                         })
                     }
                     Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
@@ -217,6 +223,8 @@ impl HistoryStore {
                             poisoned: false,
                             #[cfg(test)]
                             test_compaction_directory_sync_failure: false,
+                            #[cfg(test)]
+                            test_runtime_partial_append_once: false,
                         })
                     }
                     Err(error) => Err(error.into()),
@@ -232,7 +240,20 @@ impl HistoryStore {
         capacity: Capacity,
         state: Vec<StateEntry>,
     ) -> Result<(), WriteError> {
-        self.append_sample_inner(timestamp, capacity, state, None)
+        #[cfg(test)]
+        {
+            let mut failure = std::mem::take(&mut self.test_runtime_partial_append_once).then_some(
+                FailureSwitch {
+                    point: FailurePoint::RuntimePartialAppend,
+                    fired: None,
+                },
+            );
+            self.append_sample_inner(timestamp, capacity, state, failure.as_mut())
+        }
+        #[cfg(not(test))]
+        {
+            self.append_sample_inner(timestamp, capacity, state, None)
+        }
     }
 
     fn append_sample_inner(
@@ -240,13 +261,13 @@ impl HistoryStore {
         timestamp: u64,
         capacity: Capacity,
         state: Vec<StateEntry>,
-        failure: Option<&mut FailureSwitch>,
+        mut failure: Option<&mut FailureSwitch>,
     ) -> Result<(), WriteError> {
         if self.poisoned {
             return Err(WriteError::Poisoned);
         }
         if self.last_state.as_ref() == Some(&state) {
-            return self.checkpoint(timestamp, capacity);
+            return self.checkpoint_inner(timestamp, capacity, failure.take());
         }
         let record = Record::Sample(SampleRecord {
             timestamp,
@@ -264,6 +285,7 @@ impl HistoryStore {
         Ok(())
     }
 
+    #[allow(dead_code)] // Retained for direct store checks; append_sample forwards injected failures below.
     pub fn checkpoint(&mut self, timestamp: u64, capacity: Capacity) -> Result<(), WriteError> {
         self.checkpoint_inner(timestamp, capacity, None)
     }
@@ -450,6 +472,15 @@ impl HistoryStore {
 
     pub(crate) fn last_timestamp(&self) -> Option<u64> {
         self.last_timestamp
+    }
+
+    pub(crate) fn poisoned(&self) -> bool {
+        self.poisoned
+    }
+
+    #[cfg(test)]
+    pub(crate) fn arm_test_runtime_partial_append_once(&mut self) {
+        self.test_runtime_partial_append_once = true;
     }
 
     pub(crate) fn take_replay(&mut self) -> Replay {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,6 +540,10 @@ pub async fn run() {
         "nimproxy_usage_observations_total",
         "Final classified upstream usage observations by field and result."
     );
+    metrics::describe_gauge!(
+        "nimproxy_history_persistence_degraded",
+        "Whether canonical history persistence is degraded (0 = ok, 1 = degraded)."
+    );
 
     let pool: PoolHandle = Arc::new(RwLock::new(Arc::new(Pool::new(pool_specs))));
 
@@ -563,6 +567,13 @@ pub async fn run() {
             ))
         }
     };
+    metrics::gauge!("nimproxy_history_persistence_degraded").set(
+        if hist.status().persistence == "degraded" {
+            1.0
+        } else {
+            0.0
+        },
+    );
     {
         let hist = hist.clone();
         let prom = prometheus.clone();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -445,6 +445,7 @@ pub async fn api_config(
                 compaction_pending: history.compaction_pending,
                 days: sc.history.days,
                 file_bytes: history.file_bytes,
+                persistence: history.persistence,
             },
             limits: sc.limits.clone(),
         };

--- a/src/web/locales/en-US.json
+++ b/src/web/locales/en-US.json
@@ -1443,6 +1443,10 @@
       "en": "Oldest data point",
       "hash": "ef4ab020"
     },
+    "settings.server.history.persistence_degraded": {
+      "en": "History persistence is degraded. Restart the proxy to retry canonical storage.",
+      "hash": "4b24eb63"
+    },
     "settings.server.history.retention": {
       "en": "History retention · 0 = unlimited",
       "hash": "c137c172"

--- a/src/web/settings.js
+++ b/src/web/settings.js
@@ -303,6 +303,7 @@ function renderServer() {
         <div class="conbox"><div class="slabel" data-i18n="settings.server.history.data_file"></div><div class="kmeta" data-style="display:block">${escapeHtml(historyBytesMessage())}</div></div>
       </div>
       ${sv.history.compaction_pending ? '<p class="shint" data-style="color:var(--amber-lt)" data-i18n="settings.server.history.compaction_pending"></p>' : ''}
+      ${sv.history.persistence === 'degraded' ? '<p class="shint" data-style="color:var(--amber-lt)" data-i18n="settings.server.history.persistence_degraded"></p>' : ''}
       <div class="serr" id="history-err"></div>
     </div>`;
   applyStatic($('setbody'));

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -4357,6 +4357,28 @@ async fn corrupt_or_future_store_refuses_to_start() {
 #[tokio::test]
 async fn history_startup_degrades_to_memory_without_mutating_canonical() {
     let mock = start_mock().await;
+    let canonical_data_dir = scratch_data_dir();
+    std::fs::write(
+        canonical_data_dir.join("config.json"),
+        serde_json::to_vec_pretty(&StoreOpts::default().json(&mock.url)).unwrap(),
+    )
+    .unwrap();
+    let canonical_proxy =
+        start_proxy_in(canonical_data_dir, &[("HISTORY_SAMPLE_SECS", "3600")]).await;
+    let canonical_cookie = login(&canonical_proxy).await;
+    let canonical_config = api_config(&canonical_proxy, &canonical_cookie).await;
+    assert_eq!(
+        canonical_config["server"]["history"]["persistence"], "ok",
+        "history-startup:canonical: canonical persistence is healthy"
+    );
+    assert!(
+        metrics(&canonical_proxy)
+            .await
+            .lines()
+            .any(|line| line == "nimproxy_history_persistence_degraded 0"),
+        "history-startup:canonical: canonical persistence gauge is zero"
+    );
+    canonical_proxy.terminate();
     for (name, contents) in [
         ("empty", b"".as_slice()),
         (
@@ -4375,6 +4397,20 @@ async fn history_startup_degrades_to_memory_without_mutating_canonical() {
         let config_before = std::fs::read(data_dir.join("config.json")).unwrap();
         let history_before = std::fs::read(data_dir.join("history-v1.jsonl")).unwrap();
         let proxy = start_proxy_in(data_dir, &[("HISTORY_SAMPLE_SECS", "3600")]).await;
+        let cookie = login(&proxy).await;
+        let config = api_config(&proxy, &cookie).await;
+        assert_eq!(
+            config["server"]["history"]["persistence"],
+            "degraded",
+            "history-startup:{name}: rejected canonical persistence is degraded"
+        );
+        assert!(
+            metrics(&proxy)
+                .await
+                .lines()
+                .any(|line| line == "nimproxy_history_persistence_degraded 1"),
+            "history-startup:{name}: rejected canonical persistence gauge is one"
+        );
         let response = client()
             .post(proxy.url("/v1/chat/completions"))
             .json(&chat_body(&format!("history startup {name}"), false))

--- a/tests/fixtures/ui/config-admin.json
+++ b/tests/fixtures/ui/config-admin.json
@@ -54,7 +54,8 @@
       "available_from": 1700000000,
       "compaction_pending": true,
       "days": 30,
-      "file_bytes": 12345
+      "file_bytes": 12345,
+      "persistence": "degraded"
     },
     "limits": {
       "heartbeat_secs": 10,

--- a/tests/fixtures/ui/config-superuser.json
+++ b/tests/fixtures/ui/config-superuser.json
@@ -54,7 +54,8 @@
       "available_from": 1700000000,
       "compaction_pending": true,
       "days": 30,
-      "file_bytes": 12345
+      "file_bytes": 12345,
+      "persistence": "degraded"
     },
     "limits": {
       "heartbeat_secs": 10,

--- a/tests/fixtures/ui/scenarios.json
+++ b/tests/fixtures/ui/scenarios.json
@@ -55,7 +55,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -139,7 +140,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -223,7 +225,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -307,7 +310,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -385,7 +389,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -469,7 +474,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -547,7 +553,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -7243,7 +7250,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -7327,7 +7335,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -7411,7 +7420,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -7495,7 +7505,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -7579,7 +7590,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -7663,7 +7675,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -7747,7 +7760,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -7820,7 +7834,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -7904,7 +7919,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -7977,7 +7993,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -8061,7 +8078,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -8145,7 +8163,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -8227,7 +8246,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -8311,7 +8331,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -8395,7 +8416,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -8477,7 +8499,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -8551,7 +8574,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -8612,7 +8636,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -8696,7 +8721,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -8763,7 +8789,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -8841,7 +8868,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,
@@ -8925,7 +8953,8 @@
         "available_from": 1700000000,
         "compaction_pending": true,
         "days": 30,
-        "file_bytes": 12345
+        "file_bytes": 12345,
+        "persistence": "degraded"
       },
       "limits": {
         "heartbeat_secs": 10,


### PR DESCRIPTION
Resolves #139. Derived canonical presence/poison health is surfaced in config/Settings and a fixed gauge. History promotion for #131.