### PR TITLE
fix(ui): keep Capacity sorting descriptor-safe

### DIFF
--- a/scripts/render_check.js
+++ b/scripts/render_check.js
@@ -163,6 +163,57 @@ const INTERACTION_ROWS = [
     },
   },
   {
+    id: 'sorting-capacity-table-ascending',
+    category: 'sorting',
+    state: 'healthy',
+    action: 'activate the first Capacity table header once',
+    visible: 'the key column is ascending without a rendering or transport failure',
+    dom: [
+      {
+        selector: '#table-lanes tbody tr',
+        property: 'first-cell-sequence',
+        equals: ['Slot 1', 'Slot 2'],
+      },
+      { selector: '#liveText', property: 'textContent', equals: 'Live' },
+    ],
+  },
+  {
+    id: 'sorting-capacity-table-descending',
+    category: 'sorting',
+    state: 'healthy',
+    action: 'activate the same Capacity table header a second time',
+    visible: 'the key column reverses without a rendering or transport failure',
+    dom: [
+      {
+        selector: '#table-lanes tbody tr',
+        property: 'first-cell-sequence',
+        equals: ['Slot 2', 'Slot 1'],
+      },
+      { selector: '#liveText', property: 'textContent', equals: 'Live' },
+    ],
+  },
+  {
+    id: 'sorting-capacity-table-persists-rerender',
+    category: 'sorting',
+    state: 'healthy',
+    action: 'fulfill the next dashboard-now poll after sorting Capacity descending',
+    visible: 'the descending Capacity order rerenders and the live connection remains live',
+    dom: [
+      {
+        selector: '#table-lanes tbody tr',
+        property: 'first-cell-sequence',
+        equals: ['Slot 2', 'Slot 1'],
+      },
+      { selector: '#liveText', property: 'textContent', equals: 'Live' },
+    ],
+    request: {
+      method: 'GET',
+      path: '/api/dashboard/now',
+      query: {},
+      body: null,
+    },
+  },
+  {
     id: 'filtering-settings-role',
     category: 'filtering',
     state: 'role-user',
@@ -1342,6 +1393,33 @@ const DOM_CONTRACTS = {
       `Array.from(document.querySelectorAll('#table-models tbody tr')).map(row => row.cells[0]?.textContent.trim())`,
       ['fixture/zeta', 'fixture/alpha']),
   ],
