### PR TITLE
fix(auth): authorize user changes before hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- User-management requests now reject non-admin and stale sessions before
+  starting requested-password PBKDF2 work, while rechecking authorization
+  before committing the change.
 - A 2xx status is classified consistently across availability, charts, and
   error taxonomy instead of treating only literal HTTP 200 as success.
 - Dashboard catalog values no longer double-escape, and setup/runtime catalog

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -924,6 +924,15 @@ pub async fn users(
     Extension(Identity(username)): Extension<Identity>,
     ApiJson(req): ApiJson<UsersReq>,
 ) -> Response {
+    {
+        let guard = state.store.lock().unwrap();
+        match role_of(&guard, &username) {
+            Some(r) if r.is_admin() => {}
+            Some(_) => return forbidden("user management requires an admin"),
+            None => return stale_session(),
+        }
+    }
+
     // Hash outside the store lock (PBKDF2 is deliberately slow).
     let new_hash = match (&req.add, &req.reset_password) {
         (Some(a), None) => {
@@ -960,6 +969,9 @@ pub async fn users(
     };
 
     let mut guard = state.store.lock().unwrap();
+    // A concurrent administrator may have changed the caller's role while
+    // PBKDF2 ran without the store lock. Keep authorization live through the
+    // mutation while the first check above keeps rejected callers out of it.
     match role_of(&guard, &username) {
         Some(r) if r.is_admin() => {}
         Some(_) => return forbidden("user management requires an admin"),
@@ -1493,6 +1505,31 @@ mod tests {
         assert_eq!(
             apply_password_change(&mut sc, "ghost", "h", "n"),
             Err(PasswordChangeErr::UserGone)
+        );
+    }
+
+    #[test]
+    fn users_authorizes_before_password_hashing() {
+        let source = include_str!("settings.rs");
+        let users = source
+            .split_once("pub async fn users(")
+            .expect("users handler")
+            .1
+            .split_once("pub(crate) struct AccountPasswordReq")
+            .expect("users handler boundary")
+            .0;
+        let authorization = users
+            .find("match role_of(&guard, &username)")
+            .expect("users authorization");
+        let password_hashes: Vec<_> = users
+            .match_indices("auth::hash_password")
+            .map(|(offset, _)| offset)
+            .collect();
+
+        assert_eq!(password_hashes.len(), 2, "add and reset password hashes");
+        assert!(
+            password_hashes.iter().all(|offset| authorization < *offset),
+            "users authorization must precede every PBKDF2 password hash"
         );
     }
 }


### PR DESCRIPTION
## Outcome

Reject non-admin and stale-session user-management requests before either
requested-password PBKDF2 operation, while preserving the live authorization
check immediately before mutation.

## Change

- Reuse the existing `role_of` gate before add/reset password hashing.
- Retain the second gate under the store lock so concurrent demotion or user
  deletion cannot authorize a stale in-flight mutation.
- Add deterministic source-structural RED-to-GREEN proof covering both hash
  call sites, plus a concise changelog entry.

The setup and throttled-login subclaims were verified already safe at the
admitted head; this PR does not change them.

## Evidence

- Exact candidate: `781ac3e0d1bcdded98bf4e19318e88c6e2a93a13`
- Fresh Terra `review-change`: **APPROVE**, no surviving actionable findings.
- Focused ordering regression: passed.
- `cargo test --lib`: 193 passed.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, agent-guide
  validation, and `git diff --check`: passed.
- The integration head immediately preceding this PR passed PR #72's complete
  main-target gate, including `cargo llvm-cov --summary-only
  --fail-under-lines 90`; this security-sensitive PR's routed CI must pass
  again before integration.

## Scope and authority

Only `src/settings.rs` and `CHANGELOG.md` change. Broad knowledge
reconciliation remains owned by #152.

Refs #144. Parent: #131. Included in integration PR #72, which will carry the
default-branch closing reference after remediation is accepted.

R2: reuse the existing role gate and mutation-time recheck. J4: the accepted
#144 contract requires rejected callers to avoid PBKDF2 while preserving
authorized behavior. The owner reserves every merge to `main`.