+  'sorting-capacity-table-ascending': [
+    domContract('ascending-capacity-key-order',
+      `Array.from(document.querySelectorAll('#table-lanes tbody tr')).map(row => row.cells[0]?.textContent.trim())`,
+      ['Slot 1', 'Slot 2']),
+    domContract('capacity-sort-keeps-live-connection',
+      `document.querySelector('#liveText')?.textContent.trim() ?? null`, 'Live'),
+    domContract('capacity-sort-keeps-live-transport-class',
+      `document.querySelector('#live')?.className ?? null`, 'live'),
+  ],
+  'sorting-capacity-table-descending': [
+    domContract('descending-capacity-key-order',
+      `Array.from(document.querySelectorAll('#table-lanes tbody tr')).map(row => row.cells[0]?.textContent.trim())`,
+      ['Slot 2', 'Slot 1']),
+    domContract('capacity-sort-keeps-live-connection',
+      `document.querySelector('#liveText')?.textContent.trim() ?? null`, 'Live'),
+    domContract('capacity-sort-keeps-live-transport-class',
+      `document.querySelector('#live')?.className ?? null`, 'live'),
+  ],
+  'sorting-capacity-table-persists-rerender': [
+    domContract('descending-capacity-key-order-after-rerender',
+      `Array.from(document.querySelectorAll('#table-lanes tbody tr')).map(row => row.cells[0]?.textContent.trim())`,
+      ['Slot 2', 'Slot 1']),
+    domContract('capacity-sort-rerender-keeps-live-connection',
+      `document.querySelector('#liveText')?.textContent.trim() ?? null`, 'Live'),
+    domContract('capacity-sort-rerender-keeps-live-transport-class',
+      `document.querySelector('#live')?.className ?? null`, 'live'),
+  ],
   'filtering-settings-role': [
     domContract('server-nav-absent', `!document.querySelector('#setnav [data-sub="server"]')`, true),
     domContract('users-nav-absent', `!document.querySelector('#setnav [data-sub="users"]')`, true),
@@ -1964,6 +2042,14 @@ const FIXTURE_SCENARIOS = {
   'sorting-table-persists-rerender': dashboardRecipe({
     response: 'dashboard-now-changed.json',
     requires: ['sorting-table-descending'],
+  }),
+  'sorting-capacity-table-ascending': dashboardRecipe(),
+  'sorting-capacity-table-descending': dashboardRecipe({
+    requires: ['sorting-capacity-table-ascending'],
+  }),
+  'sorting-capacity-table-persists-rerender': dashboardRecipe({
+    response: 'dashboard-now-changed.json',
+    requires: ['sorting-capacity-table-descending'],
   }),
   'filtering-settings-role': dashboardRecipe({
     role: 'user',
@@ -4322,6 +4408,9 @@ function matrixActionExpression(id) {
     'sorting-table-ascending': `${click('#side [data-tab="models"]')};${click('#table-models thead th[data-i="0"]')}`,
     'sorting-table-descending': `${click('#table-models thead th[data-i="0"]')}`,
     'sorting-table-persists-rerender': `await pollNow()`,
+    'sorting-capacity-table-ascending': `${click('#side [data-tab="capacity"]')};${click('#table-lanes thead th[data-i="0"]')}`,
+    'sorting-capacity-table-descending': `${click('#table-lanes thead th[data-i="0"]')}`,
+    'sorting-capacity-table-persists-rerender': `await pollNow()`,
     'filtering-settings-role': openSettings,
     'refresh-dashboard-now': `await pollNow()`,
     'refresh-settings-access': `document.querySelector('#nk-key').focus();await window.__runMatrixIntervals(5000)`,

--- a/src/web/dashboard.js
+++ b/src/web/dashboard.js
@@ -804,7 +804,7 @@ function renderCapacity(c) {
     { label: catalogMessage('dashboard.common.col.key'), align: 'l', str: true }, { label: catalogMessage('dashboard.common.col.requests') }, { label: catalogMessage('dashboard.common.col.share') },
     { label: catalogMessage('dashboard.capacity.col.current_rate') }, { label: catalogMessage('dashboard.capacity.col.429s') }, { label: catalogMessage('dashboard.common.status.upstream_error_cooldowns') },
   ], lanes.map(l => ({
-    vals: [l.name, l.cur, l.cur / totalLane * 100, l.currentRpm, l.b429, l.bOther],
+    vals: [l.i, l.cur, l.cur / totalLane * 100, l.currentRpm, l.b429, l.bOther],
     cells: [`<i class="sw" data-style="background:${laneColor(l.i)}"></i>${escapeHtml(l.name)}`,
       fmt(l.cur), pctOf(l.cur / totalLane, 0), `${fmt(l.currentRpm)} / ${laneRpm(l.i)}`,
       `<span class="${l.b429 ? 'warnc' : 'dim'}">${fmt(l.b429)}</span>`,


### PR DESCRIPTION
## Outcome

Fix Capacity-table first-column sorting without coercing a catalog descriptor or conflating the sort interaction with connection state.

## Change

- Sort the Capacity key column by its existing numeric slot index while continuing to render the localized descriptor through `escapeHtml`.
- Add Chromium/CDP interaction rows for ascending order, descending order, and persistence across the next dashboard-now rerender.
- Assert the live indicator and clean browser-run contract throughout those interactions.

## Evidence

- Exact candidate: `d577386e1194d7f6662eaa55f6af814663c7ee95`
- Independent Sergeant `review-change`: no surviving correctness, coverage, scope, or test-honesty findings.
- `node scripts/render_check.js --interaction-selftest`: 72 rows, 284 visual applicability items.
- `node scripts/render_check.js --all-states`: 5 tabs, 17 chart hovers, 72 rows, no uncaught page errors.
- `node scripts/render_check.js --all-states --locale en-XA`: same result.
- Dashboard and setup hostile-catalog probes: green.
- JavaScript syntax and `git diff --check`: green.
- CI owns the canonical Rust coverage gate (`cargo llvm-cov --summary-only --fail-under-lines 90`).

## Scope

This PR contains only the #132 sort correction and its regression coverage. General render/style fault isolation remains in #148.

Refs #132. Parent: #131. Included in integration PR #72, which will carry the default-branch closing reference after the remediation is accepted.

R2: reuse `sortTable` and the existing dependency-free Chromium/CDP harness. J4: owner-authorized PR 72 remediation, with `main` merge reserved to the owner.
